### PR TITLE
refactor: extract reusable presentational components

### DIFF
--- a/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
+++ b/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
@@ -67,7 +67,7 @@ export class AdminUnclaimedProfileDetailPage {
     // Status messages
     this.loadingText = page.getByText('Loading details...');
     this.errorMessage = page.getByRole('alert');
-    this.successMessage = page.getByRole('status');
+    this.successMessage = page.locator('app-alert-banner.success');
   }
 
   async goto(email: string): Promise<void> {

--- a/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
+++ b/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
@@ -67,7 +67,7 @@ export class AdminUnclaimedProfileDetailPage {
     // Status messages
     this.loadingText = page.getByText('Loading details...');
     this.errorMessage = page.getByRole('alert');
-    this.successMessage = page.locator('app-alert-banner.success');
+    this.successMessage = page.getByRole('status');
   }
 
   async goto(email: string): Promise<void> {

--- a/members/eslint.config.js
+++ b/members/eslint.config.js
@@ -55,7 +55,7 @@ export default defineConfig([
       '@angular-eslint/component-selector': [
         'error',
         {
-          type: 'element',
+          type: ['element', 'attribute'],
           prefix: 'app',
           style: 'kebab-case',
         },

--- a/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.html
+++ b/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.html
@@ -27,10 +27,10 @@
 
   <!-- Success/Error Messages -->
   @if (service.successMessage(); as message) {
-    <div class="success-message">{{ message }}</div>
+    <app-alert-banner variant="success">{{ message }}</app-alert-banner>
   }
   @if (service.actionError(); as error) {
-    <div class="error-message">{{ error }}</div>
+    <app-alert-banner variant="error">{{ error }}</app-alert-banner>
   }
 
   <!-- Top: Contact & Birth Details (conditional layout) -->

--- a/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.scss
+++ b/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.scss
@@ -41,27 +41,6 @@
   margin-block-end: var(--space-l);
 }
 
-// Success/Error Messages
-.success-message {
-  background: var(--teal-300);
-  color: var(--brown-700);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-  margin-block-end: var(--space-m);
-}
-
-.error-message {
-  background: #fdecea;
-  color: var(--color-error, #d93025);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-  margin-block-end: var(--space-m);
-}
-
 // Top grid for birth support layout (two cards side by side)
 .detail-grid-top {
   display: grid;

--- a/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.ts
+++ b/members/src/app/admin/match-requests/admin-match-request-detail/admin-match-request-detail.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import { Tag } from '../../../tag/tag';
 import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
+import { AlertBanner } from '../../../shared/alert-banner/alert-banner';
 import { SERVICE_LABELS_LONG } from '../match-request.constants';
 import { isValidDueDate, parseDueDate, type DueDate } from '../match-request.utilities';
 import { AdminMatchRequestDetailService } from './admin-match-request-detail.service';
@@ -25,7 +26,7 @@ interface DialogConfig {
 }
 
 @Component({
-  imports: [DatePipe, Tag, ConfirmDialog],
+  imports: [DatePipe, Tag, ConfirmDialog, AlertBanner],
   templateUrl: './admin-match-request-detail.html',
   styleUrl: './admin-match-request-detail.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/admin/match-requests/match-requests-table/match-requests-table.html
+++ b/members/src/app/admin/match-requests/match-requests-table/match-requests-table.html
@@ -9,25 +9,31 @@
       <thead>
         <tr>
           <th>Status</th>
-          <th class="sortable" (click)="handleSort('name')">
+          <th
+            app-sortable-header="name"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Name
-            @if (sortColumn() === 'name') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Contact</th>
-          <th class="sortable" (click)="handleSort('dueDate')">
+          <th
+            app-sortable-header="dueDate"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Due Date
-            @if (sortColumn() === 'dueDate') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Services</th>
-          <th class="sortable" (click)="handleSort('submitted')">
+          <th
+            app-sortable-header="submitted"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Submitted
-            @if (sortColumn() === 'submitted') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Actions</th>
         </tr>

--- a/members/src/app/admin/match-requests/match-requests-table/match-requests-table.scss
+++ b/members/src/app/admin/match-requests/match-requests-table/match-requests-table.scss
@@ -33,16 +33,6 @@
       font-size: var(--step--2);
       text-transform: uppercase;
       letter-spacing: 0.05em;
-
-      &.sortable {
-        cursor: pointer;
-        user-select: none;
-        transition: background 0.2s;
-
-        &:hover {
-          background: var(--brown-200);
-        }
-      }
     }
   }
 
@@ -142,11 +132,6 @@
   color: var(--brown-450);
   padding: var(--space-l);
   font-style: italic;
-}
-
-.sort-indicator {
-  margin-inline-start: var(--space-3xs);
-  color: var(--teal-500);
 }
 
 // View link (eye icon)

--- a/members/src/app/admin/match-requests/match-requests-table/match-requests-table.ts
+++ b/members/src/app/admin/match-requests/match-requests-table/match-requests-table.ts
@@ -37,10 +37,7 @@ export class MatchRequestsTable {
   });
   protected sortColumn = this.sortState.sortColumn;
   protected sortDirection = this.sortState.sortDirection;
-
-  protected handleSort(column: string): void {
-    this.sortState.handleSort(column as MatchRequestSortColumn);
-  }
+  protected handleSort = this.sortState.handleSort;
 
   protected error = computed(() => {
     const error = this.requestsResource().error();
@@ -69,7 +66,7 @@ export class MatchRequestsTable {
           const aValid = isValidDueDate(a.estimatedDueDate);
           const bValid = isValidDueDate(b.estimatedDueDate);
 
-          // Put invalid dates at the end
+          // Invalid dates sort after valid dates (before direction flip)
           if (aValid && bValid) {
             const aDate = parseDueDate(a.estimatedDueDate);
             const bDate = parseDueDate(b.estimatedDueDate);

--- a/members/src/app/admin/match-requests/match-requests-table/match-requests-table.ts
+++ b/members/src/app/admin/match-requests/match-requests-table/match-requests-table.ts
@@ -4,7 +4,6 @@ import {
   Component,
   computed,
   input,
-  signal,
   type ResourceRef,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -17,13 +16,14 @@ import {
   parseDueDate,
   type DueDate,
 } from '../match-request.utilities';
+import { createTableSortState } from '../../../shared/create-table-sort-state';
+import { SortableHeader } from '../../../shared/sortable-header/sortable-header';
 
-type SortDirection = 'asc' | 'desc';
 type MatchRequestSortColumn = 'name' | 'dueDate' | 'submitted';
 
 @Component({
   selector: 'app-match-requests-table',
-  imports: [RouterLink, Tag],
+  imports: [RouterLink, Tag, SortableHeader],
   templateUrl: './match-requests-table.html',
   styleUrl: './match-requests-table.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,8 +31,16 @@ type MatchRequestSortColumn = 'name' | 'dueDate' | 'submitted';
 export class MatchRequestsTable {
   requestsResource = input.required<ResourceRef<ListMatchRequestsResponse | undefined>>();
 
-  protected sortColumn = signal<MatchRequestSortColumn>('submitted');
-  protected sortDirection = signal<SortDirection>('desc');
+  protected sortState = createTableSortState<MatchRequestSortColumn>({
+    defaultColumn: 'submitted',
+    defaultDirection: 'desc',
+  });
+  protected sortColumn = this.sortState.sortColumn;
+  protected sortDirection = this.sortState.sortDirection;
+
+  protected handleSort(column: string): void {
+    this.sortState.handleSort(column as MatchRequestSortColumn);
+  }
 
   protected error = computed(() => {
     const error = this.requestsResource().error();
@@ -84,17 +92,6 @@ export class MatchRequestsTable {
       return direction === 'asc' ? comparison : -comparison;
     });
   });
-
-  protected handleSort(column: MatchRequestSortColumn): void {
-    if (this.sortColumn() === column) {
-      // Toggle direction if clicking the same column
-      this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
-    } else {
-      // Set new column and default to ascending
-      this.sortColumn.set(column);
-      this.sortDirection.set('asc');
-    }
-  }
 
   protected formatDueDate(dueDate: DueDate): string {
     if (!isValidDueDate(dueDate)) {

--- a/members/src/app/admin/messages/admin-message-detail/admin-message-detail.html
+++ b/members/src/app/admin/messages/admin-message-detail/admin-message-detail.html
@@ -22,10 +22,10 @@
 
   <!-- Success/Error Messages -->
   @if (service.successMessage(); as successMsg) {
-    <div class="success-message">{{ successMsg }}</div>
+    <app-alert-banner variant="success">{{ successMsg }}</app-alert-banner>
   }
   @if (service.actionError(); as error) {
-    <div class="error-message">{{ error }}</div>
+    <app-alert-banner variant="error">{{ error }}</app-alert-banner>
   }
 
   <!-- Contact Details -->

--- a/members/src/app/admin/messages/admin-message-detail/admin-message-detail.scss
+++ b/members/src/app/admin/messages/admin-message-detail/admin-message-detail.scss
@@ -19,27 +19,6 @@
   }
 }
 
-// Success/Error Messages
-.success-message {
-  background: var(--teal-300);
-  color: var(--brown-700);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-  margin-block-end: var(--space-m);
-}
-
-.error-message {
-  background: #fdecea;
-  color: var(--color-error, #d93025);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-  margin-block-end: var(--space-m);
-}
-
 // Info cards
 .info-card {
   background: var(--brown-000);

--- a/members/src/app/admin/messages/admin-message-detail/admin-message-detail.ts
+++ b/members/src/app/admin/messages/admin-message-detail/admin-message-detail.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { Tag } from '../../../tag/tag';
 import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
+import { AlertBanner } from '../../../shared/alert-banner/alert-banner';
 import { AdminMessageDetailService } from './admin-message-detail.service';
 
 type ConfirmAction = 'mark-processed' | 'mark-pending';
@@ -22,7 +23,7 @@ interface DialogConfig {
 }
 
 @Component({
-  imports: [DatePipe, Tag, ConfirmDialog],
+  imports: [DatePipe, Tag, ConfirmDialog, AlertBanner],
   templateUrl: './admin-message-detail.html',
   styleUrl: './admin-message-detail.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/admin/messages/messages-table/messages-table.html
+++ b/members/src/app/admin/messages/messages-table/messages-table.html
@@ -9,18 +9,22 @@
       <thead>
         <tr>
           <th>Status</th>
-          <th class="sortable" (click)="handleSort('name')">
+          <th
+            app-sortable-header="name"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Name
-            @if (sortColumn() === 'name') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Email</th>
-          <th class="sortable" (click)="handleSort('submitted')">
+          <th
+            app-sortable-header="submitted"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Submitted
-            @if (sortColumn() === 'submitted') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Actions</th>
         </tr>

--- a/members/src/app/admin/messages/messages-table/messages-table.scss
+++ b/members/src/app/admin/messages/messages-table/messages-table.scss
@@ -33,16 +33,6 @@
       font-size: var(--step--2);
       text-transform: uppercase;
       letter-spacing: 0.05em;
-
-      &.sortable {
-        cursor: pointer;
-        user-select: none;
-        transition: background 0.2s;
-
-        &:hover {
-          background: var(--brown-200);
-        }
-      }
     }
   }
 
@@ -111,11 +101,6 @@
   color: var(--brown-450);
   padding: var(--space-l);
   font-style: italic;
-}
-
-.sort-indicator {
-  margin-inline-start: var(--space-3xs);
-  color: var(--teal-500);
 }
 
 // View link (eye icon)

--- a/members/src/app/admin/messages/messages-table/messages-table.ts
+++ b/members/src/app/admin/messages/messages-table/messages-table.ts
@@ -3,20 +3,20 @@ import {
   Component,
   computed,
   input,
-  signal,
   type ResourceRef,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Tag } from '../../../tag/tag';
 import type { ListMessagesResponse } from '../../admin.types';
 import { getRelativeTime } from '../../match-requests/match-request.utilities';
+import { createTableSortState } from '../../../shared/create-table-sort-state';
+import { SortableHeader } from '../../../shared/sortable-header/sortable-header';
 
-type SortDirection = 'asc' | 'desc';
 type MessageSortColumn = 'name' | 'submitted';
 
 @Component({
   selector: 'app-messages-table',
-  imports: [RouterLink, Tag],
+  imports: [RouterLink, Tag, SortableHeader],
   templateUrl: './messages-table.html',
   styleUrl: './messages-table.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,8 +24,16 @@ type MessageSortColumn = 'name' | 'submitted';
 export class MessagesTable {
   messagesResource = input.required<ResourceRef<ListMessagesResponse | undefined>>();
 
-  protected sortColumn = signal<MessageSortColumn>('submitted');
-  protected sortDirection = signal<SortDirection>('desc');
+  protected sortState = createTableSortState<MessageSortColumn>({
+    defaultColumn: 'submitted',
+    defaultDirection: 'desc',
+  });
+  protected sortColumn = this.sortState.sortColumn;
+  protected sortDirection = this.sortState.sortDirection;
+
+  protected handleSort(column: string): void {
+    this.sortState.handleSort(column as MessageSortColumn);
+  }
 
   protected error = computed(() => {
     const error = this.messagesResource().error();
@@ -59,17 +67,6 @@ export class MessagesTable {
       return direction === 'asc' ? comparison : -comparison;
     });
   });
-
-  protected handleSort(column: MessageSortColumn): void {
-    if (this.sortColumn() === column) {
-      // Toggle direction if clicking the same column
-      this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
-    } else {
-      // Set new column and default to ascending
-      this.sortColumn.set(column);
-      this.sortDirection.set('asc');
-    }
-  }
 
   protected getRelativeTime(dateString: string): string {
     return getRelativeTime(dateString);

--- a/members/src/app/admin/messages/messages-table/messages-table.ts
+++ b/members/src/app/admin/messages/messages-table/messages-table.ts
@@ -30,10 +30,7 @@ export class MessagesTable {
   });
   protected sortColumn = this.sortState.sortColumn;
   protected sortDirection = this.sortState.sortDirection;
-
-  protected handleSort(column: string): void {
-    this.sortState.handleSort(column as MessageSortColumn);
-  }
+  protected handleSort = this.sortState.handleSort;
 
   protected error = computed(() => {
     const error = this.messagesResource().error();

--- a/members/src/app/admin/users/active-members-table/active-members-table.html
+++ b/members/src/app/admin/users/active-members-table/active-members-table.html
@@ -8,29 +8,37 @@
     <table class="members-table">
       <thead>
         <tr>
-          <th class="sortable" (click)="handleSort('name')">
+          <th
+            app-sortable-header="name"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Name
-            @if (sortColumn() === 'name') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable" (click)="handleSort('email')">
+          <th
+            app-sortable-header="email"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Email
-            @if (sortColumn() === 'email') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable" (click)="handleSort('membership')">
+          <th
+            app-sortable-header="membership"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Membership
-            @if (sortColumn() === 'membership') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable" (click)="handleSort('created')">
+          <th
+            app-sortable-header="created"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Created
-            @if (sortColumn() === 'created') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Actions</th>
         </tr>

--- a/members/src/app/admin/users/active-members-table/active-members-table.ts
+++ b/members/src/app/admin/users/active-members-table/active-members-table.ts
@@ -30,10 +30,7 @@ export class ActiveMembersTable {
   });
   protected sortColumn = this.sortState.sortColumn;
   protected sortDirection = this.sortState.sortDirection;
-
-  protected handleSort(column: string): void {
-    this.sortState.handleSort(column as MemberSortColumn);
-  }
+  protected handleSort = this.sortState.handleSort;
 
   protected error = computed(() => {
     const error = this.membersResource().error();

--- a/members/src/app/admin/users/active-members-table/active-members-table.ts
+++ b/members/src/app/admin/users/active-members-table/active-members-table.ts
@@ -5,18 +5,18 @@ import {
   computed,
   input,
   type ResourceRef,
-  signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Tag } from '../../../tag/tag';
 import type { ListMembersResponse } from '../../admin.types';
+import { createTableSortState } from '../../../shared/create-table-sort-state';
+import { SortableHeader } from '../../../shared/sortable-header/sortable-header';
 
-type SortDirection = 'asc' | 'desc';
 type MemberSortColumn = 'name' | 'email' | 'membership' | 'created';
 
 @Component({
   selector: 'app-active-members-table',
-  imports: [RouterLink, DatePipe, Tag],
+  imports: [RouterLink, DatePipe, Tag, SortableHeader],
   templateUrl: './active-members-table.html',
   styleUrl: '../admin-table-shared.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,8 +24,16 @@ type MemberSortColumn = 'name' | 'email' | 'membership' | 'created';
 export class ActiveMembersTable {
   membersResource = input.required<ResourceRef<ListMembersResponse | undefined>>();
 
-  protected sortColumn = signal<MemberSortColumn>('created');
-  protected sortDirection = signal<SortDirection>('desc');
+  protected sortState = createTableSortState<MemberSortColumn>({
+    defaultColumn: 'created',
+    defaultDirection: 'desc',
+  });
+  protected sortColumn = this.sortState.sortColumn;
+  protected sortDirection = this.sortState.sortDirection;
+
+  protected handleSort(column: string): void {
+    this.sortState.handleSort(column as MemberSortColumn);
+  }
 
   protected error = computed(() => {
     const error = this.membersResource().error();
@@ -70,15 +78,4 @@ export class ActiveMembersTable {
       return direction === 'asc' ? comparison : -comparison;
     });
   });
-
-  protected handleSort(column: MemberSortColumn): void {
-    if (this.sortColumn() === column) {
-      // Toggle direction if clicking the same column
-      this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
-    } else {
-      // Set new column and default to ascending
-      this.sortColumn.set(column);
-      this.sortDirection.set('asc');
-    }
-  }
 }

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
@@ -3,11 +3,11 @@
 @let memberResource = service.memberResource;
 
 @if (service.successMessage(); as message) {
-  <div class="success-message" role="status">{{ message }}</div>
+  <app-alert-banner variant="success">{{ message }}</app-alert-banner>
 }
 
 @if (service.actionError(); as message) {
-  <div class="error" role="alert">{{ message }}</div>
+  <app-alert-banner variant="error">{{ message }}</app-alert-banner>
 }
 
 @if (memberResource.isLoading()) {
@@ -140,7 +140,9 @@
               {{ service.actionInProgress() ? 'Processing...' : 'Refund Membership' }}
             </button>
           } @else {
-            <p class="info-notice">Refund window has expired (30 days from subscription start).</p>
+            <app-alert-banner variant="info"
+              >Refund window has expired (30 days from subscription start).</app-alert-banner
+            >
           }
         }
       </div>
@@ -189,10 +191,10 @@
   } @else {
     <section class="subscription-card">
       <h2>Admin Account</h2>
-      <p class="info-notice">
+      <app-alert-banner variant="info">
         This user has admin privileges. Admin accounts cannot be deleted. To delete this account,
         first remove their admin privileges.
-      </p>
+      </app-alert-banner>
     </section>
   }
 

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.scss
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.scss
@@ -17,15 +17,6 @@ section > h2 {
   color: var(--color-error, #d93025);
 }
 
-.success-message {
-  background: var(--teal-300);
-  color: var(--brown-700);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-}
-
 .user-info-card,
 .subscription-card {
   background: var(--brown-000);

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
@@ -11,6 +11,7 @@ import {
 import { Router } from '@angular/router';
 import type { Member } from '../../admin.types';
 import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
+import { AlertBanner } from '../../../shared/alert-banner/alert-banner';
 import { AdminMemberDetailService } from './admin-member-detail.service';
 
 type ConfirmAction = 'activate' | 'cancel' | 'delete' | 'refund' | 'cleanSlate';
@@ -23,7 +24,7 @@ interface DialogConfig {
 }
 
 @Component({
-  imports: [DatePipe, ConfirmDialog],
+  imports: [DatePipe, ConfirmDialog, AlertBanner],
   templateUrl: './admin-member-detail.html',
   styleUrl: './admin-member-detail.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/admin/users/admin-table-shared.scss
+++ b/members/src/app/admin/users/admin-table-shared.scss
@@ -51,22 +51,6 @@
       font-weight: var(--font-weight-bold);
       color: var(--brown-500);
       font-size: var(--step--1);
-
-      &.sortable {
-        cursor: pointer;
-        user-select: none;
-        transition: background 0.2s;
-
-        &:hover {
-          background: var(--brown-200);
-        }
-
-        .sort-indicator {
-          margin-inline-start: var(--space-3xs);
-          color: var(--brown-450);
-          font-size: var(--step-0);
-        }
-      }
     }
   }
 

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
@@ -3,11 +3,11 @@
 @let profileResource = service.unclaimedProfileResource;
 
 @if (service.successMessage(); as message) {
-  <div class="success-message" role="status">{{ message }}</div>
+  <app-alert-banner variant="success">{{ message }}</app-alert-banner>
 }
 
 @if (service.actionError(); as message) {
-  <div class="error" role="alert">{{ message }}</div>
+  <app-alert-banner variant="error">{{ message }}</app-alert-banner>
 }
 
 @if (profileResource.isLoading()) {
@@ -17,10 +17,10 @@
 } @else if (profileResource.value(); as profile) {
   <section class="user-info-card">
     <h2>Unclaimed Profile Information</h2>
-    <p class="info-notice">
+    <app-alert-banner variant="info">
       This profile has not yet been claimed by the member. They will need to create an account with
       this email address to claim it.
-    </p>
+    </app-alert-banner>
     <dl class="info-grid">
       <dt>Name:</dt>
       <dd>{{ profile.name }}</dd>
@@ -127,9 +127,9 @@
 
     <div class="actions">
       <h3>Invitation Actions</h3>
-      <p class="info-notice">
+      <app-alert-banner variant="info">
         Send an email invitation to this user to create an account and claim their membership.
-      </p>
+      </app-alert-banner>
 
       <div class="action-buttons">
         <button

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.scss
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.scss
@@ -17,15 +17,6 @@ section > h2 {
   color: var(--color-error, #d93025);
 }
 
-.success-message {
-  background: var(--teal-300);
-  color: var(--brown-700);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
-}
-
 .user-info-card,
 .subscription-card {
   background: var(--brown-000);
@@ -57,16 +48,6 @@ section > h2 {
     padding: var(--space-3xs) var(--space-2xs);
     border-radius: var(--border-radius-md);
   }
-}
-
-.info-notice {
-  background: var(--brown-100);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-md);
-  border-inline-start: 4px solid var(--brown-400);
-  margin-block-end: var(--space-m);
-  font-size: var(--step--1);
-  color: var(--brown-500);
 }
 
 .action-buttons {

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
@@ -11,10 +11,11 @@ import {
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ConfirmDialog } from '../../../shared/confirm-dialog/confirm-dialog';
+import { AlertBanner } from '../../../shared/alert-banner/alert-banner';
 import { AdminUnclaimedProfileDetailService } from './admin-unclaimed-profile-detail.service';
 
 @Component({
-  imports: [DatePipe, FormsModule, ConfirmDialog],
+  imports: [DatePipe, FormsModule, ConfirmDialog, AlertBanner],
   templateUrl: './admin-unclaimed-profile-detail.html',
   styleUrl: './admin-unclaimed-profile-detail.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.html
+++ b/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.html
@@ -11,41 +11,56 @@
     <table class="members-table">
       <thead>
         <tr>
-          <th class="sortable" (click)="handleSort('name')">
+          <th
+            app-sortable-header="name"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Name
-            @if (sortColumn() === 'name') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable" (click)="handleSort('email')">
+          <th
+            app-sortable-header="email"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Email
-            @if (sortColumn() === 'email') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable" (click)="handleSort('hasProfile')">
+          <th
+            app-sortable-header="hasProfile"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Has Profile
-            @if (sortColumn() === 'hasProfile') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable date-cell" (click)="handleSort('subscriptionStart')">
+          <th
+            class="date-cell"
+            app-sortable-header="subscriptionStart"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Subscription Start
-            @if (sortColumn() === 'subscriptionStart') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable date-cell" (click)="handleSort('lastPayment')">
+          <th
+            class="date-cell"
+            app-sortable-header="lastPayment"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Last Payment
-            @if (sortColumn() === 'lastPayment') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
-          <th class="sortable date-cell" (click)="handleSort('nextPayment')">
+          <th
+            class="date-cell"
+            app-sortable-header="nextPayment"
+            [activeColumn]="sortColumn()"
+            [direction]="sortDirection()"
+            (sort)="handleSort($event)"
+          >
             Next Payment
-            @if (sortColumn() === 'nextPayment') {
-              <span class="sort-indicator">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
-            }
           </th>
           <th>Actions</th>
         </tr>

--- a/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.ts
+++ b/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.ts
@@ -5,13 +5,13 @@ import {
   computed,
   input,
   type ResourceRef,
-  signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Tag } from '../../../tag/tag';
 import type { ListUnclaimedProfilesResponse } from '../../admin.types';
+import { createTableSortState } from '../../../shared/create-table-sort-state';
+import { SortableHeader } from '../../../shared/sortable-header/sortable-header';
 
-type SortDirection = 'asc' | 'desc';
 type UnclaimedProfileSortColumn =
   | 'name'
   | 'email'
@@ -22,7 +22,7 @@ type UnclaimedProfileSortColumn =
 
 @Component({
   selector: 'app-unclaimed-profiles-table',
-  imports: [RouterLink, DatePipe, Tag],
+  imports: [RouterLink, DatePipe, Tag, SortableHeader],
   templateUrl: './unclaimed-profiles-table.html',
   styleUrl: '../admin-table-shared.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -30,8 +30,16 @@ type UnclaimedProfileSortColumn =
 export class UnclaimedProfilesTable {
   profilesResource = input.required<ResourceRef<ListUnclaimedProfilesResponse | undefined>>();
 
-  protected sortColumn = signal<UnclaimedProfileSortColumn>('subscriptionStart');
-  protected sortDirection = signal<SortDirection>('desc');
+  protected sortState = createTableSortState<UnclaimedProfileSortColumn>({
+    defaultColumn: 'subscriptionStart',
+    defaultDirection: 'desc',
+  });
+  protected sortColumn = this.sortState.sortColumn;
+  protected sortDirection = this.sortState.sortDirection;
+
+  protected handleSort(column: string): void {
+    this.sortState.handleSort(column as UnclaimedProfileSortColumn);
+  }
 
   protected error = computed(() => {
     const error = this.profilesResource().error();
@@ -85,15 +93,4 @@ export class UnclaimedProfilesTable {
       return direction === 'asc' ? comparison : -comparison;
     });
   });
-
-  protected handleSort(column: UnclaimedProfileSortColumn): void {
-    if (this.sortColumn() === column) {
-      // Toggle direction if clicking the same column
-      this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
-    } else {
-      // Set new column and default to ascending
-      this.sortColumn.set(column);
-      this.sortDirection.set('asc');
-    }
-  }
 }

--- a/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.ts
+++ b/members/src/app/admin/users/unclaimed-profiles-table/unclaimed-profiles-table.ts
@@ -36,10 +36,7 @@ export class UnclaimedProfilesTable {
   });
   protected sortColumn = this.sortState.sortColumn;
   protected sortDirection = this.sortState.sortDirection;
-
-  protected handleSort(column: string): void {
-    this.sortState.handleSort(column as UnclaimedProfileSortColumn);
-  }
+  protected handleSort = this.sortState.handleSort;
 
   protected error = computed(() => {
     const error = this.profilesResource().error();

--- a/members/src/app/create-profile/create-profile.html
+++ b/members/src/app/create-profile/create-profile.html
@@ -17,16 +17,16 @@
   <form [formGroup]="profileForm" (ngSubmit)="onSubmit()" class="profile-form">
     <!-- Success Message -->
     @if (successMessage()) {
-      <div class="form__success-message">
+      <app-alert-banner variant="success">
         {{ successMessage() }}
-      </div>
+      </app-alert-banner>
     }
 
     <!-- Error Message -->
     @if (errorMessage()) {
-      <div class="form__error-message">
+      <app-alert-banner variant="error">
         {{ errorMessage() }}
-      </div>
+      </app-alert-banner>
     }
 
     <!-- Title Field -->

--- a/members/src/app/create-profile/create-profile.ts
+++ b/members/src/app/create-profile/create-profile.ts
@@ -3,6 +3,7 @@ import { FormArray, FormBuilder, FormControl, ReactiveFormsModule } from '@angul
 import { Router } from '@angular/router';
 import { MembershipService } from '../services/membership.service';
 import { ProfileService } from '../services/profile.service';
+import { AlertBanner } from '../shared/alert-banner/alert-banner';
 import { createProfileFormGroup, PROFILE_TAGS } from '../shared/profile-form/profile-form-config';
 import {
   extractProfileData,
@@ -11,7 +12,7 @@ import {
 } from '../shared/profile-form/profile-form-utilities';
 
 @Component({
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, AlertBanner],
   templateUrl: './create-profile.html',
   styleUrls: ['../shared/profile-form/profile-form-styles.scss', './create-profile.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/edit-profile/edit-profile.html
+++ b/members/src/app/edit-profile/edit-profile.html
@@ -19,32 +19,32 @@
   </div>
 } @else if (profile()) {
   @if (isMembershipInactive()) {
-    <div class="inactive-membership-banner" role="status">
+    <app-alert-banner variant="warning">
       <h2>Membership Inactive</h2>
       <p>
         Your membership is no longer active. Your profile is hidden from the public directory until
         your membership is reactivated.
       </p>
       <p>Visit the <a href="/membership">Membership page</a> to view your account details.</p>
-    </div>
+    </app-alert-banner>
   }
   @let profileData = profile();
   <form [formGroup]="profileForm" (ngSubmit)="onSubmit()" class="profile-form">
     <!-- Success Message -->
     @if (successMessage()) {
-      <div class="form__success-message">
+      <app-alert-banner variant="success">
         <p>{{ successMessage() }}</p>
         <p class="message-note">
           You'll receive an email when your update is published to your public profile.
         </p>
-      </div>
+      </app-alert-banner>
     }
 
     <!-- Error Message -->
     @if (errorMessage()) {
-      <div class="form__error-message">
+      <app-alert-banner variant="error">
         {{ errorMessage() }}
-      </div>
+      </app-alert-banner>
     }
 
     <!-- Title Field -->

--- a/members/src/app/edit-profile/edit-profile.scss
+++ b/members/src/app/edit-profile/edit-profile.scss
@@ -14,24 +14,3 @@
   border: 8px solid var(--teal-500);
   margin-block: var(--space-xs);
 }
-
-// Inactive Membership Banner
-.inactive-membership-banner {
-  background: var(--brown-100);
-  border: 2px solid var(--brown-300);
-  border-radius: var(--border-radius-md);
-  padding: var(--space-m) var(--space-l);
-  margin-block-end: var(--space-l);
-
-  h2 {
-    margin-block-end: var(--space-xs);
-  }
-
-  p {
-    margin-block-end: var(--space-xs);
-
-    &:last-child {
-      margin-block-end: 0;
-    }
-  }
-}

--- a/members/src/app/edit-profile/edit-profile.ts
+++ b/members/src/app/edit-profile/edit-profile.ts
@@ -9,6 +9,7 @@ import {
 import { FormArray, FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MembershipService } from '../services/membership.service';
 import { ProfileService } from '../services/profile.service';
+import { AlertBanner } from '../shared/alert-banner/alert-banner';
 import { createProfileFormGroup, PROFILE_TAGS } from '../shared/profile-form/profile-form-config';
 import {
   extractProfileData,
@@ -20,7 +21,7 @@ const MAX_AUTO_RETRIES = 3;
 const RETRY_DELAY_MS = 2000;
 
 @Component({
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, AlertBanner],
   templateUrl: './edit-profile.html',
   styleUrls: ['../shared/profile-form/profile-form-styles.scss', './edit-profile.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/forgot-password/forgot-password.html
+++ b/members/src/app/forgot-password/forgot-password.html
@@ -2,15 +2,15 @@
 <p class="subtitle">Enter your email address and we'll send you a link to reset your password</p>
 
 @if (errorMessage(); as error) {
-  <div class="form__error-message">
+  <app-alert-banner variant="error">
     {{ error }}
-  </div>
+  </app-alert-banner>
 }
 
 @if (successMessage(); as success) {
-  <div class="form__success-message">
+  <app-alert-banner variant="success">
     {{ success }}
-  </div>
+  </app-alert-banner>
 }
 
 <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()" class="form">

--- a/members/src/app/forgot-password/forgot-password.scss
+++ b/members/src/app/forgot-password/forgot-password.scss
@@ -6,12 +6,3 @@
   text-align: center;
   margin-block: var(--space-m);
 }
-
-.form__success-message {
-  background-color: var(--color-success-light, #d4edda);
-  color: var(--color-success-dark, #155724);
-  padding: var(--space-s);
-  border-radius: var(--border-radius-s, 4px);
-  margin-block-end: var(--space-m);
-  border: 1px solid var(--color-success, #28a745);
-}

--- a/members/src/app/forgot-password/forgot-password.ts
+++ b/members/src/app/forgot-password/forgot-password.ts
@@ -2,9 +2,10 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { AlertBanner } from '../shared/alert-banner/alert-banner';
 
 @Component({
-  imports: [RouterLink, ReactiveFormsModule],
+  imports: [RouterLink, ReactiveFormsModule, AlertBanner],
   templateUrl: './forgot-password.html',
   styleUrls: ['./forgot-password.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/membership/membership.html
+++ b/members/src/app/membership/membership.html
@@ -2,13 +2,13 @@
   <!-- Authenticated User View -->
   <div class="authenticated-view">
     @if (claimableProfileResource.error()) {
-      <div class="error-banner">
+      <app-alert-banner variant="error">
         <h3>Unable to Load Profile Information</h3>
         <p>
           We encountered an error while loading your profile information. Please try refreshing the
           page.
         </p>
-      </div>
+      </app-alert-banner>
     } @else {
       @let claimableProfileData = claimableProfileResource.value();
       @if (claimableProfileData; as profileData) {

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -13,11 +13,12 @@ import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 import { MembershipService } from '../services/membership.service';
 import { ConfirmDialog } from '../shared/confirm-dialog/confirm-dialog';
+import { AlertBanner } from '../shared/alert-banner/alert-banner';
 import { FACEBOOK_GROUP_URL } from '../constants/urls';
 import { ensureUniqueSlug, generateSlug } from '../utils/slug-generator';
 
 @Component({
-  imports: [DatePipe, FormsModule, ConfirmDialog],
+  imports: [DatePipe, FormsModule, ConfirmDialog, AlertBanner],
   templateUrl: './membership.html',
   styleUrl: './membership.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/members/src/app/shared/alert-banner/alert-banner.scss
+++ b/members/src/app/shared/alert-banner/alert-banner.scss
@@ -1,0 +1,45 @@
+:host {
+  display: block;
+  padding: var(--space-s);
+  border-radius: var(--border-radius-md);
+  margin-block-end: var(--space-m);
+}
+
+:host(.success) {
+  background: var(--teal-300);
+  color: var(--brown-700);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+:host(.error) {
+  background: #fdecea;
+  color: var(--color-error, #d93025);
+  font-weight: var(--font-weight-semibold);
+  text-align: center;
+}
+
+:host(.warning) {
+  background: var(--brown-100);
+  border: 2px solid var(--brown-300);
+  padding: var(--space-m) var(--space-l);
+
+  h2 {
+    margin-block-end: var(--space-xs);
+  }
+
+  p {
+    margin-block-end: var(--space-xs);
+
+    &:last-child {
+      margin-block-end: 0;
+    }
+  }
+}
+
+:host(.info) {
+  background: var(--brown-100);
+  border-inline-start: 4px solid var(--brown-400);
+  font-size: var(--step--1);
+  color: var(--brown-500);
+}

--- a/members/src/app/shared/alert-banner/alert-banner.scss
+++ b/members/src/app/shared/alert-banner/alert-banner.scss
@@ -13,7 +13,7 @@
 }
 
 :host(.error) {
-  background: #fdecea;
+  background: color-mix(in oklch, var(--color-error, #d93025) 10%, white);
   color: var(--color-error, #d93025);
   font-weight: var(--font-weight-semibold);
   text-align: center;

--- a/members/src/app/shared/alert-banner/alert-banner.ts
+++ b/members/src/app/shared/alert-banner/alert-banner.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+type AlertVariant = 'success' | 'error' | 'warning' | 'info';
+
+@Component({
+  selector: 'app-alert-banner',
+  template: '<ng-content />',
+  styleUrl: './alert-banner.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class]': 'variant()',
+    '[attr.role]': "variant() === 'error' ? 'alert' : 'status'",
+  },
+})
+export class AlertBanner {
+  variant = input<AlertVariant>('info');
+}

--- a/members/src/app/shared/alert-banner/alert-banner.ts
+++ b/members/src/app/shared/alert-banner/alert-banner.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
-type AlertVariant = 'success' | 'error' | 'warning' | 'info';
+export type AlertVariant = 'success' | 'error' | 'warning' | 'info';
 
 @Component({
   selector: 'app-alert-banner',

--- a/members/src/app/shared/alert-banner/alert-banner.ts
+++ b/members/src/app/shared/alert-banner/alert-banner.ts
@@ -1,6 +1,13 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 
 export type AlertVariant = 'success' | 'error' | 'warning' | 'info';
+
+const ROLE_MAP: Record<AlertVariant, string | undefined> = {
+  error: 'alert',
+  success: 'status',
+  warning: undefined,
+  info: undefined,
+};
 
 @Component({
   selector: 'app-alert-banner',
@@ -9,9 +16,10 @@ export type AlertVariant = 'success' | 'error' | 'warning' | 'info';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class]': 'variant()',
-    '[attr.role]': "variant() === 'error' ? 'alert' : 'status'",
+    '[attr.role]': 'role()',
   },
 })
 export class AlertBanner {
   variant = input<AlertVariant>('info');
+  protected role = computed(() => ROLE_MAP[this.variant()]);
 }

--- a/members/src/app/shared/create-table-sort-state.ts
+++ b/members/src/app/shared/create-table-sort-state.ts
@@ -1,11 +1,11 @@
-import { signal, type WritableSignal } from '@angular/core';
+import { type Signal, signal } from '@angular/core';
 
-type SortDirection = 'asc' | 'desc';
+export type SortDirection = 'asc' | 'desc';
 
-interface TableSortState<TColumn extends string> {
-  sortColumn: WritableSignal<TColumn>;
-  sortDirection: WritableSignal<SortDirection>;
-  handleSort: (column: TColumn) => void;
+export interface TableSortState<TColumn extends string> {
+  sortColumn: Signal<TColumn>;
+  sortDirection: Signal<SortDirection>;
+  handleSort: (column: string) => void;
 }
 
 export function createTableSortState<TColumn extends string>(options: {
@@ -15,14 +15,14 @@ export function createTableSortState<TColumn extends string>(options: {
   const sortColumn = signal<TColumn>(options.defaultColumn);
   const sortDirection = signal<SortDirection>(options.defaultDirection);
 
-  const handleSort = (column: TColumn): void => {
+  function handleSort(column: string): void {
     if (sortColumn() === column) {
       sortDirection.set(sortDirection() === 'asc' ? 'desc' : 'asc');
     } else {
-      sortColumn.set(column);
+      sortColumn.set(column as TColumn);
       sortDirection.set('asc');
     }
-  };
+  }
 
   return { sortColumn, sortDirection, handleSort };
 }

--- a/members/src/app/shared/create-table-sort-state.ts
+++ b/members/src/app/shared/create-table-sort-state.ts
@@ -1,0 +1,28 @@
+import { signal, type WritableSignal } from '@angular/core';
+
+type SortDirection = 'asc' | 'desc';
+
+interface TableSortState<TColumn extends string> {
+  sortColumn: WritableSignal<TColumn>;
+  sortDirection: WritableSignal<SortDirection>;
+  handleSort: (column: TColumn) => void;
+}
+
+export function createTableSortState<TColumn extends string>(options: {
+  defaultColumn: TColumn;
+  defaultDirection: SortDirection;
+}): TableSortState<TColumn> {
+  const sortColumn = signal<TColumn>(options.defaultColumn);
+  const sortDirection = signal<SortDirection>(options.defaultDirection);
+
+  const handleSort = (column: TColumn): void => {
+    if (sortColumn() === column) {
+      sortDirection.set(sortDirection() === 'asc' ? 'desc' : 'asc');
+    } else {
+      sortColumn.set(column);
+      sortDirection.set('asc');
+    }
+  };
+
+  return { sortColumn, sortDirection, handleSort };
+}

--- a/members/src/app/shared/sortable-header/sortable-header.scss
+++ b/members/src/app/shared/sortable-header/sortable-header.scss
@@ -10,4 +10,5 @@
 
 .sort-indicator {
   margin-inline-start: var(--space-3xs);
+  color: var(--teal-500);
 }

--- a/members/src/app/shared/sortable-header/sortable-header.scss
+++ b/members/src/app/shared/sortable-header/sortable-header.scss
@@ -1,0 +1,13 @@
+:host {
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s;
+
+  &:hover {
+    background: var(--brown-200);
+  }
+}
+
+.sort-indicator {
+  margin-inline-start: var(--space-3xs);
+}

--- a/members/src/app/shared/sortable-header/sortable-header.ts
+++ b/members/src/app/shared/sortable-header/sortable-header.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+
+type SortDirection = 'asc' | 'desc';
+
+@Component({
+  selector: 'th[app-sortable-header]',
+  template: `<ng-content />
+    @if (isActive()) {
+      <span class="sort-indicator">{{ direction() === 'asc' ? '↑' : '↓' }}</span>
+    }`,
+  styleUrl: './sortable-header.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'sortable',
+    '(click)': 'sort.emit(column())',
+  },
+})
+export class SortableHeader {
+  column = input.required<string>({ alias: 'app-sortable-header' });
+  activeColumn = input.required<string>();
+  direction = input.required<SortDirection>();
+  sort = output<string>();
+
+  protected isActive = computed(() => this.activeColumn() === this.column());
+}

--- a/members/src/app/shared/sortable-header/sortable-header.ts
+++ b/members/src/app/shared/sortable-header/sortable-header.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
-
-type SortDirection = 'asc' | 'desc';
+import type { SortDirection } from '../create-table-sort-state';
 
 @Component({
   selector: 'th[app-sortable-header]',
@@ -13,6 +12,8 @@ type SortDirection = 'asc' | 'desc';
   host: {
     class: 'sortable',
     '(click)': 'sort.emit(column())',
+    '[attr.aria-sort]':
+      "isActive() ? (direction() === 'asc' ? 'ascending' : 'descending') : 'none'",
   },
 })
 export class SortableHeader {


### PR DESCRIPTION
## Summary

- **AlertBanner component** — shared `<app-alert-banner variant="success|error|warning|info">` with content projection, automatic ARIA roles, and consistent styling. Replaces ~17 duplicated banner instances across 8 components, removing dead `.success-message`, `.error-message`, `.inactive-membership-banner`, `.info-notice` SCSS.
- **`createTableSortState()` utility** — extracts identical sort column/direction signal declarations and toggle logic from 4 table components into a single reusable function.
- **SortableHeader component** — `th[app-sortable-header]` attribute component that encapsulates the sort indicator pattern, replacing 15 identical `@if` blocks across 4 admin tables.

## Test plan

- [x] `bun run build` — Angular production build passes
- [x] `bun run lint` — ESLint clean
- [x] `bun run test` — All 302 tests pass (2 skipped, unchanged)
- [ ] Visual spot-check: admin member detail, unclaimed profile detail, match request detail, message detail pages — success/error/info banners render correctly
- [ ] Visual spot-check: edit profile inactive membership warning banner renders correctly
- [ ] Visual spot-check: all 4 admin tables — sort indicators appear on click and toggle direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)