### PR TITLE
Add admin notification for welcome email failure

### DIFF
--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -24,6 +24,8 @@ export const ERROR_IDS = {
     "stripe_webhook_mailgun_not_configured",
   STRIPE_WEBHOOK_MAILGUN_FAILED: "stripe_webhook_mailgun_failed",
   STRIPE_WEBHOOK_EMAIL_FAILED: "stripe_webhook_email_failed",
+  STRIPE_WEBHOOK_WELCOME_EMAIL_NOTIFICATION_FAILED:
+    "stripe_webhook_welcome_email_notification_failed",
   STRIPE_WEBHOOK_UNEXPECTED_ERROR: "stripe_webhook_unexpected_error",
 
   // Legacy member activation errors

--- a/functions/src/stripe-webhook-api/services/process-checkout-completed.ts
+++ b/functions/src/stripe-webhook-api/services/process-checkout-completed.ts
@@ -76,7 +76,7 @@ function createMailerLiteFailureEmailHtml(options: {
   `;
 }
 
-interface OptionsConfig {
+interface FailureNotificationConfig {
   emailService: EmailServiceInterface;
   customerEmail: string;
   customerName: string | null | undefined;
@@ -88,7 +88,9 @@ interface OptionsConfig {
 }
 
 /**
- * Send notification email when MailerLite subscription fails.
+ * Notify the newsletter admin when MailerLite subscription fails.
+ * Errors are caught and logged but never thrown, so notification failure
+ * does not affect the webhook response.
  */
 async function sendMailerLiteFailureNotification({
   emailService,
@@ -99,7 +101,7 @@ async function sendMailerLiteFailureNotification({
   membershipExpiresAt,
   errorMessage,
   logger,
-}: OptionsConfig): Promise<void> {
+}: FailureNotificationConfig): Promise<void> {
   try {
     const notificationEmail: EmailMessage = {
       from: `Doula Cooperative Alerts <${NO_REPLY_EMAIL}>`,
@@ -180,19 +182,10 @@ function createWelcomeEmailFailureEmailHtml(options: {
   `;
 }
 
-interface WelcomeEmailNotificationConfig {
-  emailService: EmailServiceInterface;
-  customerEmail: string;
-  customerName: string | null | undefined;
-  userRecord: UserRecord;
-  subscriptionStart: Timestamp;
-  membershipExpiresAt: Timestamp;
-  errorMessage: string;
-  logger: Logger;
-}
-
 /**
- * Send notification email when welcome email fails.
+ * Notify the admin when a welcome email fails for a new member.
+ * Errors are caught and logged but never thrown, so notification failure
+ * does not affect the webhook response.
  */
 async function sendWelcomeEmailFailureNotification({
   emailService,
@@ -203,7 +196,7 @@ async function sendWelcomeEmailFailureNotification({
   membershipExpiresAt,
   errorMessage,
   logger,
-}: WelcomeEmailNotificationConfig): Promise<void> {
+}: FailureNotificationConfig): Promise<void> {
   try {
     const notificationEmail: EmailMessage = {
       from: `Doula Cooperative Alerts <${NO_REPLY_EMAIL}>`,
@@ -702,17 +695,19 @@ export async function processCheckoutCompleted(options: {
         });
       }
 
-      // Notify admin about the failure
-      await sendWelcomeEmailFailureNotification({
-        emailService,
-        customerEmail,
-        customerName: session.customer_details?.name,
-        userRecord,
-        subscriptionStart,
-        membershipExpiresAt,
-        errorMessage,
-        logger,
-      });
+      // Notify admin about the failure (production only)
+      if (!process.env["FUNCTIONS_EMULATOR"]) {
+        await sendWelcomeEmailFailureNotification({
+          emailService,
+          customerEmail,
+          customerName: session.customer_details?.name,
+          userRecord,
+          subscriptionStart,
+          membershipExpiresAt,
+          errorMessage,
+          logger,
+        });
+      }
     }
   }
 

--- a/functions/src/stripe-webhook-api/services/process-checkout-completed.ts
+++ b/functions/src/stripe-webhook-api/services/process-checkout-completed.ts
@@ -135,6 +135,110 @@ async function sendMailerLiteFailureNotification({
 }
 
 /**
+ * Create HTML for welcome email failure notification.
+ */
+function createWelcomeEmailFailureEmailHtml(options: {
+  customerEmail: string;
+  customerName: string | null | undefined;
+  uid: string;
+  subscriptionStart: Timestamp;
+  membershipExpiresAt: Timestamp;
+  errorMessage: string;
+}): string {
+  const {
+    customerEmail,
+    customerName,
+    uid,
+    subscriptionStart,
+    membershipExpiresAt,
+    errorMessage,
+  } = options;
+
+  const displayName = escapeHtml(customerName) || "Not provided";
+  const subscriptionStartDate = escapeHtml(
+    subscriptionStart.toDate().toISOString(),
+  );
+  const expirationDate = escapeHtml(membershipExpiresAt.toDate().toISOString());
+
+  return `
+    <h2>Welcome Email Failed</h2>
+    <p>A new member completed payment but the welcome email could not be sent. The member's account is active but they have no way to set their password.</p>
+
+    <h3>Member Details:</h3>
+    <ul>
+      <li><strong>Email:</strong> ${escapeHtml(customerEmail)}</li>
+      <li><strong>Name:</strong> ${displayName}</li>
+      <li><strong>UID:</strong> ${escapeHtml(uid)}</li>
+      <li><strong>Subscription Start:</strong> ${subscriptionStartDate}</li>
+      <li><strong>Membership Expires:</strong> ${expirationDate}</li>
+    </ul>
+
+    <h3>Error Details:</h3>
+    <p>${escapeHtml(errorMessage)}</p>
+
+    <p><strong>Action Required:</strong> Manually send a welcome email or password reset link to this member so they can access their account.</p>
+  `;
+}
+
+interface WelcomeEmailNotificationConfig {
+  emailService: EmailServiceInterface;
+  customerEmail: string;
+  customerName: string | null | undefined;
+  userRecord: UserRecord;
+  subscriptionStart: Timestamp;
+  membershipExpiresAt: Timestamp;
+  errorMessage: string;
+  logger: Logger;
+}
+
+/**
+ * Send notification email when welcome email fails.
+ */
+async function sendWelcomeEmailFailureNotification({
+  emailService,
+  customerEmail,
+  customerName,
+  userRecord,
+  subscriptionStart,
+  membershipExpiresAt,
+  errorMessage,
+  logger,
+}: WelcomeEmailNotificationConfig): Promise<void> {
+  try {
+    const notificationEmail: EmailMessage = {
+      from: `Doula Cooperative Alerts <${NO_REPLY_EMAIL}>`,
+      to: ADMIN_EMAIL,
+      subject: "Action Required: Welcome Email Failed for New Member",
+      html: createWelcomeEmailFailureEmailHtml({
+        customerEmail,
+        customerName,
+        uid: userRecord.uid,
+        subscriptionStart,
+        membershipExpiresAt,
+        errorMessage,
+      }),
+    };
+
+    await emailService.sendEmail({ message: notificationEmail }, logger);
+    logger.info("Sent welcome email failure notification", {
+      uid: userRecord.uid,
+      email: customerEmail,
+    });
+  } catch (emailError) {
+    logger.error("Failed to send welcome email failure notification", {
+      error: emailError,
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_WELCOME_EMAIL_NOTIFICATION_FAILED,
+      uid: userRecord.uid,
+      email: customerEmail,
+      severity: "CRITICAL",
+      actionRequired:
+        "Check Sentry alerts immediately - welcome email failed and notification failed",
+    });
+    // Don't throw - we don't want to fail the webhook because notification failed
+  }
+}
+
+/**
  * Generate welcome email HTML content.
  */
 function generateWelcomeEmailHtml(resetLink: string): string {
@@ -597,6 +701,18 @@ export async function processCheckoutCompleted(options: {
             "Check Firestore permissions and manually record email failure status",
         });
       }
+
+      // Notify admin about the failure
+      await sendWelcomeEmailFailureNotification({
+        emailService,
+        customerEmail,
+        customerName: session.customer_details?.name,
+        userRecord,
+        subscriptionStart,
+        membershipExpiresAt,
+        errorMessage,
+        logger,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- When the welcome email fails during Stripe checkout processing, the admin now receives a notification email with the member details and error information
- Follows the existing sendMailerLiteFailureNotification pattern exactly: HTML helper, async send function, CRITICAL severity logging on failure, no-throw semantics
- Sends to ADMIN_EMAIL with actionable instructions to manually send a welcome email or password reset link

## Test plan
- [x] bun run build — clean TypeScript compilation
- [x] bun test handle-webhook — all 11 existing webhook tests pass
- [x] bun run lint — no lint errors
- [ ] Manually verify by triggering a checkout with a broken email config in the emulator

Generated with [Claude Code](https://claude.com/claude-code)