### PR TITLE
Add welcome name prompt for new members

### DIFF
--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -305,9 +305,6 @@ export const ERROR_IDS = {
 
   // Member name update errors
   UPDATE_MEMBER_NAME_ROUTE_FAILED: "update_member_name_route_failed",
-  UPDATE_MEMBER_NAME_MEMBER_NOT_FOUND: "update_member_name_member_not_found",
-  UPDATE_MEMBER_NAME_FIRESTORE_UPDATE_ERROR:
-    "update_member_name_firestore_update_error",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -302,6 +302,12 @@ export const ERROR_IDS = {
 
   // Email verification errors
   VERIFY_EMAIL_ROUTE_FAILED: "verify_email_route_failed",
+
+  // Member name update errors
+  UPDATE_MEMBER_NAME_ROUTE_FAILED: "update_member_name_route_failed",
+  UPDATE_MEMBER_NAME_MEMBER_NOT_FOUND: "update_member_name_member_not_found",
+  UPDATE_MEMBER_NAME_FIRESTORE_UPDATE_ERROR:
+    "update_member_name_firestore_update_error",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/members-api/plugins/members-plugin.ts
+++ b/functions/src/members-api/plugins/members-plugin.ts
@@ -3,11 +3,14 @@ import { logger as firebaseLogger } from "firebase-functions/v2";
 import { AuthService } from "../../shared-api/services/auth/index.js";
 import { EmailService } from "../../shared-api/services/email/index.js";
 import { getMemberLogic } from "../routes/members.js";
+import { updateMemberNameLogic } from "../routes/update-member-name.js";
 import { updateNewsletterPreferenceLogic } from "../routes/update-newsletter-preference.js";
 import { verifyEmailLogic } from "../routes/verify-email.js";
 import {
   GetMemberResponseSchema,
   MemberIdParameterSchema,
+  UpdateMemberNameBodySchema,
+  UpdateMemberNameResponseSchema,
   UpdateNewsletterPreferenceBodySchema,
   UpdateNewsletterPreferenceResponseSchema,
   VerifyEmailResponseSchema,
@@ -120,6 +123,34 @@ export function createMembersPlugin(services?: PartialServices) {
         {
           params: MemberIdParameterSchema,
           response: VerifyEmailResponseSchema,
+        },
+      )
+      // PATCH /:memberId/name - Update member name (owner or admin) - Served at /api/members/:memberId/name
+      .patch(
+        "/:memberId/name",
+        async ({
+          params,
+          body,
+          memberService,
+          authService,
+          logger,
+          request,
+          set,
+        }) =>
+          updateMemberNameLogic({
+            memberId: params.memberId,
+            name: body.name,
+            memberService,
+            authService,
+            logger,
+            authorizationHeader:
+              request.headers.get("authorization") ?? undefined,
+            set,
+          }),
+        {
+          params: MemberIdParameterSchema,
+          body: UpdateMemberNameBodySchema,
+          response: UpdateMemberNameResponseSchema,
         },
       )
   );

--- a/functions/src/members-api/routes/update-member-name.test.ts
+++ b/functions/src/members-api/routes/update-member-name.test.ts
@@ -122,6 +122,16 @@ describe("PATCH /:memberId/name (authenticated)", () => {
       expect(body.error).toBe("Missing Authorization header");
     });
 
+    it("should return 401 when authentication token is invalid", async () => {
+      const { testApp, request } = setup({ authToken: "invalid-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Invalid authentication token");
+    });
+
     it("should return 403 when non-owner tries to update name", async () => {
       const { testApp, request } = setup({ authToken: "non-owner-token" });
 
@@ -227,6 +237,28 @@ describe("PATCH /:memberId/name (authenticated)", () => {
       const response = await handleRequest(testApp, request);
 
       expect(response.status).toBe(422);
+    });
+
+    it("should accept request with name at exactly 200 characters", async () => {
+      const { testApp, request } = setup({
+        body: { name: "a".repeat(200) },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject request with whitespace-only name", async () => {
+      const { testApp, request } = setup({
+        body: { name: "   " },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Name must not be empty or whitespace-only");
     });
   });
 

--- a/functions/src/members-api/routes/update-member-name.test.ts
+++ b/functions/src/members-api/routes/update-member-name.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { DecodedIdToken } from "firebase-admin/auth";
+import { Timestamp } from "firebase-admin/firestore";
+import {
+  AuthError,
+  ForbiddenError,
+  NotFoundError,
+} from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import type { MemberDocument } from "../../types/member-document.js";
+import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
+
+/**
+ * Tests for the member name update endpoint.
+ *
+ * Uses createMembersTestPlugin() factory with mocked services.
+ * Tests only the members plugin in isolation.
+ */
+describe("PATCH /:memberId/name (authenticated)", () => {
+  interface SetupOptions {
+    body?: Record<string, unknown>;
+    memberId?: string;
+    authToken?: string | null;
+    memberNotFound?: boolean;
+    serverError?: boolean;
+  }
+
+  function setup({
+    body = { name: "Jane Doe" },
+    memberId = "test-member-id",
+    authToken = "valid-owner-token",
+    memberNotFound = false,
+    serverError = false,
+  }: SetupOptions = {}) {
+    const mockUpdateName = mock(
+      (id: string, name: string): Promise<MemberDocument> => {
+        if (serverError) {
+          throw new Error("Firestore connection error");
+        }
+        if (memberNotFound || id === "non-existent-id") {
+          return Promise.reject(new NotFoundError("Member not found"));
+        }
+        return Promise.resolve({
+          uid: id,
+          email: "test@example.com",
+          name,
+          createdAt: Timestamp.fromDate(new Date("2024-01-01")),
+        } as MemberDocument);
+      },
+    );
+
+    const mockVerifyOwnerOrAdmin = mock(
+      (
+        authorizationHeader: string | undefined,
+        targetMemberId: string,
+      ): Promise<DecodedIdToken> => {
+        if (!authorizationHeader) {
+          return Promise.reject(new AuthError("Missing Authorization header"));
+        }
+
+        if (
+          authorizationHeader === "Bearer valid-owner-token" &&
+          (targetMemberId === "test-member-id" || targetMemberId === "test-id")
+        ) {
+          return Promise.resolve({
+            uid: targetMemberId,
+            email: "test@example.com",
+          } as DecodedIdToken);
+        }
+
+        if (authorizationHeader === "Bearer admin-token") {
+          return Promise.resolve({
+            uid: "admin-user",
+            email: "admin@example.com",
+            admin: true,
+          } as unknown as DecodedIdToken);
+        }
+
+        if (authorizationHeader === "Bearer non-owner-token") {
+          return Promise.reject(
+            new ForbiddenError("You can only update your own name"),
+          );
+        }
+
+        return Promise.reject(new AuthError("Invalid authentication token"));
+      },
+    );
+
+    const testApp = createMembersTestPlugin({
+      memberService: {
+        updateName: mockUpdateName,
+      },
+      authService: {
+        verifyOwnerOrAdmin: mockVerifyOwnerOrAdmin,
+      },
+    });
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(`http://localhost/${memberId}/name`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const { testApp, request } = setup({ authToken: null });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 403 when non-owner tries to update name", async () => {
+      const { testApp, request } = setup({ authToken: "non-owner-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("You can only update your own name");
+    });
+
+    it("should allow owner to update their own name", async () => {
+      const { testApp, request } = setup();
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        member: { name: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.member.name).toBe("Jane Doe");
+    });
+
+    it("should allow admin to update any member name", async () => {
+      const { testApp, request } = setup({
+        authToken: "admin-token",
+        body: { name: "Updated Name" },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        member: { name: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.member.name).toBe("Updated Name");
+    });
+  });
+
+  describe("Name update", () => {
+    it("should return 404 when member does not exist", async () => {
+      const { testApp, request } = setup({
+        memberId: "non-existent-id",
+        authToken: "admin-token",
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Member not found");
+    });
+
+    it("should return updated member data on success", async () => {
+      const { testApp, request } = setup({ body: { name: "New Name" } });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        member: { name: string; uid: string; email: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.member.name).toBe("New Name");
+      expect(body.member.uid).toBe("test-member-id");
+    });
+  });
+
+  describe("Input validation", () => {
+    it("should reject request without name field", async () => {
+      const { testApp, request } = setup({ body: {} });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
+
+    it("should reject request with empty name", async () => {
+      const { testApp, request } = setup({ body: { name: "" } });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
+
+    it("should reject request with non-string name", async () => {
+      const { testApp, request } = setup({ body: { name: 123 } });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should return 500 for unexpected errors", async () => {
+      const { testApp, request } = setup({ serverError: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Failed to update member name");
+    });
+  });
+});

--- a/functions/src/members-api/routes/update-member-name.test.ts
+++ b/functions/src/members-api/routes/update-member-name.test.ts
@@ -218,6 +218,16 @@ describe("PATCH /:memberId/name (authenticated)", () => {
 
       expect(response.status).toBe(422);
     });
+
+    it("should reject request with name exceeding 200 characters", async () => {
+      const { testApp, request } = setup({
+        body: { name: "a".repeat(201) },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
   });
 
   describe("Error handling", () => {

--- a/functions/src/members-api/routes/update-member-name.ts
+++ b/functions/src/members-api/routes/update-member-name.ts
@@ -1,0 +1,74 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import { HttpError } from "../../shared-api/errors/http-error.js";
+import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+import {
+  toMemberResponse,
+  type MemberResponse,
+} from "../schemas/member-schemas.js";
+import type { MemberService } from "../services/member/interface.js";
+
+/**
+ * Update member name logic (authenticated).
+ * Requires authentication - users can update their own name, admins can update any member.
+ *
+ * @returns Success response with updated member data, or error object
+ */
+export async function updateMemberNameLogic({
+  memberId,
+  name,
+  memberService,
+  authService,
+  logger,
+  authorizationHeader,
+  set,
+}: {
+  memberId: string;
+  name: string;
+  memberService: MemberService;
+  authService: AuthService;
+  logger: Logger;
+  authorizationHeader: string | undefined;
+  set: { status?: number | string };
+}): Promise<{ success: true; member: MemberResponse } | { error: string }> {
+  try {
+    // Verify authentication and authorization
+    const decodedToken = await authService.verifyOwnerOrAdmin(
+      authorizationHeader,
+      memberId,
+    );
+
+    const isAdmin = decodedToken["admin"] === true;
+    logger.info("Authorized member name update", {
+      requestingUser: decodedToken.uid,
+      targetMember: memberId,
+      isAdmin,
+    });
+
+    // Update the name via service
+    const updatedMember = await memberService.updateName(memberId, name);
+
+    return {
+      success: true,
+      member: toMemberResponse(updatedMember, isAdmin),
+    };
+  } catch (error) {
+    if (error instanceof HttpError) {
+      set.status = error.statusCode;
+      return { error: error.message };
+    }
+
+    logger.error("Failed to update member name", {
+      errorId: ERROR_IDS.UPDATE_MEMBER_NAME_ROUTE_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      errorStack: error instanceof Error ? error.stack : undefined,
+      errorType: error?.constructor?.name,
+      memberId,
+      hasAuthorizationHeader: Boolean(authorizationHeader),
+    });
+
+    set.status = 500;
+    return { error: "Failed to update member name" };
+  }
+}

--- a/functions/src/members-api/routes/update-member-name.ts
+++ b/functions/src/members-api/routes/update-member-name.ts
@@ -32,7 +32,6 @@ export async function updateMemberNameLogic({
   set: { status?: number | string };
 }): Promise<{ success: true; member: MemberResponse } | { error: string }> {
   try {
-    // Verify authentication and authorization
     const decodedToken = await authService.verifyOwnerOrAdmin(
       authorizationHeader,
       memberId,
@@ -45,7 +44,6 @@ export async function updateMemberNameLogic({
       isAdmin,
     });
 
-    // Update the name via service
     const updatedMember = await memberService.updateName(memberId, name);
 
     return {

--- a/functions/src/members-api/routes/update-member-name.ts
+++ b/functions/src/members-api/routes/update-member-name.ts
@@ -11,6 +11,7 @@ import type { MemberService } from "../services/member/interface.js";
 /**
  * Update member name logic (authenticated).
  * Requires authentication - users can update their own name, admins can update any member.
+ * The name is trimmed before saving. Admin users receive additional fields in the member response.
  *
  * @returns Success response with updated member data, or error object
  */
@@ -31,6 +32,12 @@ export async function updateMemberNameLogic({
   authorizationHeader: string | undefined;
   set: { status?: number | string };
 }): Promise<{ success: true; member: MemberResponse } | { error: string }> {
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    set.status = 422;
+    return { error: "Name must not be empty or whitespace-only" };
+  }
+
   try {
     const decodedToken = await authService.verifyOwnerOrAdmin(
       authorizationHeader,
@@ -44,7 +51,7 @@ export async function updateMemberNameLogic({
       isAdmin,
     });
 
-    const updatedMember = await memberService.updateName(memberId, name);
+    const updatedMember = await memberService.updateName(memberId, trimmedName);
 
     return {
       success: true,

--- a/functions/src/members-api/schemas/member-schemas.ts
+++ b/functions/src/members-api/schemas/member-schemas.ts
@@ -410,3 +410,41 @@ export const VerifyEmailResponseSchema = t.Union([
 ]);
 
 export type VerifyEmailResponse = Static<typeof VerifyEmailResponseSchema>;
+
+/**
+ * Request body schema for updating member name.
+ */
+export const UpdateMemberNameBodySchema = t.Object({
+  name: t.String({
+    minLength: 1,
+    maxLength: 200,
+    description: "The member's full name",
+    error: "Name must be between 1 and 200 characters",
+  }),
+});
+
+export type UpdateMemberNameBody = Static<typeof UpdateMemberNameBodySchema>;
+
+/**
+ * Member name update success response.
+ */
+export const UpdateMemberNameSuccessSchema = t.Object({
+  success: t.Literal(true),
+  member: MemberResponseSchema,
+});
+
+export type UpdateMemberNameSuccessResponse = Static<
+  typeof UpdateMemberNameSuccessSchema
+>;
+
+/**
+ * PATCH /members/:memberId/name response schema (union of success and error).
+ */
+export const UpdateMemberNameResponseSchema = t.Union([
+  UpdateMemberNameSuccessSchema,
+  ErrorResponseSchema,
+]);
+
+export type UpdateMemberNameResponse = Static<
+  typeof UpdateMemberNameResponseSchema
+>;

--- a/functions/src/members-api/services/member/interface.ts
+++ b/functions/src/members-api/services/member/interface.ts
@@ -21,6 +21,7 @@ export interface MemberService {
    * @param name - The new name to set
    * @returns Promise resolving to updated member document
    * @throws NotFoundError if member does not exist
+   * @throws Error for Firestore operation failures
    */
   updateName(memberId: string, name: string): Promise<MemberDocument>;
 }

--- a/functions/src/members-api/services/member/interface.ts
+++ b/functions/src/members-api/services/member/interface.ts
@@ -13,4 +13,14 @@ export interface MemberService {
    * @throws NotFoundError if member does not exist
    */
   findById(memberId: string): Promise<MemberDocument>;
+
+  /**
+   * Update a member's name.
+   *
+   * @param memberId - The Firestore document ID
+   * @param name - The new name to set
+   * @returns Promise resolving to updated member document
+   * @throws NotFoundError if member does not exist
+   */
+  updateName(memberId: string, name: string): Promise<MemberDocument>;
 }

--- a/functions/src/members-api/services/member/member-service.ts
+++ b/functions/src/members-api/services/member/member-service.ts
@@ -24,4 +24,27 @@ export const MemberService: MemberServiceInterface = {
 
     return document.data() as MemberDocument;
   },
+
+  /**
+   * Update a member's name.
+   *
+   * @param memberId - The Firestore document ID of the member
+   * @param name - The new name to set
+   * @returns Updated member document data
+   * @throws NotFoundError if member does not exist
+   */
+  async updateName(memberId: string, name: string): Promise<MemberDocument> {
+    const document = await MemberFirestoreService.getMemberByUid(memberId);
+
+    if (!document.exists) {
+      throw new NotFoundError("Member not found");
+    }
+
+    await MemberFirestoreService.updateMember(memberId, { name });
+
+    // Re-read the updated document
+    const updatedDocument =
+      await MemberFirestoreService.getMemberByUid(memberId);
+    return updatedDocument.data() as MemberDocument;
+  },
 };

--- a/functions/src/members-api/services/member/member-service.ts
+++ b/functions/src/members-api/services/member/member-service.ts
@@ -1,7 +1,4 @@
-import {
-  HttpError,
-  NotFoundError,
-} from "../../../shared-api/errors/http-error.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
 import { MemberFirestoreService } from "../../../shared-api/services/member-firestore/index.js";
 import type { MemberDocument } from "../../../types/member-document.js";
 import type { MemberService as MemberServiceInterface } from "./interface.js";
@@ -44,30 +41,15 @@ export const MemberService: MemberServiceInterface = {
       throw new NotFoundError("Member not found");
     }
 
-    try {
-      await MemberFirestoreService.updateMember(memberId, { name });
-    } catch (error) {
-      if (error instanceof HttpError) {
-        throw error;
-      }
-      throw error;
+    await MemberFirestoreService.updateMember(memberId, { name });
+
+    const updatedDocument =
+      await MemberFirestoreService.getMemberByUid(memberId);
+
+    if (!updatedDocument.exists) {
+      throw new NotFoundError("Member not found after update");
     }
 
-    try {
-      const updatedDocument =
-        await MemberFirestoreService.getMemberByUid(memberId);
-
-      if (!updatedDocument.exists) {
-        throw new NotFoundError("Member not found after update");
-      }
-
-      return updatedDocument.data() as MemberDocument;
-    } catch (error) {
-      if (error instanceof HttpError) {
-        throw error;
-      }
-      // Write succeeded but re-read failed — return constructed document
-      return { ...(document.data() as MemberDocument), name };
-    }
+    return updatedDocument.data() as MemberDocument;
   },
 };

--- a/functions/src/members-api/services/member/member-service.ts
+++ b/functions/src/members-api/services/member/member-service.ts
@@ -1,4 +1,7 @@
-import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import {
+  HttpError,
+  NotFoundError,
+} from "../../../shared-api/errors/http-error.js";
 import { MemberFirestoreService } from "../../../shared-api/services/member-firestore/index.js";
 import type { MemberDocument } from "../../../types/member-document.js";
 import type { MemberService as MemberServiceInterface } from "./interface.js";
@@ -32,6 +35,7 @@ export const MemberService: MemberServiceInterface = {
    * @param name - The new name to set
    * @returns Updated member document data
    * @throws NotFoundError if member does not exist
+   * @throws Error for Firestore operation failures
    */
   async updateName(memberId: string, name: string): Promise<MemberDocument> {
     const document = await MemberFirestoreService.getMemberByUid(memberId);
@@ -40,11 +44,30 @@ export const MemberService: MemberServiceInterface = {
       throw new NotFoundError("Member not found");
     }
 
-    await MemberFirestoreService.updateMember(memberId, { name });
+    try {
+      await MemberFirestoreService.updateMember(memberId, { name });
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw error;
+      }
+      throw error;
+    }
 
-    // Re-read the updated document
-    const updatedDocument =
-      await MemberFirestoreService.getMemberByUid(memberId);
-    return updatedDocument.data() as MemberDocument;
+    try {
+      const updatedDocument =
+        await MemberFirestoreService.getMemberByUid(memberId);
+
+      if (!updatedDocument.exists) {
+        throw new NotFoundError("Member not found after update");
+      }
+
+      return updatedDocument.data() as MemberDocument;
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw error;
+      }
+      // Write succeeded but re-read failed — return constructed document
+      return { ...(document.data() as MemberDocument), name };
+    }
   },
 };

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -30,9 +30,7 @@ export function createMembersTestPlugin(overrides?: {
 }) {
   const defaultMemberService: MemberService = {
     findById: mock(() => Promise.resolve({} as MemberDocument)),
-    updateName: mock((_memberId: string, _name: string) =>
-      Promise.resolve({} as MemberDocument),
-    ),
+    updateName: mock(() => Promise.resolve({} as MemberDocument)),
     ...overrides?.memberService,
   };
 

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -30,6 +30,9 @@ export function createMembersTestPlugin(overrides?: {
 }) {
   const defaultMemberService: MemberService = {
     findById: mock(() => Promise.resolve({} as MemberDocument)),
+    updateName: mock((_memberId: string, _name: string) =>
+      Promise.resolve({} as MemberDocument),
+    ),
     ...overrides?.memberService,
   };
 

--- a/members/src/app/membership/membership.html
+++ b/members/src/app/membership/membership.html
@@ -76,6 +76,43 @@
       </div>
     }
 
+    @if (showWelcomeNamePrompt()) {
+      <div class="welcome-name-prompt">
+        <h3>Welcome to the Rochester Doula Cooperative!</h3>
+        <p>
+          Thank you for joining! To get started with your membership, please enter your full name
+          below.
+        </p>
+        <form class="name-form" (ngSubmit)="onSaveName()">
+          <label for="member-name">Full Name</label>
+          <input
+            id="member-name"
+            type="text"
+            [ngModel]="nameInput()"
+            (ngModelChange)="nameInput.set($event)"
+            name="name"
+            placeholder="Enter your full name"
+            required
+            [disabled]="nameUpdateInProgress()"
+          />
+          <button
+            type="submit"
+            class="button"
+            [disabled]="nameUpdateInProgress() || nameInput().trim().length === 0"
+          >
+            @if (nameUpdateInProgress()) {
+              Saving...
+            } @else {
+              Save Name
+            }
+          </button>
+        </form>
+        @if (nameUpdateError(); as error) {
+          <p class="error-message">{{ error }}</p>
+        }
+      </div>
+    }
+
     <div class="welcome-section">
       <h1 class="welcome-greeting">Welcome back, {{ userDisplayName() }}!</h1>
 

--- a/members/src/app/membership/membership.scss
+++ b/members/src/app/membership/membership.scss
@@ -246,6 +246,62 @@
   animation: fadeSlideUp 0.5s ease-out both;
 }
 
+.welcome-name-prompt {
+  background: var(--teal-50, var(--brown-100));
+  border: 3px solid var(--teal-400, var(--brown-400));
+  border-radius: var(--border-radius-md);
+  padding: var(--space-l);
+  margin-block-end: var(--space-l);
+  max-width: 50ch;
+  text-align: center;
+  animation: fadeSlideUp 0.5s ease-out both;
+
+  h3 {
+    margin-block-end: var(--space-s);
+  }
+
+  p {
+    margin-block-end: var(--space-m);
+  }
+}
+
+.name-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+  align-items: center;
+
+  label {
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--step--1);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--brown-500);
+    align-self: flex-start;
+  }
+
+  input[type='text'] {
+    width: 100%;
+    padding: var(--space-xs) var(--space-s);
+    font-size: var(--step-0);
+    border: 1px solid var(--brown-300);
+    border-radius: var(--border-radius-md);
+    background: var(--brown-000);
+    transition: border-color 0.2s ease;
+
+    &:focus {
+      outline: none;
+      border-color: var(--teal-500);
+      box-shadow: 0 0 0 2px rgb(var(--teal-500-rgb, 0 128 128) / 0.2);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
 .profile-info {
   background: var(--teal-50);
   border: 2px solid var(--teal-200);
@@ -339,7 +395,8 @@
   .membership-card,
   .membership-actions,
   .claim-profile-banner,
-  .create-profile-banner {
+  .create-profile-banner,
+  .welcome-name-prompt {
     animation: none;
   }
 }

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -287,6 +287,25 @@ describe('Membership', () => {
       expect(saveButton).toBeDisabled();
     });
 
+    it('should keep save button disabled when name is only whitespace', async () => {
+      const { user } = await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      const nameInput = screen.getByLabelText('Full Name');
+      await user.type(nameInput, '   ');
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      expect(saveButton).toBeDisabled();
+    });
+
     it('should enable save button when name is entered', async () => {
       const { user } = await setup({
         isAuthenticated: true,

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -197,6 +197,180 @@ describe('Membership', () => {
     });
   });
 
+  describe('welcome name prompt', () => {
+    it('should show welcome prompt when member is active with no name and no slug', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      expect(screen.getByText('Welcome to the Rochester Doula Cooperative!')).toBeVisible();
+      expect(
+        screen.getByText(/To get started with your membership, please enter your full name/),
+      ).toBeVisible();
+      expect(screen.getByLabelText('Full Name')).toBeVisible();
+      expect(screen.getByRole('button', { name: 'Save Name' })).toBeVisible();
+    });
+
+    it('should not show welcome prompt when member has a name', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+          name: 'Jane Doe',
+        },
+      });
+
+      expect(
+        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show welcome prompt when membership is not active', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: false,
+        },
+      });
+
+      expect(
+        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show welcome prompt when member already has a slug', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+          slug: 'jane-doe',
+        },
+      });
+
+      expect(
+        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should disable save button when name input is empty', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      expect(saveButton).toBeDisabled();
+    });
+
+    it('should enable save button when name is entered', async () => {
+      const { user } = await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      const nameInput = screen.getByLabelText('Full Name');
+      await user.type(nameInput, 'Jane Doe');
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      expect(saveButton).toBeEnabled();
+    });
+
+    it('should call updateMemberName when save is clicked', async () => {
+      const { user, updateMemberNameMock } = await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      const nameInput = screen.getByLabelText('Full Name');
+      await user.type(nameInput, 'Jane Doe');
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      await user.click(saveButton);
+
+      expect(updateMemberNameMock).toHaveBeenCalledWith('Jane Doe');
+    });
+
+    it('should show error message when name update fails', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        // Intentionally empty - we're just suppressing console output in tests
+      });
+
+      const { user } = await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+        updateMemberNameShouldFail: true,
+      });
+
+      const nameInput = screen.getByLabelText('Full Name');
+      await user.type(nameInput, 'Jane Doe');
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      await user.click(saveButton);
+
+      expect(screen.getByText('Failed to save name')).toBeVisible();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not show create profile banner when name is missing', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      expect(screen.queryByText('Create Your Doula Profile')).not.toBeInTheDocument();
+    });
+  });
+
   describe('claimable profile banner', () => {
     it('should show error message when claimable profile fails to load', async () => {
       await setup({
@@ -364,6 +538,7 @@ interface SetupOptions {
   signOutShouldFail?: boolean;
   claimProfileShouldFail?: boolean;
   claimProfileError?: Error;
+  updateMemberNameShouldFail?: boolean;
 }
 
 async function setup({
@@ -378,6 +553,7 @@ async function setup({
   signOutShouldFail = false,
   claimProfileShouldFail = false,
   claimProfileError = new Error('Claim failed'),
+  updateMemberNameShouldFail = false,
 }: SetupOptions = {}) {
   const mockUser = isAuthenticated
     ? {
@@ -415,11 +591,16 @@ async function setup({
     ? vi.fn(() => Promise.reject(claimProfileError))
     : vi.fn(() => Promise.resolve());
 
+  const updateMemberNameMock = updateMemberNameShouldFail
+    ? vi.fn().mockRejectedValue(new Error('Failed to save name'))
+    : vi.fn().mockResolvedValue(undefined);
+
   const mockMembershipService = {
     userDocument: signal(mockUserDocument),
     getClaimableProfileData: getClaimableProfileDataMock,
     reloadUserDocument: vi.fn(),
     claimProfile: claimProfileMock,
+    updateMemberName: updateMemberNameMock,
   };
 
   await render(Membership, {
@@ -442,5 +623,6 @@ async function setup({
     user,
     claimProfileMock,
     signOutMock,
+    updateMemberNameMock,
   };
 }

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -15,8 +15,8 @@ describe('Membership', () => {
     it('should not show any content when user is not authenticated', async () => {
       await setup({ isAuthenticated: false });
 
-      expect(screen.queryByText(/Welcome back/)).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Sign Out' })).not.toBeInTheDocument();
+      expect(screen.queryByText(/Welcome back/)).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Sign Out' })).toBeNull();
     });
   });
 
@@ -231,9 +231,7 @@ describe('Membership', () => {
         },
       });
 
-      expect(
-        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Welcome to the Rochester Doula Cooperative!')).toBeNull();
     });
 
     it('should not show welcome prompt when membership is not active', async () => {
@@ -248,9 +246,7 @@ describe('Membership', () => {
         },
       });
 
-      expect(
-        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Welcome to the Rochester Doula Cooperative!')).toBeNull();
     });
 
     it('should not show welcome prompt when member already has a slug', async () => {
@@ -266,9 +262,7 @@ describe('Membership', () => {
         },
       });
 
-      expect(
-        screen.queryByText('Welcome to the Rochester Doula Cooperative!'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Welcome to the Rochester Doula Cooperative!')).toBeNull();
     });
 
     it('should disable save button when name input is empty', async () => {
@@ -407,7 +401,7 @@ describe('Membership', () => {
         },
       });
 
-      expect(screen.queryByText('Create Your Doula Profile')).not.toBeInTheDocument();
+      expect(screen.queryByText('Create Your Doula Profile')).toBeNull();
     });
   });
 

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -346,6 +346,27 @@ describe('Membership', () => {
       expect(updateMemberNameMock).toHaveBeenCalledWith('Jane Doe');
     });
 
+    it('should trim whitespace from name before sending to service', async () => {
+      const { user, updateMemberNameMock } = await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      const nameInput = screen.getByLabelText('Full Name');
+      await user.type(nameInput, '  Jane Doe  ');
+
+      const saveButton = screen.getByRole('button', { name: 'Save Name' });
+      await user.click(saveButton);
+
+      expect(updateMemberNameMock).toHaveBeenCalledWith('Jane Doe');
+    });
+
     it('should show error message when name update fails', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
         // Intentionally empty - we're just suppressing console output in tests

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -57,7 +57,7 @@ export class Membership {
     return userDocument?.membershipActive && !userDocument?.slug && !!userDocument?.name;
   });
 
-  // Show welcome prompt for active members who have no name set
+  // Show welcome prompt for active members without a slug who have no name set
   protected showWelcomeNamePrompt = computed(() => {
     const userDocument = this.userDocument();
     return userDocument?.membershipActive && !userDocument?.slug && !userDocument?.name;

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -51,13 +51,16 @@ export class Membership {
     loader: ({ params }) => this.membershipService.getClaimableProfileData(params.user),
   });
 
-  // Show create profile banner for active members without a slug who have a name
+  // Name prompt and profile creation banner are mutually exclusive:
+  // the name prompt appears first; once the member sets their name,
+  // the profile creation banner takes its place.
   protected showCreateProfileBanner = computed(() => {
     const userDocument = this.userDocument();
     return userDocument?.membershipActive && !userDocument?.slug && !!userDocument?.name;
   });
 
-  // Show welcome prompt for active members without a slug who have no name set
+  // Show welcome prompt for active members who need to set their name
+  // before they can create a profile (profile creation requires a name to generate a slug)
   protected showWelcomeNamePrompt = computed(() => {
     const userDocument = this.userDocument();
     return userDocument?.membershipActive && !userDocument?.slug && !userDocument?.name;

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -7,13 +7,14 @@ import {
   resource,
   signal,
 } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 import { MembershipService } from '../services/membership.service';
 import { ensureUniqueSlug, generateSlug } from '../utils/slug-generator';
 
 @Component({
-  imports: [DatePipe],
+  imports: [DatePipe, FormsModule],
   templateUrl: './membership.html',
   styleUrl: './membership.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -29,6 +30,9 @@ export class Membership {
   protected createProfileError = signal<string | undefined>(undefined);
   protected newsletterUpdateInProgress = signal(false);
   protected newsletterUpdateError = signal<string | undefined>(undefined);
+  protected nameInput = signal('');
+  protected nameUpdateInProgress = signal(false);
+  protected nameUpdateError = signal<string | undefined>(undefined);
 
   protected userDocument = this.membershipService.userDocument;
   protected userDocumentResource = this.membershipService.userDocumentResource;
@@ -51,6 +55,12 @@ export class Membership {
   protected showCreateProfileBanner = computed(() => {
     const userDocument = this.userDocument();
     return userDocument?.membershipActive && !userDocument?.slug && !!userDocument?.name;
+  });
+
+  // Show welcome prompt for active members who have no name set
+  protected showWelcomeNamePrompt = computed(() => {
+    const userDocument = this.userDocument();
+    return userDocument?.membershipActive && !userDocument?.slug && !userDocument?.name;
   });
 
   // Computed signals for formatted user data
@@ -186,6 +196,28 @@ export class Membership {
       this.createProfileError.set(errorMessage);
     } finally {
       this.createProfileInProgress.set(false);
+    }
+  }
+
+  protected async onSaveName() {
+    const name = this.nameInput().trim();
+    if (name.length === 0) {
+      return;
+    }
+
+    this.nameUpdateInProgress.set(true);
+    this.nameUpdateError.set(undefined);
+
+    try {
+      await this.membershipService.updateMemberName(name);
+      // Resource will auto-reload via reloadUserDocument() in service
+    } catch (error) {
+      console.error('Error updating name:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to save your name. Please try again.';
+      this.nameUpdateError.set(errorMessage);
+    } finally {
+      this.nameUpdateInProgress.set(false);
     }
   }
 

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -263,7 +263,8 @@ export class MembershipService {
   }
 
   /**
-   * Update the member's name
+   * Update the member's name.
+   * Triggers `reloadUserDocument()` on success to refresh the cached member data.
    * @param name - The full name to set
    * @throws Error with user-friendly message
    */
@@ -307,6 +308,12 @@ export class MembershipService {
 
           case 504: {
             throw new Error('Request timed out. Please check your connection and try again.');
+          }
+
+          default: {
+            throw new Error(
+              `Unable to update your name (error ${String(error.status)}). Please try again or contact support.`,
+            );
           }
         }
       }

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -293,8 +293,16 @@ export class MembershipService {
             throw new Error('You must be signed in to update your name.');
           }
 
+          case 403: {
+            throw new Error('You do not have permission to update this name.');
+          }
+
           case 404: {
             throw new Error('Member account not found. Please contact support.');
+          }
+
+          case 422: {
+            throw new Error('Invalid name. Please check your input and try again.');
           }
 
           case 504: {

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -263,6 +263,51 @@ export class MembershipService {
   }
 
   /**
+   * Update the member's name
+   * @param name - The full name to set
+   * @throws Error with user-friendly message
+   */
+  async updateMemberName(name: string): Promise<void> {
+    const uid = this.auth.currentUser?.uid;
+    if (!uid) {
+      throw new Error('You must be signed in to update your name.');
+    }
+
+    try {
+      await firstValueFrom(
+        this.http.patch<{ success: boolean; member: ApiMemberResponse }>(
+          `/api/members/${uid}/name`,
+          { name },
+        ),
+      );
+      // Trigger reload of user document to reflect changes
+      this.reloadUserDocument();
+    } catch (error: unknown) {
+      console.error('Failed to update member name:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      if (error instanceof HttpErrorResponse) {
+        switch (error.status) {
+          case 401: {
+            throw new Error('You must be signed in to update your name.');
+          }
+
+          case 404: {
+            throw new Error('Member account not found. Please contact support.');
+          }
+
+          case 504: {
+            throw new Error('Request timed out. Please check your connection and try again.');
+          }
+        }
+      }
+
+      throw new Error('Unable to update your name. Please try again.');
+    }
+  }
+
+  /**
    * Trigger a reload of the user document from the API
    */
   reloadUserDocument(): void {


### PR DESCRIPTION
## Summary
- New members who sign up through Stripe Checkout without entering a name get stuck with no call-to-action on the membership page
- Adds a prominent welcome prompt that appears when `membershipActive && !slug && !name`, allowing them to set their name before proceeding to profile creation
- Backend: `PATCH /api/members/:memberId/name` endpoint with owner-or-admin auth and input validation
- Frontend: Welcome card with name input form on the membership dashboard

## Test plan
- [ ] Backend tests pass: `cd functions && bun test src/members-api/routes/update-member-name.test.ts` (10 tests)
- [ ] Frontend tests pass: `cd members && bun run test --include src/app/membership/membership.spec.ts` (33 tests)
- [ ] Full test suite passes: `cd members && bun run test` (275 tests)
- [ ] Manual test: Log in as a member with no name, verify welcome prompt appears
- [ ] Manual test: Enter name and save, verify create-profile banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)