### PR TITLE
Auto-sign-in after password reset with email verification

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true
   }
 }

--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -299,6 +299,9 @@ export const ERROR_IDS = {
   API_STRIPE_WEBHOOK_ADMIN_CLAIM_FAILED:
     "api_stripe_webhook_admin_claim_failed",
   API_STRIPE_WEBHOOK_UNEXPECTED_ERROR: "api_stripe_webhook_unexpected_error",
+
+  // Email verification errors
+  VERIFY_EMAIL_ROUTE_FAILED: "verify_email_route_failed",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/members-api/plugins/members-plugin.ts
+++ b/functions/src/members-api/plugins/members-plugin.ts
@@ -4,14 +4,17 @@ import { AuthService } from "../../shared-api/services/auth/index.js";
 import { EmailService } from "../../shared-api/services/email/index.js";
 import { getMemberLogic } from "../routes/members.js";
 import { updateNewsletterPreferenceLogic } from "../routes/update-newsletter-preference.js";
+import { verifyEmailLogic } from "../routes/verify-email.js";
 import {
   GetMemberResponseSchema,
   MemberIdParameterSchema,
   UpdateNewsletterPreferenceBodySchema,
   UpdateNewsletterPreferenceResponseSchema,
+  VerifyEmailResponseSchema,
 } from "../schemas/member-schemas.js";
 import { MemberService } from "../services/member/member-service.js";
 import { NewsletterService } from "../services/newsletter/newsletter-service.js";
+import { VerifyEmailServiceImpl } from "../services/verify-email/verify-email-service.js";
 import { SERVICE_KEYS, type PartialServices } from "../types/services.js";
 
 /**
@@ -41,6 +44,10 @@ export function createMembersPlugin(services?: PartialServices) {
       .decorate(
         SERVICE_KEYS.NEWSLETTER_SERVICE,
         services?.newsletterService ?? NewsletterService,
+      )
+      .decorate(
+        SERVICE_KEYS.VERIFY_EMAIL_SERVICE,
+        services?.verifyEmailService ?? VerifyEmailServiceImpl,
       )
       // GET /:memberId - Get member by ID (owner or admin) - Served at /api/members/:memberId
       .get(
@@ -88,6 +95,31 @@ export function createMembersPlugin(services?: PartialServices) {
           params: MemberIdParameterSchema,
           body: UpdateNewsletterPreferenceBodySchema,
           response: UpdateNewsletterPreferenceResponseSchema,
+        },
+      )
+      // POST /:memberId/verify-email - Mark email as verified (owner only) - Served at /api/members/:memberId/verify-email
+      .post(
+        "/:memberId/verify-email",
+        async ({
+          params,
+          verifyEmailService,
+          authService,
+          logger,
+          request,
+          set,
+        }) =>
+          verifyEmailLogic({
+            memberId: params.memberId,
+            authService,
+            verifyEmailService,
+            logger,
+            authorizationHeader:
+              request.headers.get("authorization") ?? undefined,
+            set,
+          }),
+        {
+          params: MemberIdParameterSchema,
+          response: VerifyEmailResponseSchema,
         },
       )
   );

--- a/functions/src/members-api/routes/verify-email.test.ts
+++ b/functions/src/members-api/routes/verify-email.test.ts
@@ -15,6 +15,8 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
     authToken?: string | null;
     serverError?: boolean;
     emailAlreadyVerified?: boolean;
+    /** When true, overrides auth mock with explicit email_verified: false */
+    emailVerifiedExplicit?: boolean;
   }
 
   function setup({
@@ -22,6 +24,7 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
     authToken = "valid-owner-token",
     serverError = false,
     emailAlreadyVerified = false,
+    emailVerifiedExplicit = false,
   }: SetupOptions = {}) {
     const mockMarkEmailVerified = mock((): Promise<void> => {
       if (serverError) {
@@ -30,17 +33,20 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
       return Promise.resolve();
     });
 
+    // Override auth service when we need explicit email_verified state
+    const needsAuthOverride = emailAlreadyVerified || emailVerifiedExplicit;
+
     const testApp = createMembersTestPlugin({
       verifyEmailService: {
         markEmailVerified: mockMarkEmailVerified,
       },
-      ...(emailAlreadyVerified && {
+      ...(needsAuthOverride && {
         authService: {
           verifyOwnerOrAdmin: mock(() =>
             Promise.resolve({
               uid: memberId,
               email: "test@example.com",
-              email_verified: true,
+              email_verified: emailAlreadyVerified,
             } as DecodedIdToken),
           ),
         },
@@ -102,7 +108,7 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
 
   describe("Email verification", () => {
     it("should successfully verify email for owner", async () => {
-      const { testApp, request } = setup();
+      const { testApp, request } = setup({ emailVerifiedExplicit: true });
 
       const response = await handleRequest(testApp, request);
 

--- a/functions/src/members-api/routes/verify-email.test.ts
+++ b/functions/src/members-api/routes/verify-email.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { DecodedIdToken } from "firebase-admin/auth";
+import {
+  AuthError,
+  ForbiddenError,
+} from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
+
+/**
+ * Tests for the verify email endpoint.
+ *
+ * Uses createMembersTestPlugin() factory with mocked services.
+ * Tests only the members plugin in isolation.
+ */
+describe("POST /:memberId/verify-email (authenticated)", () => {
+  interface SetupOptions {
+    memberId?: string;
+    authToken?: string | null;
+    serverError?: boolean;
+  }
+
+  function setup({
+    memberId = "test-member-id",
+    authToken = "valid-owner-token",
+    serverError = false,
+  }: SetupOptions = {}) {
+    const mockMarkEmailVerified = mock((_uid: string): Promise<void> => {
+      if (serverError) {
+        throw new Error("Firebase Admin error");
+      }
+      return Promise.resolve();
+    });
+
+    const mockVerifyOwnerOrAdmin = mock(
+      (
+        authorizationHeader: string | undefined,
+        targetMemberId: string,
+      ): Promise<DecodedIdToken> => {
+        if (!authorizationHeader) {
+          return Promise.reject(new AuthError("Missing Authorization header"));
+        }
+
+        if (
+          authorizationHeader === "Bearer valid-owner-token" &&
+          (targetMemberId === "test-member-id" || targetMemberId === "test-id")
+        ) {
+          return Promise.resolve({
+            uid: targetMemberId,
+            email: "test@example.com",
+          } as DecodedIdToken);
+        }
+
+        if (authorizationHeader === "Bearer admin-token") {
+          return Promise.resolve({
+            uid: "admin-user",
+            email: "admin@example.com",
+            admin: true,
+          } as unknown as DecodedIdToken);
+        }
+
+        if (authorizationHeader === "Bearer non-owner-token") {
+          return Promise.reject(
+            new ForbiddenError("You can only verify your own email"),
+          );
+        }
+
+        return Promise.reject(new AuthError("Invalid authentication token"));
+      },
+    );
+
+    const testApp = createMembersTestPlugin({
+      verifyEmailService: {
+        markEmailVerified: mockMarkEmailVerified,
+      },
+      authService: {
+        verifyOwnerOrAdmin: mockVerifyOwnerOrAdmin,
+      },
+    });
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(`http://localhost/${memberId}/verify-email`, {
+      method: "POST",
+      headers,
+    });
+
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const { testApp, request } = setup({ authToken: null });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 403 when non-owner tries to verify email", async () => {
+      const { testApp, request } = setup({ authToken: "non-owner-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should return 403 when admin tries to verify another member's email", async () => {
+      const { testApp, request } = setup({ authToken: "admin-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("You can only verify your own email");
+    });
+  });
+
+  describe("Email verification", () => {
+    it("should successfully verify email for owner", async () => {
+      const { testApp, request } = setup();
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should return 500 for unexpected errors", async () => {
+      const { testApp, request } = setup({ serverError: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Failed to verify email");
+    });
+  });
+});

--- a/functions/src/members-api/routes/verify-email.test.ts
+++ b/functions/src/members-api/routes/verify-email.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import type { DecodedIdToken } from "firebase-admin/auth";
 import { handleRequest } from "../../test-utils/handle-request.js";
 import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
 
@@ -40,7 +41,7 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
               uid: memberId,
               email: "test@example.com",
               email_verified: true,
-            }),
+            } as DecodedIdToken),
           ),
         },
       }),

--- a/functions/src/members-api/routes/verify-email.test.ts
+++ b/functions/src/members-api/routes/verify-email.test.ts
@@ -1,9 +1,4 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { DecodedIdToken } from "firebase-admin/auth";
-import {
-  AuthError,
-  ForbiddenError,
-} from "../../shared-api/errors/http-error.js";
 import { handleRequest } from "../../test-utils/handle-request.js";
 import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
 
@@ -18,64 +13,37 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
     memberId?: string;
     authToken?: string | null;
     serverError?: boolean;
+    emailAlreadyVerified?: boolean;
   }
 
   function setup({
     memberId = "test-member-id",
     authToken = "valid-owner-token",
     serverError = false,
+    emailAlreadyVerified = false,
   }: SetupOptions = {}) {
-    const mockMarkEmailVerified = mock((_uid: string): Promise<void> => {
+    const mockMarkEmailVerified = mock((): Promise<void> => {
       if (serverError) {
         throw new Error("Firebase Admin error");
       }
       return Promise.resolve();
     });
 
-    const mockVerifyOwnerOrAdmin = mock(
-      (
-        authorizationHeader: string | undefined,
-        targetMemberId: string,
-      ): Promise<DecodedIdToken> => {
-        if (!authorizationHeader) {
-          return Promise.reject(new AuthError("Missing Authorization header"));
-        }
-
-        if (
-          authorizationHeader === "Bearer valid-owner-token" &&
-          (targetMemberId === "test-member-id" || targetMemberId === "test-id")
-        ) {
-          return Promise.resolve({
-            uid: targetMemberId,
-            email: "test@example.com",
-          } as DecodedIdToken);
-        }
-
-        if (authorizationHeader === "Bearer admin-token") {
-          return Promise.resolve({
-            uid: "admin-user",
-            email: "admin@example.com",
-            admin: true,
-          } as unknown as DecodedIdToken);
-        }
-
-        if (authorizationHeader === "Bearer non-owner-token") {
-          return Promise.reject(
-            new ForbiddenError("You can only verify your own email"),
-          );
-        }
-
-        return Promise.reject(new AuthError("Invalid authentication token"));
-      },
-    );
-
     const testApp = createMembersTestPlugin({
       verifyEmailService: {
         markEmailVerified: mockMarkEmailVerified,
       },
-      authService: {
-        verifyOwnerOrAdmin: mockVerifyOwnerOrAdmin,
-      },
+      ...(emailAlreadyVerified && {
+        authService: {
+          verifyOwnerOrAdmin: mock(() =>
+            Promise.resolve({
+              uid: memberId,
+              email: "test@example.com",
+              email_verified: true,
+            }),
+          ),
+        },
+      }),
     });
 
     const headers: Record<string, string> = {
@@ -102,6 +70,14 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
       expect(response.status).toBe(401);
       const body = (await response.json()) as { error?: string };
       expect(body.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 401 for invalid authentication token", async () => {
+      const { testApp, request } = setup({ authToken: "invalid-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
     });
 
     it("should return 403 when non-owner tries to verify email", async () => {
@@ -132,6 +108,51 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { success: boolean };
       expect(body.success).toBe(true);
+    });
+
+    it("should return 400 when email is already verified", async () => {
+      const { testApp, request } = setup({ emailAlreadyVerified: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Email is already verified");
+    });
+  });
+
+  describe("Input validation", () => {
+    it("should reject empty member ID", async () => {
+      const { testApp } = setup();
+
+      const request = new Request("http://localhost//verify-email", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer valid-owner-token",
+          "Content-Type": "application/json",
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(404);
+    });
+
+    it("should reject member IDs longer than 128 characters", async () => {
+      const { testApp } = setup();
+
+      const longId = "a".repeat(129);
+      const request = new Request(`http://localhost/${longId}/verify-email`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer admin-token",
+          "Content-Type": "application/json",
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
     });
   });
 

--- a/functions/src/members-api/routes/verify-email.ts
+++ b/functions/src/members-api/routes/verify-email.ts
@@ -2,13 +2,11 @@ import { ERROR_IDS } from "../../constants/error-ids.js";
 import {
   ForbiddenError,
   HttpError,
+  ValidationError,
 } from "../../shared-api/errors/http-error.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { Logger } from "../../shared-api/types/logger.js";
-
-export interface VerifyEmailService {
-  markEmailVerified(uid: string): Promise<void>;
-}
+import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
  * Route logic for POST /:memberId/verify-email
@@ -16,6 +14,7 @@ export interface VerifyEmailService {
  * Marks a member's email as verified in Firebase Auth.
  * Owner-only: the authenticated user's UID must match the memberId.
  * Admin access is explicitly denied — admins should not verify emails on behalf of members.
+ * Rejects requests when the email is already verified to prevent misuse.
  */
 export async function verifyEmailLogic({
   memberId,
@@ -43,7 +42,15 @@ export async function verifyEmailLogic({
       throw new ForbiddenError("You can only verify your own email");
     }
 
+    // Reject if email is already verified — prevents misuse by already-verified users
+    if (decodedToken.email_verified === true) {
+      throw new ValidationError("Email is already verified");
+    }
+
     await verifyEmailService.markEmailVerified(memberId);
+
+    logger.info("Email marked as verified", { memberId });
+
     return { success: true };
   } catch (error: unknown) {
     if (error instanceof HttpError) {

--- a/functions/src/members-api/routes/verify-email.ts
+++ b/functions/src/members-api/routes/verify-email.ts
@@ -1,0 +1,65 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import {
+  ForbiddenError,
+  HttpError,
+} from "../../shared-api/errors/http-error.js";
+import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+
+export interface VerifyEmailService {
+  markEmailVerified(uid: string): Promise<void>;
+}
+
+/**
+ * Route logic for POST /:memberId/verify-email
+ *
+ * Marks a member's email as verified in Firebase Auth.
+ * Owner-only: the authenticated user's UID must match the memberId.
+ * Admin access is explicitly denied — admins should not verify emails on behalf of members.
+ */
+export async function verifyEmailLogic({
+  memberId,
+  authService,
+  verifyEmailService,
+  logger,
+  authorizationHeader,
+  set,
+}: {
+  memberId: string;
+  authService: AuthService;
+  verifyEmailService: VerifyEmailService;
+  logger: Logger;
+  authorizationHeader: string | undefined;
+  set: { status?: number | string };
+}): Promise<{ success: true } | { error: string }> {
+  try {
+    const decodedToken = await authService.verifyOwnerOrAdmin(
+      authorizationHeader,
+      memberId,
+    );
+
+    // Only the owner can verify their own email — reject admin
+    if (decodedToken.uid !== memberId) {
+      throw new ForbiddenError("You can only verify your own email");
+    }
+
+    await verifyEmailService.markEmailVerified(memberId);
+    return { success: true };
+  } catch (error: unknown) {
+    if (error instanceof HttpError) {
+      set.status = error.statusCode;
+      return { error: error.message };
+    }
+
+    logger.error("Failed to verify email", {
+      errorId: ERROR_IDS.VERIFY_EMAIL_ROUTE_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      errorStack: error instanceof Error ? error.stack : undefined,
+      memberId,
+    });
+
+    set.status = 500;
+    return { error: "Failed to verify email" };
+  }
+}

--- a/functions/src/members-api/routes/verify-email.ts
+++ b/functions/src/members-api/routes/verify-email.ts
@@ -6,15 +6,17 @@ import {
 } from "../../shared-api/errors/http-error.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { Logger } from "../../shared-api/types/logger.js";
+import type { VerifyEmailResponse } from "../schemas/member-schemas.js";
 import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
  * Route logic for POST /:memberId/verify-email
  *
  * Marks a member's email as verified in Firebase Auth.
- * Owner-only: the authenticated user's UID must match the memberId.
- * Admin access is explicitly denied — admins should not verify emails on behalf of members.
- * Rejects requests when the email is already verified to prevent misuse.
+ * Uses verifyOwnerOrAdmin for initial auth (consistent with other member routes),
+ * then explicitly rejects non-owner tokens to restrict this security-sensitive
+ * action to the account holder only.
+ * Idempotency guard: rejects requests when the email is already verified.
  */
 export async function verifyEmailLogic({
   memberId,
@@ -30,7 +32,7 @@ export async function verifyEmailLogic({
   logger: Logger;
   authorizationHeader: string | undefined;
   set: { status?: number | string };
-}): Promise<{ success: true } | { error: string }> {
+}): Promise<VerifyEmailResponse> {
   try {
     const decodedToken = await authService.verifyOwnerOrAdmin(
       authorizationHeader,
@@ -42,7 +44,7 @@ export async function verifyEmailLogic({
       throw new ForbiddenError("You can only verify your own email");
     }
 
-    // Reject if email is already verified — prevents misuse by already-verified users
+    // Idempotency guard: only allow verification for users whose email is not yet verified
     if (decodedToken.email_verified === true) {
       throw new ValidationError("Email is already verified");
     }
@@ -63,7 +65,9 @@ export async function verifyEmailLogic({
       error,
       errorMessage: error instanceof Error ? error.message : "Unknown error",
       errorStack: error instanceof Error ? error.stack : undefined,
+      errorType: error?.constructor?.name,
       memberId,
+      hasAuthorizationHeader: Boolean(authorizationHeader),
     });
 
     set.status = 500;

--- a/functions/src/members-api/schemas/member-schemas.ts
+++ b/functions/src/members-api/schemas/member-schemas.ts
@@ -393,3 +393,20 @@ export const UpdateNewsletterPreferenceResponseSchema = t.Union([
 export type UpdateNewsletterPreferenceResponse = Static<
   typeof UpdateNewsletterPreferenceResponseSchema
 >;
+
+/**
+ * Verify email success response.
+ */
+export const VerifyEmailSuccessSchema = t.Object({
+  success: t.Literal(true),
+});
+
+/**
+ * POST /members/:memberId/verify-email response schema (union of success and error).
+ */
+export const VerifyEmailResponseSchema = t.Union([
+  VerifyEmailSuccessSchema,
+  ErrorResponseSchema,
+]);
+
+export type VerifyEmailResponse = Static<typeof VerifyEmailResponseSchema>;

--- a/functions/src/members-api/services/verify-email/interface.ts
+++ b/functions/src/members-api/services/verify-email/interface.ts
@@ -1,0 +1,3 @@
+export interface VerifyEmailService {
+  markEmailVerified(uid: string): Promise<void>;
+}

--- a/functions/src/members-api/services/verify-email/interface.ts
+++ b/functions/src/members-api/services/verify-email/interface.ts
@@ -1,3 +1,9 @@
 export interface VerifyEmailService {
+  /**
+   * Mark a user's email as verified in Firebase Auth.
+   *
+   * @param uid - The Firebase Auth UID of the user
+   * @throws Error if the Firebase Admin SDK call fails
+   */
   markEmailVerified(uid: string): Promise<void>;
 }

--- a/functions/src/members-api/services/verify-email/verify-email-service.ts
+++ b/functions/src/members-api/services/verify-email/verify-email-service.ts
@@ -1,5 +1,5 @@
 import { getAuth } from "firebase-admin/auth";
-import type { VerifyEmailService } from "../../routes/verify-email.js";
+import type { VerifyEmailService } from "./interface.js";
 
 /**
  * Real implementation of VerifyEmailService using Firebase Admin SDK.

--- a/functions/src/members-api/services/verify-email/verify-email-service.ts
+++ b/functions/src/members-api/services/verify-email/verify-email-service.ts
@@ -1,0 +1,11 @@
+import { getAuth } from "firebase-admin/auth";
+import type { VerifyEmailService } from "../../routes/verify-email.js";
+
+/**
+ * Real implementation of VerifyEmailService using Firebase Admin SDK.
+ */
+export const VerifyEmailServiceImpl: VerifyEmailService = {
+  async markEmailVerified(uid: string): Promise<void> {
+    await getAuth().updateUser(uid, { emailVerified: true });
+  },
+};

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -9,9 +9,9 @@ import {
 } from "../../test-utils/auth-mocks.js";
 import type { MemberDocument } from "../../types/member-document.js";
 import { createMembersPlugin } from "../plugins/members-plugin.js";
-import type { VerifyEmailService } from "../routes/verify-email.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
+import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
  * Creates the members plugin with default mock services for testing.

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -9,6 +9,7 @@ import {
 } from "../../test-utils/auth-mocks.js";
 import type { MemberDocument } from "../../types/member-document.js";
 import { createMembersPlugin } from "../plugins/members-plugin.js";
+import type { VerifyEmailService } from "../routes/verify-email.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
 
@@ -24,6 +25,7 @@ export function createMembersTestPlugin(overrides?: {
   newsletterService?: Partial<NewsletterService>;
   authService?: Partial<AuthService>;
   emailService?: EmailServiceInterface;
+  verifyEmailService?: Partial<VerifyEmailService>;
   logger?: Logger;
 }) {
   const defaultMemberService: MemberService = {
@@ -50,11 +52,17 @@ export function createMembersTestPlugin(overrides?: {
     ...overrides?.emailService,
   };
 
+  const defaultVerifyEmailService: VerifyEmailService = {
+    markEmailVerified: mock(() => Promise.resolve()),
+    ...overrides?.verifyEmailService,
+  };
+
   return createMembersPlugin({
     memberService: defaultMemberService,
     newsletterService: defaultNewsletterService,
     authService: defaultAuthService,
     emailService: defaultEmailService,
+    verifyEmailService: defaultVerifyEmailService,
     ...(overrides?.logger !== undefined && { logger: overrides.logger }),
   });
 }

--- a/functions/src/members-api/types/services.ts
+++ b/functions/src/members-api/types/services.ts
@@ -1,9 +1,9 @@
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
-import type { VerifyEmailService } from "../routes/verify-email.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
+import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
  * Service keys used for dependency injection via Elysia's decorate.

--- a/functions/src/members-api/types/services.ts
+++ b/functions/src/members-api/types/services.ts
@@ -1,6 +1,7 @@
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
+import type { VerifyEmailService } from "../routes/verify-email.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
 
@@ -14,6 +15,7 @@ export const SERVICE_KEYS = {
   EMAIL_SERVICE: "emailService",
   LOGGER: "logger",
   NEWSLETTER_SERVICE: "newsletterService",
+  VERIFY_EMAIL_SERVICE: "verifyEmailService",
 } as const;
 
 /**
@@ -27,6 +29,7 @@ export interface Services {
   [SERVICE_KEYS.EMAIL_SERVICE]: EmailServiceInterface;
   [SERVICE_KEYS.LOGGER]: Logger;
   [SERVICE_KEYS.NEWSLETTER_SERVICE]: NewsletterService;
+  [SERVICE_KEYS.VERIFY_EMAIL_SERVICE]: VerifyEmailService;
 }
 
 /**

--- a/members/src/app/auth-actions/auth-actions.integration.spec.ts
+++ b/members/src/app/auth-actions/auth-actions.integration.spec.ts
@@ -96,6 +96,46 @@ describe('AuthActions - Integration Tests', () => {
       expect(await screen.findByText('Sign In Page')).toBeVisible();
     });
 
+    it('should navigate to membership even when verifyEmail fails after sign-in', async () => {
+      const { user } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code',
+        verifyEmailShouldSucceed: false,
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newSecurePassword123');
+      await user.type(confirmPasswordInput, 'newSecurePassword123');
+      await user.click(submitButton);
+
+      expect(await screen.findByText('Membership Page')).toBeVisible();
+    });
+
+    it('should navigate to sign-in when email is empty after password reset', async () => {
+      const { user } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code',
+        userEmail: '',
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newSecurePassword123');
+      await user.type(confirmPasswordInput, 'newSecurePassword123');
+      await user.click(submitButton);
+
+      expect(await screen.findByText('Sign In Page')).toBeVisible();
+    });
+
     it('should stay on auth-actions page when password reset fails', async () => {
       const { user } = await setup({
         mode: 'resetPassword',
@@ -177,8 +217,10 @@ interface SetupIntegrationOptions {
   verifyCodeShouldSucceed?: boolean;
   confirmResetShouldSucceed?: boolean;
   signInShouldSucceed?: boolean;
+  verifyEmailShouldSucceed?: boolean;
   errorMessage?: string;
   restoredEmail?: string;
+  userEmail?: string;
 }
 
 async function setup({
@@ -189,8 +231,10 @@ async function setup({
   verifyCodeShouldSucceed = shouldSucceed,
   confirmResetShouldSucceed = shouldSucceed,
   signInShouldSucceed = true,
+  verifyEmailShouldSucceed = true,
   errorMessage = 'An error occurred',
   restoredEmail = 'restored@example.com',
+  userEmail = 'user@example.com',
 }: SetupIntegrationOptions = {}) {
   // Build the route from semantic parameters
   const queryParameters = new URLSearchParams();
@@ -211,7 +255,7 @@ async function setup({
     verifyPasswordResetCode: vi
       .fn()
       .mockImplementation(() =>
-        verifyCodeShouldSucceed ? Promise.resolve('user@example.com') : createRejection(),
+        verifyCodeShouldSucceed ? Promise.resolve(userEmail) : createRejection(),
       ),
     confirmPasswordReset: vi
       .fn()
@@ -234,7 +278,13 @@ async function setup({
   };
 
   const mockMembershipService = {
-    verifyEmail: vi.fn().mockResolvedValue(undefined),
+    verifyEmail: vi
+      .fn()
+      .mockImplementation(() =>
+        verifyEmailShouldSucceed
+          ? Promise.resolve()
+          : Promise.reject(new Error('Unable to verify email. Please try again.')),
+      ),
   };
 
   // Set up routes that match the real app structure

--- a/members/src/app/auth-actions/auth-actions.integration.spec.ts
+++ b/members/src/app/auth-actions/auth-actions.integration.spec.ts
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { AuthService } from '../services/auth.service';
+import { MembershipService } from '../services/membership.service';
 import { AuthActions } from './auth-actions';
 
 // Mock components for routing
@@ -56,10 +57,30 @@ describe('AuthActions - Integration Tests', () => {
   });
 
   describe('resetPassword navigation flow', () => {
-    it('should navigate to sign-in page after successful password reset', async () => {
+    it('should navigate to membership page after successful password reset with auto-sign-in', async () => {
       const { user } = await setup({
         mode: 'resetPassword',
         oobCode: 'reset-code',
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newSecurePassword123');
+      await user.type(confirmPasswordInput, 'newSecurePassword123');
+      await user.click(submitButton);
+
+      expect(await screen.findByText('Membership Page')).toBeVisible();
+    });
+
+    it('should navigate to sign-in page when auto-sign-in fails after password reset', async () => {
+      const { user } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code',
+        signInShouldSucceed: false,
       });
 
       expect(await screen.findByText('Reset your password')).toBeVisible();
@@ -155,6 +176,7 @@ interface SetupIntegrationOptions {
   shouldSucceed?: boolean;
   verifyCodeShouldSucceed?: boolean;
   confirmResetShouldSucceed?: boolean;
+  signInShouldSucceed?: boolean;
   errorMessage?: string;
   restoredEmail?: string;
 }
@@ -166,6 +188,7 @@ async function setup({
   shouldSucceed = true,
   verifyCodeShouldSucceed = shouldSucceed,
   confirmResetShouldSucceed = shouldSucceed,
+  signInShouldSucceed = true,
   errorMessage = 'An error occurred',
   restoredEmail = 'restored@example.com',
 }: SetupIntegrationOptions = {}) {
@@ -201,6 +224,17 @@ async function setup({
         shouldSucceed ? Promise.resolve({ data: { email: restoredEmail } }) : createRejection(),
       ),
     sendPasswordResetEmail: vi.fn().mockResolvedValue(undefined),
+    signInWithEmail: vi
+      .fn()
+      .mockImplementation(() =>
+        signInShouldSucceed
+          ? Promise.resolve({ user: { uid: 'test-uid' } })
+          : Promise.reject(new Error('Sign in failed')),
+      ),
+  };
+
+  const mockMembershipService = {
+    verifyEmail: vi.fn().mockResolvedValue(undefined),
   };
 
   // Set up routes that match the real app structure
@@ -215,6 +249,7 @@ async function setup({
     providers: [
       provideRouter(routes, withComponentInputBinding()),
       { provide: AuthService, useValue: mockAuthService },
+      { provide: MembershipService, useValue: mockMembershipService },
     ],
   });
 

--- a/members/src/app/auth-actions/auth-actions.spec.ts
+++ b/members/src/app/auth-actions/auth-actions.spec.ts
@@ -202,7 +202,7 @@ describe('AuthActions - Unit Tests', () => {
     });
 
     it('should auto-sign-in and navigate to membership after password reset', async () => {
-      const { user, mockAuthService, mockMembershipService } = await setup({
+      const { user, mockAuthService, mockMembershipService, navigateSpy } = await setup({
         mode: 'resetPassword',
         oobCode: 'reset-code-auto',
       });
@@ -224,10 +224,11 @@ describe('AuthActions - Unit Tests', () => {
         );
       });
       expect(mockMembershipService.verifyEmail).toHaveBeenCalledOnce();
+      expect(navigateSpy).toHaveBeenCalledWith(['/membership']);
     });
 
     it('should fall back to sign-in page when auto-sign-in fails', async () => {
-      const { user, mockAuthService } = await setup({
+      const { user, mockAuthService, navigateSpy } = await setup({
         mode: 'resetPassword',
         oobCode: 'reset-code-signin-fail',
         signInShouldSucceed: false,
@@ -252,6 +253,60 @@ describe('AuthActions - Unit Tests', () => {
       expect(
         screen.getByText('Password has been reset successfully. You can now sign in.'),
       ).toBeVisible();
+      expect(navigateSpy).toHaveBeenCalledWith(['/sign-in'], {
+        queryParams: { email: 'user@example.com' },
+      });
+    });
+
+    it('should skip auto-sign-in and redirect to sign-in when email is empty', async () => {
+      const { user, mockAuthService, navigateSpy } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code-no-email',
+        userEmail: '',
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newPassword123');
+      await user.type(confirmPasswordInput, 'newPassword123');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockAuthService.confirmPasswordReset).toHaveBeenCalled();
+      });
+
+      expect(mockAuthService.signInWithEmail).not.toHaveBeenCalled();
+      expect(await screen.findByText('Success')).toBeVisible();
+      expect(navigateSpy).toHaveBeenCalledWith(['/sign-in'], undefined);
+    });
+
+    it('should navigate to membership even when verifyEmail fails after sign-in', async () => {
+      const { user, mockMembershipService, navigateSpy } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code-verify-fail',
+        verifyEmailShouldSucceed: false,
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newPassword123');
+      await user.type(confirmPasswordInput, 'newPassword123');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMembershipService.verifyEmail).toHaveBeenCalledOnce();
+      });
+
+      // Should still navigate to membership dashboard despite verifyEmail failure
+      expect(navigateSpy).toHaveBeenCalledWith(['/membership']);
     });
   });
 
@@ -342,6 +397,7 @@ interface SetupOptions {
   verifyCodeShouldSucceed?: boolean;
   confirmResetShouldSucceed?: boolean;
   signInShouldSucceed?: boolean;
+  verifyEmailShouldSucceed?: boolean;
   errorMessage?: string;
   restoredEmail?: string;
   userEmail?: string;
@@ -356,6 +412,7 @@ async function setup({
   verifyCodeShouldSucceed = shouldSucceed,
   confirmResetShouldSucceed = shouldSucceed,
   signInShouldSucceed = true,
+  verifyEmailShouldSucceed = true,
   errorMessage = 'An error occurred',
   restoredEmail = 'restored@example.com',
   userEmail = 'user@example.com',
@@ -395,7 +452,13 @@ async function setup({
   };
 
   const mockMembershipService = {
-    verifyEmail: vi.fn().mockResolvedValue(undefined),
+    verifyEmail: vi
+      .fn()
+      .mockImplementation(() =>
+        verifyEmailShouldSucceed
+          ? Promise.resolve()
+          : Promise.reject(new Error('Unable to verify email. Please try again.')),
+      ),
   };
 
   await render(AuthActions, {

--- a/members/src/app/auth-actions/auth-actions.spec.ts
+++ b/members/src/app/auth-actions/auth-actions.spec.ts
@@ -1,7 +1,10 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { MembershipService } from '../services/membership.service';
 import { AuthActions } from './auth-actions';
 
 type AuthActionMode = 'verifyEmail' | 'resetPassword' | 'recoverEmail';
@@ -197,6 +200,59 @@ describe('AuthActions - Unit Tests', () => {
       expect(await screen.findByText('There was a problem')).toBeVisible();
       expect(await screen.findByText('Invalid or expired action code')).toBeVisible();
     });
+
+    it('should auto-sign-in and navigate to membership after password reset', async () => {
+      const { user, mockAuthService, mockMembershipService } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code-auto',
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newPassword123');
+      await user.type(confirmPasswordInput, 'newPassword123');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockAuthService.signInWithEmail).toHaveBeenCalledWith(
+          'user@example.com',
+          'newPassword123',
+        );
+      });
+      expect(mockMembershipService.verifyEmail).toHaveBeenCalledOnce();
+    });
+
+    it('should fall back to sign-in page when auto-sign-in fails', async () => {
+      const { user, mockAuthService } = await setup({
+        mode: 'resetPassword',
+        oobCode: 'reset-code-signin-fail',
+        signInShouldSucceed: false,
+      });
+
+      expect(await screen.findByText('Reset your password')).toBeVisible();
+
+      const passwordInput = screen.getByLabelText('New password');
+      const confirmPasswordInput = screen.getByLabelText('Confirm new password');
+      const submitButton = screen.getByRole('button', { name: 'Set new password' });
+
+      await user.type(passwordInput, 'newPassword123');
+      await user.type(confirmPasswordInput, 'newPassword123');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockAuthService.confirmPasswordReset).toHaveBeenCalled();
+      });
+
+      // Should show success even though auto-sign-in failed (falls back to sign-in redirect)
+      expect(await screen.findByText('Success')).toBeVisible();
+      expect(
+        screen.getByText('Password has been reset successfully. You can now sign in.'),
+      ).toBeVisible();
+    });
   });
 
   describe('recoverEmail mode', () => {
@@ -285,6 +341,7 @@ interface SetupOptions {
   shouldSucceed?: boolean;
   verifyCodeShouldSucceed?: boolean;
   confirmResetShouldSucceed?: boolean;
+  signInShouldSucceed?: boolean;
   errorMessage?: string;
   restoredEmail?: string;
   userEmail?: string;
@@ -298,6 +355,7 @@ async function setup({
   shouldSucceed = true,
   verifyCodeShouldSucceed = shouldSucceed,
   confirmResetShouldSucceed = shouldSucceed,
+  signInShouldSucceed = true,
   errorMessage = 'An error occurred',
   restoredEmail = 'restored@example.com',
   userEmail = 'user@example.com',
@@ -321,6 +379,13 @@ async function setup({
       .mockImplementation(() =>
         confirmResetShouldSucceed ? Promise.resolve() : createRejection(),
       ),
+    signInWithEmail: vi
+      .fn()
+      .mockImplementation(() =>
+        signInShouldSucceed
+          ? Promise.resolve({ user: { uid: 'test-uid' } })
+          : Promise.reject(new Error('Sign in failed')),
+      ),
     checkActionCode: vi
       .fn()
       .mockImplementation(() =>
@@ -329,8 +394,16 @@ async function setup({
     sendPasswordResetEmail: vi.fn().mockResolvedValue(undefined),
   };
 
+  const mockMembershipService = {
+    verifyEmail: vi.fn().mockResolvedValue(undefined),
+  };
+
   await render(AuthActions, {
-    providers: [{ provide: AuthService, useValue: mockAuthService }],
+    providers: [
+      provideRouter([]),
+      { provide: AuthService, useValue: mockAuthService },
+      { provide: MembershipService, useValue: mockMembershipService },
+    ],
     inputs: {
       mode,
       oobCode,
@@ -338,7 +411,11 @@ async function setup({
       lang,
     },
   });
+
+  const router = TestBed.inject(Router);
+  const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
   const user = userEvent.setup();
 
-  return { user, mockAuthService };
+  return { user, mockAuthService, mockMembershipService, navigateSpy };
 }

--- a/members/src/app/auth-actions/auth-actions.ts
+++ b/members/src/app/auth-actions/auth-actions.ts
@@ -117,33 +117,16 @@ export class AuthActions {
     try {
       await this.authService.confirmPasswordReset(code, password);
 
-      // Try to auto-sign-in and verify email
       const email = this.emailForAction();
-      if (email !== '') {
-        try {
-          await this.authService.signInWithEmail(email, password);
-          // Now authenticated - mark email as verified (best-effort)
-          try {
-            await this.membershipService.verifyEmail();
-          } catch (verifyError: unknown) {
-            console.error('Email verification failed after password reset:', {
-              error: verifyError instanceof Error ? verifyError.message : String(verifyError),
-            });
-          }
-          // Navigate directly to membership dashboard
-          this.processingState.set('success');
-          this.statusMessage.set(
-            'Password has been reset successfully. Welcome to your membership dashboard!',
-          );
-          await this.router.navigate(['/membership']);
-          return;
-        } catch (signInError: unknown) {
-          console.error('Auto-sign-in after password reset failed:', {
-            email,
-            error: signInError instanceof Error ? signInError.message : String(signInError),
-          });
-          // Fall through to sign-in page redirect
-        }
+      const signedIn = await this.attemptAutoSignIn(email, password);
+
+      if (signedIn) {
+        this.processingState.set('success');
+        this.statusMessage.set(
+          'Password has been reset successfully. Welcome to your membership dashboard!',
+        );
+        await this.router.navigate(['/membership']);
+        return;
       }
 
       // Fallback: redirect to sign-in with email prefilled
@@ -158,6 +141,40 @@ export class AuthActions {
       this.processingState.set('error');
       this.statusMessage.set(message);
     }
+  }
+
+  /**
+   * Attempt to sign in with the given email and password after a password reset.
+   * If sign-in succeeds, also attempts to mark email as verified (best-effort).
+   * If verification fails, the user still lands on the dashboard and can
+   * re-verify through the standard email verification flow.
+   * @returns true if sign-in succeeded, false otherwise
+   */
+  private async attemptAutoSignIn(email: string, password: string): Promise<boolean> {
+    if (email === '') {
+      return false;
+    }
+
+    try {
+      await this.authService.signInWithEmail(email, password);
+    } catch (signInError: unknown) {
+      console.error('Auto-sign-in after password reset failed:', {
+        email,
+        error: signInError instanceof Error ? signInError.message : String(signInError),
+      });
+      return false;
+    }
+
+    // Now authenticated -- mark email as verified (best-effort, failure is non-blocking)
+    try {
+      await this.membershipService.verifyEmail();
+    } catch (verifyError: unknown) {
+      console.error('Email verification failed after password reset:', {
+        error: verifyError instanceof Error ? verifyError.message : String(verifyError),
+      });
+    }
+
+    return true;
   }
 
   private async handleRecoverEmail(code: string): Promise<void> {

--- a/members/src/app/auth-actions/auth-actions.ts
+++ b/members/src/app/auth-actions/auth-actions.ts
@@ -123,7 +123,13 @@ export class AuthActions {
         try {
           await this.authService.signInWithEmail(email, password);
           // Now authenticated - mark email as verified (best-effort)
-          await this.membershipService.verifyEmail();
+          try {
+            await this.membershipService.verifyEmail();
+          } catch (verifyError: unknown) {
+            console.error('Email verification failed after password reset:', {
+              error: verifyError instanceof Error ? verifyError.message : String(verifyError),
+            });
+          }
           // Navigate directly to membership dashboard
           this.processingState.set('success');
           this.statusMessage.set(
@@ -131,8 +137,12 @@ export class AuthActions {
           );
           await this.router.navigate(['/membership']);
           return;
-        } catch {
-          // Sign-in failed - fall back to redirect to sign-in page
+        } catch (signInError: unknown) {
+          console.error('Auto-sign-in after password reset failed:', {
+            email,
+            error: signInError instanceof Error ? signInError.message : String(signInError),
+          });
+          // Fall through to sign-in page redirect
         }
       }
 
@@ -141,7 +151,7 @@ export class AuthActions {
       this.statusMessage.set('Password has been reset successfully. You can now sign in.');
       await this.router.navigate(
         ['/sign-in'],
-        email !== '' ? { queryParams: { email } } : undefined,
+        email === '' ? undefined : { queryParams: { email } },
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to reset password.';

--- a/members/src/app/auth-actions/auth-actions.ts
+++ b/members/src/app/auth-actions/auth-actions.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, inject, input, signal } fro
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { MembershipService } from '../services/membership.service';
 
 // Firebase Auth action modes
 type AuthActionMode = 'verifyEmail' | 'resetPassword' | 'recoverEmail';
@@ -14,6 +15,7 @@ type AuthActionMode = 'verifyEmail' | 'resetPassword' | 'recoverEmail';
 })
 export class AuthActions {
   private authService = inject(AuthService);
+  private membershipService = inject(MembershipService);
   private router = inject(Router);
   private fb = inject(FormBuilder);
 
@@ -114,13 +116,32 @@ export class AuthActions {
     this.processingState.set('verifying');
     try {
       await this.authService.confirmPasswordReset(code, password);
+
+      // Try to auto-sign-in and verify email
+      const email = this.emailForAction();
+      if (email !== '') {
+        try {
+          await this.authService.signInWithEmail(email, password);
+          // Now authenticated - mark email as verified (best-effort)
+          await this.membershipService.verifyEmail();
+          // Navigate directly to membership dashboard
+          this.processingState.set('success');
+          this.statusMessage.set(
+            'Password has been reset successfully. Welcome to your membership dashboard!',
+          );
+          await this.router.navigate(['/membership']);
+          return;
+        } catch {
+          // Sign-in failed - fall back to redirect to sign-in page
+        }
+      }
+
+      // Fallback: redirect to sign-in with email prefilled
       this.processingState.set('success');
       this.statusMessage.set('Password has been reset successfully. You can now sign in.');
-      // Optionally redirect to sign-in with email prefilled
-      const email = this.emailForAction();
       await this.router.navigate(
         ['/sign-in'],
-        email && email !== '' ? { queryParams: { email } } : undefined,
+        email !== '' ? { queryParams: { email } } : undefined,
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to reset password.';

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -270,6 +270,30 @@ export class MembershipService {
   }
 
   /**
+   * Mark the current user's email as verified via the API.
+   * This should be called after a successful password reset + sign-in,
+   * since confirming a password reset proves the user owns the email.
+   * @throws Error with user-friendly message
+   */
+  async verifyEmail(): Promise<void> {
+    const uid = this.auth.currentUser?.uid;
+    if (!uid) {
+      throw new Error('You must be signed in to verify your email.');
+    }
+
+    try {
+      await firstValueFrom(
+        this.http.post<{ success: boolean }>(`/api/members/${uid}/verify-email`, {}),
+      );
+    } catch (error: unknown) {
+      console.error('Failed to verify email:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Don't throw - email verification is best-effort after password reset
+    }
+  }
+
+  /**
    * Claim an unclaimed profile for the authenticated user
    * @param slug - The slug of the profile to claim
    * @throws Error with user-friendly message

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -271,8 +271,8 @@ export class MembershipService {
 
   /**
    * Mark the current user's email as verified via the API.
-   * This should be called after a successful password reset + sign-in,
-   * since confirming a password reset proves the user owns the email.
+   * Currently used after password reset + sign-in, where confirming
+   * the reset code proves email ownership.
    * @throws Error with user-friendly message
    */
   async verifyEmail(): Promise<void> {
@@ -293,6 +293,9 @@ export class MembershipService {
 
       if (error instanceof HttpErrorResponse) {
         switch (error.status) {
+          case 400: {
+            throw new Error('Email is already verified.');
+          }
           case 401: {
             throw new Error('You must be signed in to verify your email.');
           }

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -287,9 +287,25 @@ export class MembershipService {
       );
     } catch (error: unknown) {
       console.error('Failed to verify email:', {
+        uid,
         error: error instanceof Error ? error.message : String(error),
       });
-      // Don't throw - email verification is best-effort after password reset
+
+      if (error instanceof HttpErrorResponse) {
+        switch (error.status) {
+          case 401: {
+            throw new Error('You must be signed in to verify your email.');
+          }
+          case 403: {
+            throw new Error('You do not have permission to verify this email.');
+          }
+          case 504: {
+            throw new Error('Request timed out. Please check your connection and try again.');
+          }
+        }
+      }
+
+      throw new Error('Unable to verify email. Please try again.');
     }
   }
 


### PR DESCRIPTION
## Summary
- After confirming a password reset, the user is now automatically signed in using the email retrieved from verifyPasswordResetCode and the password they just set
- A new POST /api/members/:memberId/verify-email endpoint marks the email as verified (owner-only, uses Firebase Admin updateUser)
- If auto-sign-in fails, gracefully falls back to the existing redirect to /sign-in with email prefilled
- This solves two problems: (1) confirmPasswordReset does NOT set emailVerified to true, leaving members unverified forever; (2) users had to manually re-enter credentials after resetting their password

## Test plan
- [ ] Backend tests pass: cd functions && bun test src/members-api/routes/verify-email.test.ts (5 tests)
- [ ] Frontend unit tests pass: cd members && bun run test --include src/app/auth-actions/auth-actions.spec.ts (21 tests)
- [ ] Frontend integration tests pass: cd members && bun run test --include src/app/auth-actions/auth-actions.integration.spec.ts (9 tests)
- [ ] Full test suite passes: cd members && bun run test (269 tests)
- [ ] Manual test: Trigger password reset, enter new password, confirm auto-redirect to /membership
- [ ] Manual test: Verify emailVerified is true after the flow

Generated with [Claude Code](https://claude.com/claude-code)