### PR TITLE
feat: handle Stripe refunds via webhook and admin UI

### DIFF
--- a/functions/src/admin-members-api/plugins/admin-members-plugin.ts
+++ b/functions/src/admin-members-api/plugins/admin-members-plugin.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { logger as firebaseLogger } from "firebase-functions/v2";
 import { AuthService } from "../../shared-api/services/auth/index.js";
+import { EmailService } from "../../shared-api/services/email/index.js";
 import { adminDerive } from "../../shared-api/utils/admin-derive.js";
 import { adminGuard } from "../../shared-api/utils/admin-guard.js";
 import { getAdminUid } from "../../shared-api/utils/get-admin-uid.js";
@@ -11,6 +12,7 @@ import {
   extendMembershipLogic,
   getMemberLogic,
   listMembersLogic,
+  refundMembershipLogic,
   updateClaimsLogic,
   updateMemberLogic,
 } from "../routes/index.js";
@@ -24,6 +26,8 @@ import {
   GetMemberApiResponseSchema,
   ListMembersApiResponseSchema,
   MemberIdParameterSchema,
+  RefundMembershipApiResponseSchema,
+  RefundMembershipBodySchema,
   UpdateClaimsApiResponseSchema,
   UpdateClaimsBodySchema,
   UpdateMemberApiResponseSchema,
@@ -55,6 +59,10 @@ export function createAdminMembersPlugin(services?: PartialServices) {
         services?.memberAdminService ?? MemberAdminService,
       )
       .decorate(SERVICE_KEYS.AUTH_SERVICE, services?.authService ?? AuthService)
+      .decorate(
+        SERVICE_KEYS.EMAIL_SERVICE,
+        services?.emailService ?? EmailService,
+      )
       .decorate(SERVICE_KEYS.LOGGER, services?.logger ?? firebaseLogger)
       .derive(adminDerive)
       .onBeforeHandle({ as: "local" }, adminGuard)
@@ -213,6 +221,36 @@ export function createAdminMembersPlugin(services?: PartialServices) {
                 {
                   body: ExtendMembershipBodySchema,
                   response: ExtendMembershipApiResponseSchema,
+                },
+              )
+              // POST /:memberId/membership/refund (served at /api/admin/members/:memberId/membership/refund)
+              .post(
+                "/refund",
+                async ({
+                  params,
+                  body,
+                  adminToken,
+                  memberAdminService,
+                  emailService,
+                  logger,
+                  set,
+                }) => {
+                  const typedBody = body as { reason?: string } | undefined;
+                  return refundMembershipLogic({
+                    memberId: params.memberId,
+                    ...(typedBody?.reason !== undefined && {
+                      reason: typedBody.reason,
+                    }),
+                    adminUid: getAdminUid(adminToken, logger),
+                    memberAdminService,
+                    emailService,
+                    logger,
+                    set,
+                  });
+                },
+                {
+                  body: RefundMembershipBodySchema,
+                  response: RefundMembershipApiResponseSchema,
                 },
               ),
           )

--- a/functions/src/admin-members-api/routes/index.ts
+++ b/functions/src/admin-members-api/routes/index.ts
@@ -4,5 +4,6 @@ export { deleteUserLogic } from "./delete-user.js";
 export { extendMembershipLogic } from "./extend-membership.js";
 export { getMemberLogic } from "./get-member.js";
 export { listMembersLogic } from "./list-members.js";
+export { refundMembershipLogic } from "./refund-membership.js";
 export { updateClaimsLogic } from "./update-claims.js";
 export { updateMemberLogic } from "./update-member.js";

--- a/functions/src/admin-members-api/routes/refund-membership.test.ts
+++ b/functions/src/admin-members-api/routes/refund-membership.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Timestamp } from "firebase-admin/firestore";
+import {
+  NotFoundError,
+  ValidationError,
+} from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import type { MemberDocument } from "../../types/member-document.js";
+import type { RefundMembershipResult } from "../services/refund-membership.js";
+import { createAdminTestPlugin } from "../test-utils/create-admin-test-plugin.js";
+
+/**
+ * Tests for POST /:memberId/membership/refund.
+ *
+ * Uses createAdminTestPlugin() factory with mocked services.
+ */
+describe("POST /:memberId/membership/refund", () => {
+  interface SetupOptions {
+    // Request parameters
+    memberId?: string;
+    authToken?: string | null;
+    body?: Record<string, unknown>;
+
+    // Scenario flags
+    memberNotFound?: boolean;
+    noStripeData?: boolean;
+    stripeApiError?: boolean;
+    refundResult?: RefundMembershipResult;
+  }
+
+  function setup({
+    memberId = "test-id",
+    authToken = "admin-token",
+    body = {},
+    memberNotFound = false,
+    noStripeData = false,
+    stripeApiError = false,
+    refundResult,
+  }: SetupOptions = {}) {
+    const defaultMember: MemberDocument = {
+      uid: "test-id",
+      email: "test@example.com",
+      createdAt: Timestamp.now(),
+      membershipActive: false,
+      subscriptionStatus: "refunded",
+      stripeCustomerId: "cus_test",
+      stripeSubscriptionId: "sub_test",
+      refundedAt: Timestamp.now(),
+    };
+
+    const defaultResult: RefundMembershipResult = {
+      member: defaultMember,
+      stripeRefundCreated: true,
+      subscriptionCanceled: true,
+      refundActions: {
+        memberDeactivated: true,
+      },
+    };
+
+    const mockRefundMembership = mock((): Promise<RefundMembershipResult> => {
+      if (memberNotFound) {
+        return Promise.reject(new NotFoundError("Member not found"));
+      }
+      if (noStripeData) {
+        return Promise.reject(
+          new ValidationError(
+            "Member does not have Stripe subscription data. Use manual deactivation instead.",
+          ),
+        );
+      }
+      if (stripeApiError) {
+        return Promise.reject(new Error("Stripe API error"));
+      }
+      return Promise.resolve(refundResult ?? defaultResult);
+    });
+
+    const testApp = createAdminTestPlugin({
+      memberAdminService: {
+        refundMembership: mockRefundMembership,
+      },
+    });
+
+    // Build request from parameters
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(
+      `http://localhost/${memberId}/membership/refund`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      },
+    );
+
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const { testApp, request } = setup({ authToken: null });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 403 when non-admin tries to refund", async () => {
+      const { testApp, request } = setup({ authToken: "non-admin-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Successful refund", () => {
+    it("should refund membership successfully", async () => {
+      const { testApp, request } = setup();
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const responseBody = (await response.json()) as {
+        success?: boolean;
+        refundResult?: {
+          stripeRefundCreated?: boolean;
+          subscriptionCanceled?: boolean;
+          memberDeactivated?: boolean;
+        };
+      };
+      expect(responseBody.success).toBe(true);
+      expect(responseBody.refundResult?.stripeRefundCreated).toBe(true);
+      expect(responseBody.refundResult?.subscriptionCanceled).toBe(true);
+      expect(responseBody.refundResult?.memberDeactivated).toBe(true);
+    });
+
+    it("should accept optional reason in body", async () => {
+      const { testApp, request } = setup({
+        body: { reason: "Customer requested refund" },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should include warning when non-critical actions fail", async () => {
+      const { testApp, request } = setup({
+        refundResult: {
+          member: {
+            uid: "test-id",
+            email: "test@example.com",
+            createdAt: Timestamp.now(),
+            membershipActive: false,
+            subscriptionStatus: "refunded",
+            refundedAt: Timestamp.now(),
+          },
+          stripeRefundCreated: true,
+          subscriptionCanceled: true,
+          refundActions: {
+            memberDeactivated: true,
+            profileDrafted: false,
+            warning: "Non-critical actions failed: Draft profile failed",
+          },
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const responseBody = (await response.json()) as {
+        success?: boolean;
+        refundResult?: { warning?: string };
+      };
+      expect(responseBody.success).toBe(true);
+      expect(responseBody.refundResult?.warning).toContain(
+        "Non-critical actions failed",
+      );
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should return 404 for non-existent member", async () => {
+      const { testApp, request } = setup({ memberNotFound: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 400 when member has no Stripe data", async () => {
+      const { testApp, request } = setup({ noStripeData: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(400);
+      const responseBody = (await response.json()) as { error?: string };
+      expect(responseBody.error).toContain("Stripe subscription data");
+    });
+
+    it("should return 500 for Stripe API errors", async () => {
+      const { testApp, request } = setup({ stripeApiError: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/functions/src/admin-members-api/routes/refund-membership.ts
+++ b/functions/src/admin-members-api/routes/refund-membership.ts
@@ -1,0 +1,77 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+import { handleRouteError } from "../../shared-api/utils/route-error-handler.js";
+import type { RefundMembershipApiResponse } from "../schemas/member-schemas.js";
+import { toMemberResponse } from "../schemas/member-schemas.js";
+import type { MemberAdminService } from "../services/interface.js";
+
+/**
+ * Route handler for POST /:memberId/membership/refund.
+ *
+ * Custom handler (not factory) since refund returns a richer result
+ * than just a MemberDocument wrapped in MemberSuccessResponse.
+ */
+export async function refundMembershipLogic({
+  memberId,
+  reason,
+  adminUid,
+  memberAdminService,
+  emailService,
+  logger,
+  set,
+}: {
+  memberId: string;
+  reason?: string;
+  adminUid: string;
+  memberAdminService: MemberAdminService;
+  emailService?: EmailServiceInterface;
+  logger: Logger;
+  set: { status?: number | string };
+}): Promise<RefundMembershipApiResponse> {
+  try {
+    const result = await memberAdminService.refundMembership({
+      memberId,
+      ...(reason !== undefined && { reason }),
+      ...(emailService !== undefined && { emailService }),
+    });
+
+    logger.info("Admin refunded membership", {
+      adminUid,
+      targetMemberId: memberId,
+      stripeRefundCreated: result.stripeRefundCreated,
+      subscriptionCanceled: result.subscriptionCanceled,
+      memberDeactivated: result.refundActions.memberDeactivated,
+    });
+
+    const isAdmin = await memberAdminService.isAdmin(memberId, logger);
+
+    return {
+      success: true,
+      member: toMemberResponse(result.member, isAdmin),
+      refundResult: {
+        stripeRefundCreated: result.stripeRefundCreated,
+        subscriptionCanceled: result.subscriptionCanceled,
+        memberDeactivated: result.refundActions.memberDeactivated,
+        ...(result.refundActions.profileDrafted !== undefined && {
+          profileDrafted: result.refundActions.profileDrafted,
+        }),
+        ...(result.refundActions.newsletterUnsubscribed !== undefined && {
+          newsletterUnsubscribed: result.refundActions.newsletterUnsubscribed,
+        }),
+        ...(result.refundActions.warning !== undefined && {
+          warning: result.refundActions.warning,
+        }),
+      },
+    };
+  } catch (error) {
+    return handleRouteError({
+      error,
+      operation: "refund membership",
+      errorId: ERROR_IDS.API_ADMIN_REFUND_MEMBERSHIP_FAILED,
+      logger,
+      set,
+      context: { memberId, adminUid },
+    });
+  }
+}

--- a/functions/src/admin-members-api/schemas/member-schemas.ts
+++ b/functions/src/admin-members-api/schemas/member-schemas.ts
@@ -12,6 +12,7 @@ export const SubscriptionStatusSchema = t.Union([
   t.Literal("incomplete"),
   t.Literal("trialing"),
   t.Literal("unpaid"),
+  t.Literal("refunded"),
 ]);
 
 /**
@@ -127,6 +128,17 @@ export const MemberResponseSchema = t.Object({
       description: "Newsletter unsubscription timestamp (ISO 8601)",
     }),
   ),
+  refundedAt: t.Optional(
+    t.String({
+      format: "date-time",
+      description: "Refund timestamp (ISO 8601)",
+    }),
+  ),
+  refundReason: t.Optional(
+    t.String({
+      description: "Reason for the refund",
+    }),
+  ),
 });
 
 /**
@@ -199,6 +211,12 @@ export function toMemberResponse(
       newsletterUnsubscribedAt: timestampToIso(
         document.newsletterUnsubscribedAt,
       ),
+    }),
+    ...(document.refundedAt !== undefined && {
+      refundedAt: timestampToIso(document.refundedAt),
+    }),
+    ...(document.refundReason !== undefined && {
+      refundReason: document.refundReason,
     }),
   };
 }
@@ -435,4 +453,72 @@ export const UpdateClaimsApiResponseSchema = t.Union([
 
 export type UpdateClaimsApiResponse = Static<
   typeof UpdateClaimsApiResponseSchema
+>;
+
+/**
+ * Request body schema for refunding membership.
+ */
+export const RefundMembershipBodySchema = t.Optional(
+  t.Object({
+    reason: t.Optional(
+      t.String({
+        description: "Reason for the refund",
+      }),
+    ),
+  }),
+);
+
+/**
+ * Refund result details schema.
+ */
+export const RefundResultSchema = t.Object({
+  stripeRefundCreated: t.Boolean({
+    description: "Whether the Stripe refund was created",
+  }),
+  subscriptionCanceled: t.Boolean({
+    description: "Whether the Stripe subscription was canceled",
+  }),
+  memberDeactivated: t.Boolean({
+    description: "Whether the member was deactivated in Firestore",
+  }),
+  profileDrafted: t.Optional(
+    t.Boolean({
+      description: "Whether the Hugo profile was set to draft",
+    }),
+  ),
+  newsletterUnsubscribed: t.Optional(
+    t.Boolean({
+      description: "Whether the member was unsubscribed from newsletter",
+    }),
+  ),
+  warning: t.Optional(
+    t.String({
+      description: "Warning message for non-critical failures",
+    }),
+  ),
+});
+
+/**
+ * Success response for refund membership.
+ */
+export const RefundMembershipResponseSchema = t.Object({
+  success: t.Literal(true),
+  member: MemberResponseSchema,
+  refundResult: RefundResultSchema,
+});
+
+export type RefundMembershipResponse = Static<
+  typeof RefundMembershipResponseSchema
+>;
+
+/**
+ * POST /api/admin/members/:memberId/membership/refund response - union of success and error.
+ */
+export const RefundMembershipApiResponseSchema = t.Union([
+  RefundMembershipResponseSchema,
+  ErrorResponseSchema,
+]);
+
+export type RefundMembershipApiResponse = Static<
+  typeof RefundMembershipApiResponseSchema
 >;

--- a/functions/src/admin-members-api/services/index.ts
+++ b/functions/src/admin-members-api/services/index.ts
@@ -4,6 +4,7 @@ import { deleteUser } from "./delete-user.js";
 import { extendMembership } from "./extend-membership.js";
 import { isAdmin } from "./is-admin.js";
 import { listMembers } from "./list-members.js";
+import { refundMembership } from "./refund-membership.js";
 import { updateClaims } from "./update-claims.js";
 import { updateMember } from "./update-member.js";
 import { verifyMemberExists } from "./verify-member-exists.js";
@@ -22,6 +23,7 @@ export const MemberAdminService = {
   deleteUser,
   updateClaims,
   isAdmin,
+  refundMembership,
 };
 
 // Re-export individual functions for direct imports
@@ -31,6 +33,7 @@ export { deleteUser } from "./delete-user.js";
 export { extendMembership } from "./extend-membership.js";
 export { isAdmin } from "./is-admin.js";
 export { listMembers } from "./list-members.js";
+export { refundMembership } from "./refund-membership.js";
 export { updateClaims } from "./update-claims.js";
 export { updateMember } from "./update-member.js";
 export { verifyMemberExists } from "./verify-member-exists.js";

--- a/functions/src/admin-members-api/services/interface.ts
+++ b/functions/src/admin-members-api/services/interface.ts
@@ -1,5 +1,7 @@
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import type { MemberDocument } from "../../types/member-document.js";
+import type { RefundMembershipResult } from "./refund-membership.js";
 
 /**
  * Service interface for admin member management operations.
@@ -124,4 +126,18 @@ export interface MemberAdminService {
    * @returns Promise resolving to true if user has admin claim, false otherwise
    */
   isAdmin(uid: string, logger: Logger): Promise<boolean>;
+
+  /**
+   * Refund a member's Stripe payment, cancel subscription, and deactivate membership.
+   *
+   * @param options - Member ID, optional reason, and email service for notifications
+   * @returns Promise resolving to refund result with updated member and action statuses
+   * @throws NotFoundError if member does not exist
+   * @throws ValidationError if member has no Stripe data
+   */
+  refundMembership(options: {
+    memberId: string;
+    reason?: string;
+    emailService?: EmailServiceInterface;
+  }): Promise<RefundMembershipResult>;
 }

--- a/functions/src/admin-members-api/services/refund-membership.ts
+++ b/functions/src/admin-members-api/services/refund-membership.ts
@@ -28,8 +28,8 @@ export interface RefundMembershipResult {
  * Refund a member's Stripe payment, cancel their subscription,
  * and deactivate their membership.
  *
- * Called from the admin API. Pre-marks the resulting Stripe event
- * as processed to prevent the webhook from double-processing.
+ * Called from the admin API. The resulting Stripe charge.refunded webhook
+ * is handled idempotently by processRefundActions (skips if already refunded).
  */
 export async function refundMembership({
   memberId,
@@ -127,12 +127,25 @@ export async function refundMembership({
     }
   }
 
-  // Step 5: Cancel subscription
-  const subscriptionCanceled = await cancelStripeSubscription({
-    subscriptionId: member.stripeSubscriptionId,
-  });
+  // Step 4: Cancel subscription
+  let subscriptionCanceled = false;
+  try {
+    await cancelStripeSubscription({
+      subscriptionId: member.stripeSubscriptionId,
+    });
+    subscriptionCanceled = true;
+  } catch (error) {
+    logger.error("Failed to cancel subscription during admin refund", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED,
+      memberId,
+      stripeSubscriptionId: member.stripeSubscriptionId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 
-  // Step 6: Process refund actions (deactivate, draft profile, unsubscribe)
+  // Step 5: Process refund actions (deactivate, draft profile, unsubscribe)
   const refundActions = await processRefundActions({
     memberId,
     member,
@@ -140,7 +153,7 @@ export async function refundMembership({
     ...(emailService !== undefined && { emailService }),
   });
 
-  // Step 7: Retrieve updated member document
+  // Step 6: Retrieve updated member document
   const updatedMember = await retrieveAndValidateMember({ memberId });
 
   return {

--- a/functions/src/admin-members-api/services/refund-membership.ts
+++ b/functions/src/admin-members-api/services/refund-membership.ts
@@ -1,0 +1,152 @@
+import { logger } from "firebase-functions/v2";
+import Stripe from "stripe";
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import {
+  NotFoundError,
+  ValidationError,
+} from "../../shared-api/errors/http-error.js";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
+import { retrieveAndValidateMember } from "../../shared-api/utils/firestore-helpers.js";
+import { cancelStripeSubscription } from "../../stripe-webhook-api/services/cancel-stripe-subscription.js";
+import {
+  processRefundActions,
+  type RefundActionsResult,
+} from "../../stripe-webhook-api/services/process-refund-actions.js";
+import type { MemberDocument } from "../../types/member-document.js";
+
+/**
+ * Result of an admin-initiated refund.
+ */
+export interface RefundMembershipResult {
+  member: MemberDocument;
+  stripeRefundCreated: boolean;
+  subscriptionCanceled: boolean;
+  refundActions: RefundActionsResult;
+}
+
+/**
+ * Refund a member's Stripe payment, cancel their subscription,
+ * and deactivate their membership.
+ *
+ * Called from the admin API. Pre-marks the resulting Stripe event
+ * as processed to prevent the webhook from double-processing.
+ */
+export async function refundMembership({
+  memberId,
+  reason,
+  emailService,
+}: {
+  memberId: string;
+  reason?: string;
+  emailService?: EmailServiceInterface;
+}): Promise<RefundMembershipResult> {
+  // Step 1: Verify member exists and has Stripe data
+  const member = await retrieveAndValidateMember({ memberId });
+
+  if (!member.stripeCustomerId || !member.stripeSubscriptionId) {
+    logger.warn("Refund attempted for member without Stripe data", {
+      errorId: ERROR_IDS.API_ADMIN_REFUND_NO_STRIPE_DATA,
+      memberId,
+    });
+    throw new ValidationError(
+      "Member does not have Stripe subscription data. Use manual deactivation instead.",
+    );
+  }
+
+  const stripeApiKey = process.env["STRIPE_API_KEY"];
+
+  if (!stripeApiKey) {
+    throw new Error("STRIPE_API_KEY not configured");
+  }
+
+  const stripe = new Stripe(stripeApiKey);
+
+  // Step 2: Find latest charge for this customer
+  let latestChargeId: string | undefined;
+  try {
+    const charges = await stripe.charges.list({
+      customer: member.stripeCustomerId,
+      limit: 1,
+    });
+
+    const latestCharge = charges.data[0];
+
+    if (!latestCharge) {
+      throw new NotFoundError("No charges found for this customer");
+    }
+
+    latestChargeId = latestCharge.id;
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      throw error;
+    }
+
+    logger.error("Failed to list Stripe charges", {
+      errorId: ERROR_IDS.API_ADMIN_REFUND_STRIPE_API_FAILED,
+      memberId,
+      stripeCustomerId: member.stripeCustomerId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+
+  // Step 3: Create refund
+  let stripeRefundCreated = false;
+  try {
+    const refund = await stripe.refunds.create({
+      charge: latestChargeId,
+    });
+
+    stripeRefundCreated = true;
+    logger.info("Stripe refund created", {
+      memberId,
+      chargeId: latestChargeId,
+      refundId: refund.id,
+    });
+  } catch (error) {
+    // If refund is already done, that's okay - continue with deactivation
+    if (
+      error instanceof Stripe.errors.StripeInvalidRequestError &&
+      error.code === "charge_already_refunded"
+    ) {
+      logger.info("Charge already refunded, continuing with deactivation", {
+        memberId,
+        chargeId: latestChargeId,
+      });
+      stripeRefundCreated = true;
+    } else {
+      logger.error("Failed to create Stripe refund", {
+        errorId: ERROR_IDS.API_ADMIN_REFUND_STRIPE_API_FAILED,
+        memberId,
+        chargeId: latestChargeId,
+        error,
+        errorMessage: error instanceof Error ? error.message : "Unknown error",
+      });
+      throw error;
+    }
+  }
+
+  // Step 5: Cancel subscription
+  const subscriptionCanceled = await cancelStripeSubscription({
+    subscriptionId: member.stripeSubscriptionId,
+  });
+
+  // Step 6: Process refund actions (deactivate, draft profile, unsubscribe)
+  const refundActions = await processRefundActions({
+    memberId,
+    member,
+    reason: reason ?? "Admin-initiated refund",
+    ...(emailService !== undefined && { emailService }),
+  });
+
+  // Step 7: Retrieve updated member document
+  const updatedMember = await retrieveAndValidateMember({ memberId });
+
+  return {
+    member: updatedMember,
+    stripeRefundCreated,
+    subscriptionCanceled,
+    refundActions,
+  };
+}

--- a/functions/src/admin-members-api/test-utils/create-admin-test-plugin.ts
+++ b/functions/src/admin-members-api/test-utils/create-admin-test-plugin.ts
@@ -1,6 +1,7 @@
 import { mock } from "bun:test";
 import type { DecodedIdToken } from "firebase-admin/auth";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import {
   createMockVerifyAdmin,
@@ -20,6 +21,7 @@ import type { MemberAdminService } from "../services/interface.js";
 export function createAdminTestPlugin(overrides?: {
   memberAdminService?: Partial<MemberAdminService>;
   authService?: Partial<AuthService>;
+  emailService?: Partial<EmailServiceInterface>;
   logger?: Logger;
 }) {
   const defaultMemberAdminService: MemberAdminService = {
@@ -51,6 +53,16 @@ export function createAdminTestPlugin(overrides?: {
     ),
     verifyMemberExists: mock(() => Promise.resolve({} as MemberDocument)),
     isAdmin: mock(() => Promise.resolve(false)),
+    refundMembership: mock(() =>
+      Promise.resolve({
+        member: {} as MemberDocument,
+        stripeRefundCreated: true,
+        subscriptionCanceled: true,
+        refundActions: {
+          memberDeactivated: true,
+        },
+      }),
+    ),
     ...overrides?.memberAdminService,
   };
 
@@ -61,9 +73,15 @@ export function createAdminTestPlugin(overrides?: {
     ...overrides?.authService,
   };
 
+  const defaultEmailService: EmailServiceInterface = {
+    sendEmail: mock(() => Promise.resolve()),
+    ...overrides?.emailService,
+  };
+
   return createAdminMembersPlugin({
     memberAdminService: defaultMemberAdminService,
     authService: defaultAuthService,
+    emailService: defaultEmailService,
     ...(overrides?.logger !== undefined && { logger: overrides.logger }),
   });
 }

--- a/functions/src/admin-members-api/types/services.ts
+++ b/functions/src/admin-members-api/types/services.ts
@@ -1,4 +1,5 @@
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import type { MemberAdminService } from "../services/interface.js";
 
@@ -9,6 +10,7 @@ import type { MemberAdminService } from "../services/interface.js";
 export const SERVICE_KEYS = {
   MEMBER_ADMIN_SERVICE: "memberAdminService",
   AUTH_SERVICE: "authService",
+  EMAIL_SERVICE: "emailService",
   LOGGER: "logger",
 } as const;
 
@@ -20,6 +22,7 @@ export const SERVICE_KEYS = {
 export interface Services {
   [SERVICE_KEYS.MEMBER_ADMIN_SERVICE]: MemberAdminService;
   [SERVICE_KEYS.AUTH_SERVICE]: AuthService;
+  [SERVICE_KEYS.EMAIL_SERVICE]: EmailServiceInterface;
   [SERVICE_KEYS.LOGGER]: Logger;
 }
 

--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -307,6 +307,27 @@ export const ERROR_IDS = {
 
   // Member name update errors
   UPDATE_MEMBER_NAME_ROUTE_FAILED: "update_member_name_route_failed",
+
+  // Stripe webhook refund errors
+  STRIPE_WEBHOOK_REFUND_MEMBER_LOOKUP_FAILED:
+    "stripe_webhook_refund_member_lookup_failed",
+  STRIPE_WEBHOOK_REFUND_MEMBER_NOT_FOUND:
+    "stripe_webhook_refund_member_not_found",
+  STRIPE_WEBHOOK_REFUND_DEACTIVATION_FAILED:
+    "stripe_webhook_refund_deactivation_failed",
+  STRIPE_WEBHOOK_REFUND_DRAFT_PROFILE_FAILED:
+    "stripe_webhook_refund_draft_profile_failed",
+  STRIPE_WEBHOOK_REFUND_NEWSLETTER_FAILED:
+    "stripe_webhook_refund_newsletter_failed",
+  STRIPE_WEBHOOK_REFUND_NOTIFICATION_FAILED:
+    "stripe_webhook_refund_notification_failed",
+  STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED:
+    "stripe_webhook_refund_subscription_cancel_failed",
+
+  // Admin refund membership errors
+  API_ADMIN_REFUND_MEMBERSHIP_FAILED: "api_admin_refund_membership_failed",
+  API_ADMIN_REFUND_STRIPE_API_FAILED: "api_admin_refund_stripe_api_failed",
+  API_ADMIN_REFUND_NO_STRIPE_DATA: "api_admin_refund_no_stripe_data",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -36,7 +36,15 @@ export const membersApi = onRequest(
 
 // Admin Members APIs (members.doulacooperative.com)
 export const adminMembersApi = onRequest(
-  { invoker: "public" },
+  {
+    invoker: "public",
+    secrets: [
+      ...STRIPE_SECRETS,
+      ...PROFILE_SECRETS,
+      ...MAILERLITE_SECRETS,
+      ...MAILGUN_SECRETS,
+    ],
+  },
   async (request, response) => {
     const { handleAdminMembersApi } =
       await import("./admin-members-api/handler.js");
@@ -102,7 +110,12 @@ export const formsApi = onRequest(
 export const stripeWebhookApi = onRequest(
   {
     invoker: "public",
-    secrets: [...STRIPE_SECRETS, "MAILERLITE_API_KEY", "MAILGUN_API_KEY"],
+    secrets: [
+      ...STRIPE_SECRETS,
+      ...PROFILE_SECRETS,
+      "MAILERLITE_API_KEY",
+      "MAILGUN_API_KEY",
+    ],
   },
   async (request, response) => {
     const { handleStripeWebhookApi } =

--- a/functions/src/members-api/schemas/member-schemas.ts
+++ b/functions/src/members-api/schemas/member-schemas.ts
@@ -12,6 +12,7 @@ export const SubscriptionStatusSchema = t.Union([
   t.Literal("incomplete"),
   t.Literal("trialing"),
   t.Literal("unpaid"),
+  t.Literal("refunded"),
 ]);
 
 /**
@@ -139,6 +140,17 @@ export const MemberResponseSchema = t.Object({
       description: "Newsletter unsubscription timestamp (ISO 8601)",
     }),
   ),
+  refundedAt: t.Optional(
+    t.String({
+      format: "date-time",
+      description: "Refund timestamp (ISO 8601)",
+    }),
+  ),
+  refundReason: t.Optional(
+    t.String({
+      description: "Reason for the membership refund",
+    }),
+  ),
 });
 
 /**
@@ -217,6 +229,12 @@ export function toMemberResponse(
       newsletterUnsubscribedAt: timestampToIso(
         document.newsletterUnsubscribedAt,
       ),
+    }),
+    ...(document.refundedAt !== undefined && {
+      refundedAt: timestampToIso(document.refundedAt),
+    }),
+    ...(document.refundReason !== undefined && {
+      refundReason: document.refundReason,
     }),
   };
 }

--- a/functions/src/shared-api/utils/firestore-helpers.ts
+++ b/functions/src/shared-api/utils/firestore-helpers.ts
@@ -15,6 +15,7 @@ export type MemberOperation =
   | "activate membership"
   | "deactivate membership"
   | "extend membership"
+  | "refund membership"
   | "update member";
 
 /**

--- a/functions/src/stripe-webhook-api/handler.test.ts
+++ b/functions/src/stripe-webhook-api/handler.test.ts
@@ -108,6 +108,14 @@ describe("handleStripeWebhookApi", () => {
             isEventProcessed: mock(() => Promise.resolve(false)),
             markEventProcessed: mockMarkEventProcessed,
             processCheckoutCompleted: mockProcessCheckout,
+            processChargeRefunded: mock(() =>
+              Promise.resolve({
+                memberId: "test-member",
+                memberFound: true,
+                subscriptionCanceled: true,
+                refundActions: { memberDeactivated: true },
+              }),
+            ),
           },
           logger: mockLogger,
         },

--- a/functions/src/stripe-webhook-api/routes/handle-webhook.test.ts
+++ b/functions/src/stripe-webhook-api/routes/handle-webhook.test.ts
@@ -7,6 +7,7 @@ import {
   StripeSignatureError,
 } from "../../shared-api/errors/stripe-errors.js";
 import { handleRequest } from "../../test-utils/handle-request.js";
+import type { ChargeRefundedResult } from "../services/process-charge-refunded.js";
 import { createStripeWebhookTestPlugin } from "../test-utils/create-stripe-webhook-test-plugin.js";
 import { createMockStripeEvent } from "../test-utils/stripe-mocks.js";
 
@@ -33,6 +34,8 @@ describe("POST /webhook", () => {
       warning?: string;
     };
     processCheckoutError?: Error;
+    processChargeRefundedResult?: ChargeRefundedResult;
+    processChargeRefundedError?: Error;
   }
 
   function setup({
@@ -55,6 +58,15 @@ describe("POST /webhook", () => {
       mailerliteSynced: true,
     },
     processCheckoutError,
+    processChargeRefundedResult = {
+      memberId: "test-member-123",
+      memberFound: true,
+      subscriptionCanceled: true,
+      refundActions: {
+        memberDeactivated: true,
+      },
+    },
+    processChargeRefundedError,
   }: SetupOptions = {}) {
     const mockVerifySignature = mock((): Stripe.Event => {
       if (signatureInvalid) {
@@ -80,11 +92,19 @@ describe("POST /webhook", () => {
       return Promise.resolve(processCheckoutResult);
     });
 
+    const mockProcessChargeRefunded = mock(() => {
+      if (processChargeRefundedError) {
+        return Promise.reject(processChargeRefundedError);
+      }
+      return Promise.resolve(processChargeRefundedResult);
+    });
+
     const testApp = createStripeWebhookTestPlugin({
       stripeWebhookService: {
         verifySignature: mockVerifySignature,
         markEventProcessed: mockMarkEventProcessed,
         processCheckoutCompleted: mockProcessCheckout,
+        processChargeRefunded: mockProcessChargeRefunded,
       },
     });
 
@@ -294,6 +314,151 @@ describe("POST /webhook", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { received?: boolean };
       expect(body.received).toBe(true);
+    });
+  });
+
+  describe("charge.refunded", () => {
+    it("should successfully process a refund", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_test_789",
+        },
+        processChargeRefundedResult: {
+          memberId: "refunded-member-123",
+          memberFound: true,
+          subscriptionCanceled: true,
+          refundActions: {
+            memberDeactivated: true,
+          },
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        received?: boolean;
+        userId?: string;
+      };
+      expect(body.received).toBe(true);
+      expect(body.userId).toBe("refunded-member-123");
+    });
+
+    it("should handle refund when member is not found", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_unknown",
+        },
+        processChargeRefundedResult: {
+          memberFound: false,
+          subscriptionCanceled: false,
+          refundActions: {
+            memberDeactivated: false,
+          },
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { received?: boolean };
+      expect(body.received).toBe(true);
+    });
+
+    it("should return duplicate:true when refund event already processed", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_test_789",
+        },
+        eventAlreadyProcessed: true,
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        received?: boolean;
+        duplicate?: boolean;
+      };
+      expect(body.received).toBe(true);
+      expect(body.duplicate).toBe(true);
+    });
+
+    it("should handle missing customer ID on charge", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          // No customer field
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        received?: boolean;
+        warning?: string;
+      };
+      expect(body.received).toBe(true);
+      expect(body.warning).toBe("No customer ID on charge");
+    });
+
+    it("should include warning when non-critical refund actions fail", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_test_789",
+        },
+        processChargeRefundedResult: {
+          memberId: "refunded-member-123",
+          memberFound: true,
+          subscriptionCanceled: true,
+          refundActions: {
+            memberDeactivated: true,
+            profileDrafted: false,
+            warning: "Non-critical actions failed: Draft profile failed",
+          },
+        },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        received?: boolean;
+        warning?: string;
+      };
+      expect(body.received).toBe(true);
+      expect(body.warning).toContain("Non-critical actions failed");
+    });
+
+    it("should return 500 for unexpected refund processing errors", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_test_789",
+        },
+        processChargeRefundedError: new Error("Database connection failed"),
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as {
+        error?: string;
+        errorId?: string;
+      };
+      expect(body.error).toBe("Internal server error");
+      expect(body.errorId).toBe(ERROR_IDS.API_STRIPE_WEBHOOK_UNEXPECTED_ERROR);
     });
   });
 });

--- a/functions/src/stripe-webhook-api/routes/handle-webhook.test.ts
+++ b/functions/src/stripe-webhook-api/routes/handle-webhook.test.ts
@@ -460,5 +460,22 @@ describe("POST /webhook", () => {
       expect(body.error).toBe("Internal server error");
       expect(body.errorId).toBe(ERROR_IDS.API_STRIPE_WEBHOOK_UNEXPECTED_ERROR);
     });
+
+    it("should return HttpError status when refund processing throws HttpError", async () => {
+      const { testApp, request } = setup({
+        eventType: "charge.refunded",
+        sessionData: {
+          id: "ch_test_456",
+          customer: "cus_test_789",
+        },
+        processChargeRefundedError: new HttpError("Duplicate refund", 409),
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(409);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Duplicate refund");
+    });
   });
 });

--- a/functions/src/stripe-webhook-api/routes/handle-webhook.ts
+++ b/functions/src/stripe-webhook-api/routes/handle-webhook.ts
@@ -131,7 +131,67 @@ export async function handleStripeWebhookLogic(options: {
     }
   }
 
-  // Step 4: Acknowledge unhandled event types
+  // Step 4: Handle charge.refunded events
+  if (event.type === "charge.refunded") {
+    // Step 4a: Check idempotency
+    const wasMarked = await stripeWebhookService.markEventProcessed({
+      eventId: event.id,
+      eventType: event.type,
+    });
+
+    if (!wasMarked) {
+      logger.info(`Event ${event.id} already processed, skipping`, {
+        eventId: event.id,
+        eventType: event.type,
+      });
+      return { received: true, duplicate: true };
+    }
+
+    // Step 4b: Process the refund
+    try {
+      const charge = event.data.object as { customer?: string | null };
+      const stripeCustomerId =
+        typeof charge.customer === "string" ? charge.customer : undefined;
+
+      if (!stripeCustomerId) {
+        logger.warn("charge.refunded event missing customer ID", {
+          eventId: event.id,
+        });
+        return { received: true, warning: "No customer ID on charge" };
+      }
+
+      const result = await stripeWebhookService.processChargeRefunded({
+        stripeCustomerId,
+        emailService,
+      });
+
+      return {
+        received: true,
+        ...(result.memberId !== undefined && { userId: result.memberId }),
+        ...(result.refundActions.warning !== undefined && {
+          warning: result.refundActions.warning,
+        }),
+      };
+    } catch (error) {
+      if (error instanceof HttpError) {
+        set.status = error.statusCode;
+        return { error: error.message };
+      }
+
+      logger.error("Unexpected error processing refund", {
+        error,
+        errorId: ERROR_IDS.API_STRIPE_WEBHOOK_UNEXPECTED_ERROR,
+        eventId: event.id,
+      });
+      set.status = 500;
+      return {
+        error: "Internal server error",
+        errorId: ERROR_IDS.API_STRIPE_WEBHOOK_UNEXPECTED_ERROR,
+      };
+    }
+  }
+
+  // Step 5: Acknowledge unhandled event types
   logger.warn(`Unhandled event type: ${event.type}`, {
     errorId: ERROR_IDS.STRIPE_WEBHOOK_UNHANDLED_EVENT,
     eventType: event.type,

--- a/functions/src/stripe-webhook-api/routes/handle-webhook.ts
+++ b/functions/src/stripe-webhook-api/routes/handle-webhook.ts
@@ -148,18 +148,18 @@ export async function handleStripeWebhookLogic(options: {
     }
 
     // Step 4b: Process the refund
+    const charge = event.data.object as { customer?: string | null };
+    const stripeCustomerId =
+      typeof charge.customer === "string" ? charge.customer : undefined;
+
+    if (!stripeCustomerId) {
+      logger.warn("charge.refunded event missing customer ID", {
+        eventId: event.id,
+      });
+      return { received: true, warning: "No customer ID on charge" };
+    }
+
     try {
-      const charge = event.data.object as { customer?: string | null };
-      const stripeCustomerId =
-        typeof charge.customer === "string" ? charge.customer : undefined;
-
-      if (!stripeCustomerId) {
-        logger.warn("charge.refunded event missing customer ID", {
-          eventId: event.id,
-        });
-        return { received: true, warning: "No customer ID on charge" };
-      }
-
       const result = await stripeWebhookService.processChargeRefunded({
         stripeCustomerId,
         emailService,
@@ -182,6 +182,7 @@ export async function handleStripeWebhookLogic(options: {
         error,
         errorId: ERROR_IDS.API_STRIPE_WEBHOOK_UNEXPECTED_ERROR,
         eventId: event.id,
+        stripeCustomerId,
       });
       set.status = 500;
       return {

--- a/functions/src/stripe-webhook-api/services/cancel-stripe-subscription.ts
+++ b/functions/src/stripe-webhook-api/services/cancel-stripe-subscription.ts
@@ -1,0 +1,50 @@
+import { logger } from "firebase-functions/v2";
+import Stripe from "stripe";
+
+/**
+ * Cancel a Stripe subscription.
+ * Handles the "resource_missing" error gracefully (subscription already canceled).
+ *
+ * @param subscriptionId - The Stripe subscription ID to cancel
+ * @returns true if canceled successfully or already canceled, false if unexpected error
+ */
+export async function cancelStripeSubscription({
+  subscriptionId,
+}: {
+  subscriptionId: string;
+}): Promise<boolean> {
+  const stripeApiKey = process.env["STRIPE_API_KEY"];
+
+  if (!stripeApiKey) {
+    logger.error("STRIPE_API_KEY not configured, cannot cancel subscription", {
+      subscriptionId,
+    });
+    return false;
+  }
+
+  const stripe = new Stripe(stripeApiKey);
+
+  try {
+    await stripe.subscriptions.cancel(subscriptionId);
+    logger.info("Stripe subscription canceled", { subscriptionId });
+    return true;
+  } catch (error) {
+    // Handle already-canceled subscription gracefully
+    if (
+      error instanceof Stripe.errors.StripeInvalidRequestError &&
+      error.code === "resource_missing"
+    ) {
+      logger.info("Stripe subscription already canceled or not found", {
+        subscriptionId,
+      });
+      return true;
+    }
+
+    logger.error("Failed to cancel Stripe subscription", {
+      subscriptionId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    return false;
+  }
+}

--- a/functions/src/stripe-webhook-api/services/cancel-stripe-subscription.ts
+++ b/functions/src/stripe-webhook-api/services/cancel-stripe-subscription.ts
@@ -1,25 +1,27 @@
 import { logger } from "firebase-functions/v2";
 import Stripe from "stripe";
+import { ERROR_IDS } from "../../constants/error-ids.js";
 
 /**
  * Cancel a Stripe subscription.
  * Handles the "resource_missing" error gracefully (subscription already canceled).
  *
  * @param subscriptionId - The Stripe subscription ID to cancel
- * @returns true if canceled successfully or already canceled, false if unexpected error
+ * @throws Error if STRIPE_API_KEY is not configured or if the Stripe API call fails
  */
 export async function cancelStripeSubscription({
   subscriptionId,
 }: {
   subscriptionId: string;
-}): Promise<boolean> {
+}): Promise<void> {
   const stripeApiKey = process.env["STRIPE_API_KEY"];
 
   if (!stripeApiKey) {
     logger.error("STRIPE_API_KEY not configured, cannot cancel subscription", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED,
       subscriptionId,
     });
-    return false;
+    throw new Error("STRIPE_API_KEY not configured");
   }
 
   const stripe = new Stripe(stripeApiKey);
@@ -27,7 +29,6 @@ export async function cancelStripeSubscription({
   try {
     await stripe.subscriptions.cancel(subscriptionId);
     logger.info("Stripe subscription canceled", { subscriptionId });
-    return true;
   } catch (error) {
     // Handle already-canceled subscription gracefully
     if (
@@ -37,14 +38,15 @@ export async function cancelStripeSubscription({
       logger.info("Stripe subscription already canceled or not found", {
         subscriptionId,
       });
-      return true;
+      return;
     }
 
     logger.error("Failed to cancel Stripe subscription", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED,
       subscriptionId,
       error,
       errorMessage: error instanceof Error ? error.message : "Unknown error",
     });
-    return false;
+    throw error;
   }
 }

--- a/functions/src/stripe-webhook-api/services/find-member-by-stripe-customer.ts
+++ b/functions/src/stripe-webhook-api/services/find-member-by-stripe-customer.ts
@@ -1,5 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
 import { MEMBERS_COLLECTION } from "../../collections/index.js";
+import { ERROR_IDS } from "../../constants/error-ids.js";
 import type { MemberDocument } from "../../types/member-document.js";
 
 /**
@@ -12,26 +14,36 @@ export async function findMemberByStripeCustomer({
   stripeCustomerId,
 }: {
   stripeCustomerId: string;
-}): Promise<(MemberDocument & { uid: string }) | undefined> {
-  const firestore = getFirestore();
-  const querySnapshot = await firestore
-    .collection(MEMBERS_COLLECTION)
-    .where("stripeCustomerId", "==", stripeCustomerId)
-    .limit(1)
-    .get();
+}): Promise<MemberDocument | undefined> {
+  try {
+    const firestore = getFirestore();
+    const querySnapshot = await firestore
+      .collection(MEMBERS_COLLECTION)
+      .where("stripeCustomerId", "==", stripeCustomerId)
+      .limit(1)
+      .get();
 
-  if (querySnapshot.empty) {
-    return undefined;
+    if (querySnapshot.empty) {
+      return undefined;
+    }
+
+    const document = querySnapshot.docs[0];
+
+    if (!document) {
+      return undefined;
+    }
+
+    return {
+      ...(document.data() as MemberDocument),
+      uid: document.id,
+    };
+  } catch (error) {
+    logger.error("Failed to query member by Stripe customer ID", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_MEMBER_LOOKUP_FAILED,
+      stripeCustomerId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
   }
-
-  const document = querySnapshot.docs[0];
-
-  if (!document) {
-    return undefined;
-  }
-
-  return {
-    ...(document.data() as MemberDocument),
-    uid: document.id,
-  };
 }

--- a/functions/src/stripe-webhook-api/services/find-member-by-stripe-customer.ts
+++ b/functions/src/stripe-webhook-api/services/find-member-by-stripe-customer.ts
@@ -1,0 +1,37 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { MEMBERS_COLLECTION } from "../../collections/index.js";
+import type { MemberDocument } from "../../types/member-document.js";
+
+/**
+ * Find a member by their Stripe customer ID.
+ *
+ * @param stripeCustomerId - The Stripe customer ID to search for
+ * @returns The member document if found, undefined otherwise
+ */
+export async function findMemberByStripeCustomer({
+  stripeCustomerId,
+}: {
+  stripeCustomerId: string;
+}): Promise<(MemberDocument & { uid: string }) | undefined> {
+  const firestore = getFirestore();
+  const querySnapshot = await firestore
+    .collection(MEMBERS_COLLECTION)
+    .where("stripeCustomerId", "==", stripeCustomerId)
+    .limit(1)
+    .get();
+
+  if (querySnapshot.empty) {
+    return undefined;
+  }
+
+  const document = querySnapshot.docs[0];
+
+  if (!document) {
+    return undefined;
+  }
+
+  return {
+    ...(document.data() as MemberDocument),
+    uid: document.id,
+  };
+}

--- a/functions/src/stripe-webhook-api/services/index.ts
+++ b/functions/src/stripe-webhook-api/services/index.ts
@@ -1,6 +1,7 @@
 import { checkIdempotency } from "./check-idempotency.js";
 import type { StripeWebhookService as StripeWebhookServiceInterface } from "./interface.js";
 import { markEventProcessed } from "./mark-event-processed.js";
+import { processChargeRefunded } from "./process-charge-refunded.js";
 import { processCheckoutCompleted } from "./process-checkout-completed.js";
 import { verifySignature } from "./verify-signature.js";
 
@@ -13,10 +14,12 @@ export const StripeWebhookService: StripeWebhookServiceInterface = {
   isEventProcessed: checkIdempotency,
   markEventProcessed,
   processCheckoutCompleted,
+  processChargeRefunded,
 };
 
 // Re-export individual functions for direct imports
 export { checkIdempotency } from "./check-idempotency.js";
 export { markEventProcessed } from "./mark-event-processed.js";
+export { processChargeRefunded } from "./process-charge-refunded.js";
 export { processCheckoutCompleted } from "./process-checkout-completed.js";
 export { verifySignature } from "./verify-signature.js";

--- a/functions/src/stripe-webhook-api/services/interface.ts
+++ b/functions/src/stripe-webhook-api/services/interface.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
+import type { ChargeRefundedResult } from "./process-charge-refunded.js";
 
 /**
  * Result of processing a checkout session completion.
@@ -64,4 +65,16 @@ export interface StripeWebhookService {
     emailService: EmailServiceInterface;
     logger: Logger;
   }): Promise<CheckoutCompletedResult>;
+
+  /**
+   * Process a charge.refunded event.
+   * Finds member, cancels subscription, deactivates membership, drafts profile, unsubscribes newsletter.
+   *
+   * @param options - Stripe customer ID and email service
+   * @returns Promise resolving to refund processing result
+   */
+  processChargeRefunded(options: {
+    stripeCustomerId: string;
+    emailService?: EmailServiceInterface;
+  }): Promise<ChargeRefundedResult>;
 }

--- a/functions/src/stripe-webhook-api/services/process-charge-refunded.ts
+++ b/functions/src/stripe-webhook-api/services/process-charge-refunded.ts
@@ -64,17 +64,10 @@ export async function processChargeRefunded({
   // Step 2: Cancel subscription (prevent future charges)
   let subscriptionCanceled = false;
   if (member.stripeSubscriptionId) {
-    subscriptionCanceled = await cancelStripeSubscription({
+    await cancelStripeSubscription({
       subscriptionId: member.stripeSubscriptionId,
     });
-
-    if (!subscriptionCanceled) {
-      logger.error("Failed to cancel Stripe subscription during refund", {
-        errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED,
-        memberId: member.uid,
-        stripeSubscriptionId: member.stripeSubscriptionId,
-      });
-    }
+    subscriptionCanceled = true;
   }
 
   // Step 3: Process refund actions (deactivate, draft profile, unsubscribe)

--- a/functions/src/stripe-webhook-api/services/process-charge-refunded.ts
+++ b/functions/src/stripe-webhook-api/services/process-charge-refunded.ts
@@ -1,0 +1,94 @@
+import { logger } from "firebase-functions/v2";
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
+import { cancelStripeSubscription } from "./cancel-stripe-subscription.js";
+import { findMemberByStripeCustomer } from "./find-member-by-stripe-customer.js";
+import {
+  processRefundActions,
+  type RefundActionsResult,
+} from "./process-refund-actions.js";
+
+/**
+ * Result of processing a charge.refunded webhook event.
+ */
+export interface ChargeRefundedResult {
+  memberId?: string;
+  memberFound: boolean;
+  subscriptionCanceled: boolean;
+  refundActions: RefundActionsResult;
+}
+
+/**
+ * Process a charge.refunded Stripe webhook event.
+ *
+ * 1. Find the member by Stripe customer ID
+ * 2. Cancel the Stripe subscription (prevent future charges)
+ * 3. Deactivate membership, draft profile, unsubscribe from newsletter
+ */
+export async function processChargeRefunded({
+  stripeCustomerId,
+  emailService,
+}: {
+  stripeCustomerId: string;
+  emailService?: EmailServiceInterface;
+}): Promise<ChargeRefundedResult> {
+  // Step 1: Find member by Stripe customer ID
+  let member;
+  try {
+    member = await findMemberByStripeCustomer({ stripeCustomerId });
+  } catch (error) {
+    logger.error("Failed to look up member by Stripe customer ID", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_MEMBER_LOOKUP_FAILED,
+      stripeCustomerId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+
+  if (!member) {
+    logger.info(
+      "No member found for Stripe customer ID during refund processing",
+      {
+        errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_MEMBER_NOT_FOUND,
+        stripeCustomerId,
+      },
+    );
+    return {
+      memberFound: false,
+      subscriptionCanceled: false,
+      refundActions: { memberDeactivated: false },
+    };
+  }
+
+  // Step 2: Cancel subscription (prevent future charges)
+  let subscriptionCanceled = false;
+  if (member.stripeSubscriptionId) {
+    subscriptionCanceled = await cancelStripeSubscription({
+      subscriptionId: member.stripeSubscriptionId,
+    });
+
+    if (!subscriptionCanceled) {
+      logger.error("Failed to cancel Stripe subscription during refund", {
+        errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_SUBSCRIPTION_CANCEL_FAILED,
+        memberId: member.uid,
+        stripeSubscriptionId: member.stripeSubscriptionId,
+      });
+    }
+  }
+
+  // Step 3: Process refund actions (deactivate, draft profile, unsubscribe)
+  const refundActions = await processRefundActions({
+    memberId: member.uid,
+    member,
+    reason: "Stripe refund",
+    ...(emailService !== undefined && { emailService }),
+  });
+
+  return {
+    memberId: member.uid,
+    memberFound: true,
+    subscriptionCanceled,
+    refundActions,
+  };
+}

--- a/functions/src/stripe-webhook-api/services/process-refund-actions.ts
+++ b/functions/src/stripe-webhook-api/services/process-refund-actions.ts
@@ -106,7 +106,7 @@ export async function processRefundActions({
       error,
       errorMessage: error instanceof Error ? error.message : "Unknown error",
     });
-    return { memberDeactivated: false, warning: "Failed to deactivate member" };
+    throw error;
   }
 
   const failures: string[] = [];
@@ -166,6 +166,14 @@ export async function processRefundActions({
           `Newsletter unsubscribe (${member.email}): ${errorMessage}`,
         );
       }
+    } else {
+      logger.warn(
+        "MAILERLITE_API_KEY not configured, skipping newsletter unsubscribe",
+        { memberId, email: member.email },
+      );
+      failures.push(
+        "Newsletter unsubscribe skipped: MAILERLITE_API_KEY not configured",
+      );
     }
   }
 

--- a/functions/src/stripe-webhook-api/services/process-refund-actions.ts
+++ b/functions/src/stripe-webhook-api/services/process-refund-actions.ts
@@ -1,0 +1,216 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import {
+  ERROR_IDS,
+  NEWSLETTER_EMAIL,
+  NO_REPLY_EMAIL,
+} from "../../constants/index.js";
+import { draftProfile } from "../../profiles-api/services/github/draft-profile.js";
+import type {
+  EmailMessage,
+  EmailServiceInterface,
+} from "../../shared-api/services/email/index.js";
+import { updateMemberWithValidation } from "../../shared-api/utils/firestore-helpers.js";
+import { escapeHtml } from "../../shared-api/utils/html-escape.js";
+import { removeNewsletterSubscriber } from "../../shared-api/utils/mailerlite.js";
+import type { MemberDocument } from "../../types/member-document.js";
+
+/**
+ * Result of processing refund actions for a member.
+ */
+export interface RefundActionsResult {
+  memberDeactivated: boolean;
+  profileDrafted?: boolean;
+  newsletterUnsubscribed?: boolean;
+  warning?: string;
+}
+
+/**
+ * Creates HTML for refund failure notification email sent to admin.
+ */
+function createRefundFailureEmailHtml({
+  email,
+  memberId,
+  failures,
+}: {
+  email: string;
+  memberId: string;
+  failures: string[];
+}): string {
+  const failureItems = failures
+    .map(failure => `<li>${escapeHtml(failure)}</li>`)
+    .join("\n");
+
+  return `
+    <h2>Refund Processing - Cascading Action Failures</h2>
+    <p>A membership refund was processed, but some follow-up actions failed.</p>
+
+    <h3>Member Details:</h3>
+    <ul>
+      <li><strong>Email:</strong> ${escapeHtml(email)}</li>
+      <li><strong>Member ID:</strong> ${escapeHtml(memberId)}</li>
+    </ul>
+
+    <h3>Failed Actions:</h3>
+    <ul>
+      ${failureItems}
+    </ul>
+
+    <p><strong>Action Required:</strong> Please manually complete the failed actions above.</p>
+  `;
+}
+
+/**
+ * Process the cascading actions required after a membership refund.
+ *
+ * CRITICAL: Deactivate member document (sets membershipActive=false, subscriptionStatus="refunded")
+ * NON-CRITICAL: Draft Hugo profile (if member has slug), unsubscribe from newsletter, send admin notification on failure
+ */
+export async function processRefundActions({
+  memberId,
+  member,
+  reason,
+  emailService,
+}: {
+  memberId: string;
+  member: MemberDocument;
+  reason?: string;
+  emailService?: EmailServiceInterface;
+}): Promise<RefundActionsResult> {
+  // Idempotency check: if member is already refunded, skip
+  if (member.subscriptionStatus === "refunded") {
+    logger.info("Member already refunded, skipping refund actions", {
+      memberId,
+    });
+    return { memberDeactivated: true };
+  }
+
+  // CRITICAL: Update member document
+  const refundUpdates: Partial<MemberDocument> = {
+    membershipActive: false,
+    subscriptionStatus: "refunded",
+    refundedAt: Timestamp.now(),
+    ...(reason !== undefined && { refundReason: reason }),
+  };
+
+  try {
+    await updateMemberWithValidation({
+      memberId,
+      updates: refundUpdates,
+      operation: "refund membership",
+    });
+  } catch (error) {
+    logger.error("CRITICAL: Failed to deactivate member during refund", {
+      errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_DEACTIVATION_FAILED,
+      memberId,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    return { memberDeactivated: false, warning: "Failed to deactivate member" };
+  }
+
+  const failures: string[] = [];
+
+  // NON-CRITICAL: Draft Hugo profile if member has a slug
+  let profileDrafted: boolean | undefined;
+  if (member.slug !== undefined && member.slug.length > 0) {
+    try {
+      await draftProfile({ slug: member.slug });
+      logger.info("Set Hugo profile to draft after refund", {
+        memberId,
+        slug: member.slug,
+      });
+      profileDrafted = true;
+    } catch (error) {
+      profileDrafted = false;
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      logger.error("Failed to draft profile during refund", {
+        errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_DRAFT_PROFILE_FAILED,
+        memberId,
+        slug: member.slug,
+        error,
+        errorMessage,
+      });
+      failures.push(`Draft profile (slug: ${member.slug}): ${errorMessage}`);
+    }
+  }
+
+  // NON-CRITICAL: Unsubscribe from newsletter if subscribed
+  let newsletterUnsubscribed: boolean | undefined;
+  if (member.newsletterSubscribed === true) {
+    const mailerliteApiKey = process.env["MAILERLITE_API_KEY"];
+    if (mailerliteApiKey) {
+      try {
+        await removeNewsletterSubscriber({
+          email: member.email,
+          apiKey: mailerliteApiKey,
+        });
+        logger.info("Unsubscribed from newsletter after refund", {
+          memberId,
+          email: member.email,
+        });
+        newsletterUnsubscribed = true;
+      } catch (error) {
+        newsletterUnsubscribed = false;
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        logger.error("Failed to unsubscribe from newsletter during refund", {
+          errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_NEWSLETTER_FAILED,
+          memberId,
+          email: member.email,
+          error,
+          errorMessage,
+        });
+        failures.push(
+          `Newsletter unsubscribe (${member.email}): ${errorMessage}`,
+        );
+      }
+    }
+  }
+
+  // NON-CRITICAL: Send admin notification if any cascading action failed
+  if (failures.length > 0 && emailService !== undefined) {
+    try {
+      const notificationEmail: EmailMessage = {
+        from: `Doula Cooperative Alerts <${NO_REPLY_EMAIL}>`,
+        to: NEWSLETTER_EMAIL,
+        subject:
+          "Refund Processing - Action Required for Failed Follow-up Actions",
+        html: createRefundFailureEmailHtml({
+          email: member.email,
+          memberId,
+          failures,
+        }),
+      };
+
+      await emailService.sendEmail({ message: notificationEmail }, logger);
+      logger.info("Sent refund failure notification email", { memberId });
+    } catch (emailError) {
+      logger.error(
+        "CRITICAL: Failed to send refund failure notification email",
+        {
+          errorId: ERROR_IDS.STRIPE_WEBHOOK_REFUND_NOTIFICATION_FAILED,
+          memberId,
+          error: emailError,
+          severity: "CRITICAL",
+          context:
+            "Refund cascading actions failed AND notification email failed",
+          failures,
+        },
+      );
+    }
+  }
+
+  const warning =
+    failures.length > 0
+      ? `Non-critical actions failed: ${failures.join("; ")}`
+      : undefined;
+
+  return {
+    memberDeactivated: true,
+    ...(profileDrafted !== undefined && { profileDrafted }),
+    ...(newsletterUnsubscribed !== undefined && { newsletterUnsubscribed }),
+    ...(warning !== undefined && { warning }),
+  };
+}

--- a/functions/src/stripe-webhook-api/test-utils/create-stripe-webhook-test-plugin.ts
+++ b/functions/src/stripe-webhook-api/test-utils/create-stripe-webhook-test-plugin.ts
@@ -32,6 +32,16 @@ export function createStripeWebhookTestPlugin(overrides?: {
         mailerliteSynced: true,
       }),
     ),
+    processChargeRefunded: mock(() =>
+      Promise.resolve({
+        memberId: "test-member-123",
+        memberFound: true,
+        subscriptionCanceled: true,
+        refundActions: {
+          memberDeactivated: true,
+        },
+      }),
+    ),
     ...overrides?.stripeWebhookService,
   };
 

--- a/functions/src/types/member-document.ts
+++ b/functions/src/types/member-document.ts
@@ -6,7 +6,8 @@ export type SubscriptionStatus =
   | "canceled"
   | "incomplete"
   | "trialing"
-  | "unpaid";
+  | "unpaid"
+  | "refunded";
 
 /**
  * Member document stored in Firestore.
@@ -53,6 +54,8 @@ export interface MemberDocument {
   newsletterSubscribed?: boolean;
   newsletterSubscribedAt?: Timestamp;
   newsletterUnsubscribedAt?: Timestamp;
+  refundedAt?: Timestamp;
+  refundReason?: string;
 }
 
 /**

--- a/members/src/app/admin/services/admin-members.service.ts
+++ b/members/src/app/admin/services/admin-members.service.ts
@@ -286,4 +286,37 @@ export class AdminMembersService {
       ),
     );
   }
+
+  async refundMembership(
+    uid: string,
+    reason?: string,
+  ): Promise<{
+    success: boolean;
+    refundResult: {
+      stripeRefundCreated: boolean;
+      subscriptionCanceled: boolean;
+      memberDeactivated: boolean;
+      profileDrafted?: boolean;
+      newsletterUnsubscribed?: boolean;
+      warning?: string;
+    };
+  }> {
+    // Authorization header added automatically by authInterceptor
+    const body = {
+      ...(reason !== undefined && { reason }),
+    };
+    return firstValueFrom(
+      this.httpClient.post<{
+        success: boolean;
+        refundResult: {
+          stripeRefundCreated: boolean;
+          subscriptionCanceled: boolean;
+          memberDeactivated: boolean;
+          profileDrafted?: boolean;
+          newsletterUnsubscribed?: boolean;
+          warning?: string;
+        };
+      }>(`/api/admin/members/${uid}/membership/refund`, body),
+    );
+  }
 }

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
@@ -65,6 +65,16 @@
         <dd>{{ member.subscriptionStatus || '—' }}</dd>
       }
 
+      @if (member.subscriptionStatus === 'refunded') {
+        <dt>Refunded At:</dt>
+        <dd>{{ member.refundedAt ? (member.refundedAt | date: 'MMM d, yyyy h:mm a') : '—' }}</dd>
+
+        @if (member.refundReason) {
+          <dt>Refund Reason:</dt>
+          <dd>{{ member.refundReason }}</dd>
+        }
+      }
+
       <dt>Has Profile:</dt>
       <dd>
         @if (member.slug) {
@@ -112,6 +122,21 @@
             [disabled]="service.actionInProgress()"
           >
             {{ service.actionInProgress() ? 'Processing...' : 'Activate Membership' }}
+          </button>
+        }
+
+        @if (
+          member.stripeCustomerId &&
+          member.membershipActive &&
+          member.subscriptionStatus !== 'refunded'
+        ) {
+          <button
+            type="button"
+            class="button button--danger"
+            (click)="showRefundConfirm()"
+            [disabled]="service.actionInProgress()"
+          >
+            {{ service.actionInProgress() ? 'Processing...' : 'Refund Membership' }}
           </button>
         }
       </div>

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
@@ -117,4 +117,35 @@ export class AdminMemberDetailService {
       this.profileUidSignal.set(member.uid);
     }
   }
+
+  /**
+   * Refund membership for the current member
+   */
+  async refundMembership(uid: string): Promise<void> {
+    this.actionInProgress.set(true);
+    this.successMessage.set(undefined);
+    this.actionError.set(undefined);
+
+    try {
+      const result = await this.adminMembersService.refundMembership(uid);
+      const warnings: string[] = [];
+
+      if (result.refundResult.warning) {
+        warnings.push(result.refundResult.warning);
+      }
+
+      const message =
+        warnings.length > 0
+          ? `Membership refunded successfully. Warning: ${warnings.join('; ')}`
+          : 'Membership refunded successfully';
+
+      this.successMessage.set(message);
+      this.memberResource.reload();
+    } catch (error) {
+      console.error('Error refunding membership:', error);
+      this.actionError.set('Failed to refund membership.');
+    } finally {
+      this.actionInProgress.set(false);
+    }
+  }
 }

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
@@ -13,7 +13,7 @@ import type { Member } from '../../admin.types';
 import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
 import { AdminMemberDetailService } from './admin-member-detail.service';
 
-type ConfirmAction = 'activate' | 'deactivate' | 'delete';
+type ConfirmAction = 'activate' | 'deactivate' | 'delete' | 'refund';
 
 interface DialogConfig {
   title: string;
@@ -91,6 +91,18 @@ export class AdminMemberDetail {
     this.confirmDialog()?.showModal();
   }
 
+  protected showRefundConfirm(): void {
+    this.pendingAction.set('refund');
+    this.dialogConfig.set({
+      title: 'Confirm Refund',
+      message:
+        'Are you sure you want to refund this membership? This will issue a Stripe refund, cancel the subscription, deactivate the membership, and hide the profile.',
+      confirmText: 'Refund',
+      variant: 'danger',
+    });
+    this.confirmDialog()?.showModal();
+  }
+
   protected onCancelDialog(): void {
     this.confirmDialog()?.close();
     this.pendingAction.set(undefined);
@@ -111,6 +123,10 @@ export class AdminMemberDetail {
         }
         case 'delete': {
           await this.deleteUser();
+          break;
+        }
+        case 'refund': {
+          await this.service.refundMembership(this.uid());
           break;
         }
       }

--- a/members/src/app/api-types/members-api.types.ts
+++ b/members/src/app/api-types/members-api.types.ts
@@ -15,7 +15,8 @@ export type SubscriptionStatus =
   | 'canceled'
   | 'incomplete'
   | 'trialing'
-  | 'unpaid';
+  | 'unpaid'
+  | 'refunded';
 
 export type WelcomeEmailStatus = 'sent' | 'failed' | 'pending';
 
@@ -46,6 +47,8 @@ export interface ApiMemberResponse {
   newsletterSubscribed?: boolean;
   newsletterSubscribedAt?: string; // ISO 8601
   newsletterUnsubscribedAt?: string; // ISO 8601
+  refundedAt?: string; // ISO 8601
+  refundReason?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `charge.refunded` webhook handler that deactivates membership, cancels subscription, drafts Hugo profile, and unsubscribes from newsletter
- Add admin API endpoint `POST /:memberId/membership/refund` for admin-initiated refunds (issues Stripe refund + all cascading actions)
- Add "Refund Membership" button to Angular admin member detail view
- Use state-based idempotency (`subscriptionStatus === "refunded"`) to prevent double-processing when both webhook and admin paths fire

## New files (7)

| File | Purpose |
|------|---------|
| `stripe-webhook-api/services/find-member-by-stripe-customer.ts` | Firestore query by stripeCustomerId |
| `stripe-webhook-api/services/cancel-stripe-subscription.ts` | Cancel Stripe subscription (handles already-canceled) |
| `stripe-webhook-api/services/process-refund-actions.ts` | Shared deactivate + draft profile + unsubscribe logic |
| `stripe-webhook-api/services/process-charge-refunded.ts` | Webhook event handler for charge.refunded |
| `admin-members-api/services/refund-membership.ts` | Admin API refund service (Stripe refund + cascading actions) |
| `admin-members-api/routes/refund-membership.ts` | Admin route handler |
| `admin-members-api/routes/refund-membership.test.ts` | Admin route tests (auth, success, error scenarios) |

## Manual step required

Add `charge.refunded` to the webhook endpoint event subscriptions in the Stripe Dashboard.

## Test plan

- [x] Functions build passes (0 type errors)
- [x] Angular build passes
- [x] All 396 tests pass (0 failures)
- [x] Lint passes (0 errors, 0 warnings)
- [ ] After deploy: add `charge.refunded` event to Stripe webhook in Dashboard
- [ ] Test admin refund flow via admin UI on a test member with Stripe data
- [ ] Test webhook path by issuing a refund directly in Stripe Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)