### PR TITLE
fix: make verify-email endpoint idempotent

### DIFF
--- a/functions/src/members-api/routes/verify-email.test.ts
+++ b/functions/src/members-api/routes/verify-email.test.ts
@@ -117,14 +117,14 @@ describe("POST /:memberId/verify-email (authenticated)", () => {
       expect(body.success).toBe(true);
     });
 
-    it("should return 400 when email is already verified", async () => {
+    it("should return success when email is already verified (idempotent)", async () => {
       const { testApp, request } = setup({ emailAlreadyVerified: true });
 
       const response = await handleRequest(testApp, request);
 
-      expect(response.status).toBe(400);
-      const body = (await response.json()) as { error?: string };
-      expect(body.error).toBe("Email is already verified");
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { success: boolean };
+      expect(body.success).toBe(true);
     });
   });
 

--- a/functions/src/members-api/routes/verify-email.ts
+++ b/functions/src/members-api/routes/verify-email.ts
@@ -2,7 +2,6 @@ import { ERROR_IDS } from "../../constants/error-ids.js";
 import {
   ForbiddenError,
   HttpError,
-  ValidationError,
 } from "../../shared-api/errors/http-error.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { Logger } from "../../shared-api/types/logger.js";
@@ -16,7 +15,7 @@ import type { VerifyEmailService } from "../services/verify-email/interface.js";
  * Uses verifyOwnerOrAdmin for initial auth (consistent with other member routes),
  * then explicitly rejects non-owner tokens to restrict this security-sensitive
  * action to the account holder only.
- * Idempotency guard: rejects requests when the email is already verified.
+ * Idempotent: returns success if the email is already verified.
  */
 export async function verifyEmailLogic({
   memberId,
@@ -44,9 +43,10 @@ export async function verifyEmailLogic({
       throw new ForbiddenError("You can only verify your own email");
     }
 
-    // Idempotency guard: only allow verification for users whose email is not yet verified
+    // Idempotent: if already verified, return success without re-verifying
     if (decodedToken.email_verified === true) {
-      throw new ValidationError("Email is already verified");
+      logger.info("Email already verified, returning success", { memberId });
+      return { success: true };
     }
 
     await verifyEmailService.markEmailVerified(memberId);


### PR DESCRIPTION
## Summary

- Return 200 success instead of 400 error when the verify-email endpoint is called for an already-verified email
- Eliminates noisy console errors during the password reset onboarding flow, where Firebase Auth marks the email as verified before the app calls the endpoint
- Makes the endpoint truly idempotent per REST best practices

## Test plan

- [ ] Run `cd functions && bun test src/members-api/routes/verify-email.test.ts` — all 9 tests pass
- [ ] Test new member onboarding: pay via Stripe, set password, confirm no 400 error in console
- [ ] Test calling verify-email twice for the same user — both return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)