### PR TITLE
fix: keep optimistic profile data during GitHub sync delay

### DIFF
--- a/.claude/rules/angular-tests.md
+++ b/.claude/rules/angular-tests.md
@@ -1,0 +1,6 @@
+- never use `fixture.detectChanges()` directly in unit tests
+- use `TestBed.flushEffects()` from `@angular/core/testing` to flush pending effects after changing signal values from tests
+- when testing behavior driven by `effect()` that reacts to signal changes, cycle the signal through intermediate values (e.g., `'loading'` → `'error'`) and call `TestBed.flushEffects()` after each `.set()` to ensure effects re-trigger
+- use `waitFor` from `@testing-library/angular` after flushing effects to assert DOM updates
+- the `setup()` function's return value includes `fixture` from `render()` — prefer `TestBed.flushEffects()` over `fixture.detectChanges()` for flushing effects
+- when testing components with writable mock signals, type them as `WritableSignal<T>` so tests can call `.set()` to simulate state transitions

--- a/members/e2e/tests/create-profile-flow.spec.ts
+++ b/members/e2e/tests/create-profile-flow.spec.ts
@@ -133,7 +133,7 @@ test.describe('Create Profile → Edit Profile Flow', () => {
     await expect(authenticatedUserPage.getByText('Profile Load Error')).not.toBeVisible();
   });
 
-  test('shows retry button when all auto-retries are exhausted', async ({
+  test('shows sync-pending banner when all auto-retries are exhausted after create', async ({
     authenticatedUserPage,
   }) => {
     await mockMembersRoute(authenticatedUserPage);
@@ -161,12 +161,17 @@ test.describe('Create Profile → Edit Profile Flow', () => {
     // === Create profile and navigate to edit ===
     await fillAndSubmitCreateForm(authenticatedUserPage);
 
-    // === Wait for all auto-retries to exhaust (3 retries × 2s each + buffer) ===
-    await expect(authenticatedUserPage.getByText('Profile Load Error')).toBeVisible({
-      timeout: 15_000,
-    });
+    // === After retries exhaust, form should remain visible with optimistic data ===
+    const editProfilePage = new EditProfilePage(authenticatedUserPage);
+    await editProfilePage.waitForProfileForm();
+    await expect(editProfilePage.titleInput).toHaveValue('Test User');
 
-    // === Retry button should be visible ===
-    await expect(authenticatedUserPage.getByRole('button', { name: /Retry/i })).toBeVisible();
+    // === Sync-pending info banner should appear ===
+    await expect(
+      authenticatedUserPage.getByText(/will appear on the public site shortly/i),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // === Error UI should NOT be shown ===
+    await expect(authenticatedUserPage.getByText('Profile Load Error')).not.toBeVisible();
   });
 });

--- a/members/src/app/edit-profile/edit-profile.html
+++ b/members/src/app/edit-profile/edit-profile.html
@@ -28,6 +28,11 @@
       <p>Visit the <a href="/membership">Membership page</a> to view your account details.</p>
     </app-alert-banner>
   }
+  @if (syncPending()) {
+    <app-alert-banner variant="info">
+      Your profile changes are saved and will appear on the public site shortly.
+    </app-alert-banner>
+  }
   @let profileData = profile();
   <form [formGroup]="profileForm" (ngSubmit)="onSubmit()" class="profile-form">
     <!-- Success Message -->

--- a/members/src/app/edit-profile/edit-profile.spec.ts
+++ b/members/src/app/edit-profile/edit-profile.spec.ts
@@ -61,6 +61,14 @@ describe('EditProfile', () => {
     });
   });
 
+  describe('sync pending state', () => {
+    it('should not show sync-pending banner when profile loads normally', async () => {
+      await setup();
+
+      expect(screen.queryByText(/will appear on the public site shortly/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('form initialization', () => {
     it('should populate form with profile data', async () => {
       await setup();

--- a/members/src/app/edit-profile/edit-profile.spec.ts
+++ b/members/src/app/edit-profile/edit-profile.spec.ts
@@ -1,4 +1,5 @@
-import { signal } from '@angular/core';
+import { type WritableSignal, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -65,6 +66,63 @@ describe('EditProfile', () => {
     it('should not show sync-pending banner when profile loads normally', async () => {
       await setup();
 
+      expect(screen.queryByText(/will appear on the public site shortly/i)).not.toBeInTheDocument();
+    });
+
+    it('should show sync-pending banner when retries exhaust with optimistic data', async () => {
+      const { mockProfileService } = await setup({
+        resourceStatus: 'error',
+        hasOptimisticData: true,
+      });
+
+      // Simulate fast retries exhausting by cycling through loading → error transitions.
+      // First error fires in constructor (autoRetryCount → 1).
+      // Each cycle increments the counter until sync-pending kicks in.
+      for (let i = 0; i < 3; i++) {
+        mockProfileService.profileResource.status.set('loading');
+        TestBed.flushEffects();
+        mockProfileService.profileResource.status.set('error');
+        TestBed.flushEffects();
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText(/will appear on the public site shortly/i)).toBeVisible();
+      });
+    });
+
+    it('should hide sync-pending banner when resource eventually resolves', async () => {
+      const { mockProfileService } = await setup({
+        resourceStatus: 'error',
+        hasOptimisticData: true,
+      });
+
+      // Exhaust auto-retries to trigger sync-pending
+      for (let i = 0; i < 3; i++) {
+        mockProfileService.profileResource.status.set('loading');
+        TestBed.flushEffects();
+        mockProfileService.profileResource.status.set('error');
+        TestBed.flushEffects();
+      }
+
+      await waitFor(() => {
+        expect(screen.getByText(/will appear on the public site shortly/i)).toBeVisible();
+      });
+
+      // Resource finally resolves
+      mockProfileService.profileResource.status.set('resolved');
+      TestBed.flushEffects();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/will appear on the public site shortly/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show error UI when retries exhaust without optimistic data', async () => {
+      await setup({ hasProfile: false });
+
+      expect(screen.getByText('Profile Load Error')).toBeVisible();
       expect(screen.queryByText(/will appear on the public site shortly/i)).not.toBeInTheDocument();
     });
   });
@@ -325,6 +383,8 @@ interface SetupOptions {
   userDocumentLoading?: boolean;
   userHasSlug?: boolean;
   profileResourceLoading?: boolean;
+  resourceStatus?: 'idle' | 'loading' | 'error' | 'resolved';
+  hasOptimisticData?: boolean;
 }
 
 async function setup({
@@ -337,6 +397,8 @@ async function setup({
   userDocumentLoading = false,
   userHasSlug = true,
   profileResourceLoading = false,
+  resourceStatus,
+  hasOptimisticData = false,
 }: SetupOptions = {}) {
   const defaultProfile: ProfileData = {
     title: 'Jane Doe',
@@ -385,15 +447,24 @@ async function setup({
   // unless optimistic data is present (not simulated in these tests)
   const profileSignalValue = profileResourceLoading ? undefined : profileValue;
 
+  // When hasOptimisticData is true, simulate a profile signal that has data
+  // even though the resource is in error state (optimistic data from create/update)
+  const resolvedProfileSignal = hasOptimisticData
+    ? (profileData ?? defaultProfile)
+    : profileSignalValue;
+
   const resolveStatus = (): string => {
+    if (resourceStatus) return resourceStatus;
     if (profileResourceLoading) return 'loading';
     if (!hasProfile && userHasSlug) return 'error';
     if (profileValue !== undefined) return 'resolved';
     return 'idle';
   };
 
+  const statusSignal: WritableSignal<string> = signal(resolveStatus());
+
   const mockProfileService = {
-    profile: signal(profileSignalValue),
+    profile: signal(resolvedProfileSignal),
     profileImageUrl: signal(
       hasProfile && userHasSlug
         ? 'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile'
@@ -405,7 +476,7 @@ async function setup({
       hasValue: vi.fn(() => !profileResourceLoading && profileValue !== undefined),
       value: vi.fn(() => profileValue),
       error: vi.fn(() => (!hasProfile && userHasSlug ? new Error('Profile not found') : undefined)),
-      status: signal(resolveStatus()),
+      status: statusSignal,
       reload: vi.fn(),
     },
     getTagUrl: vi.fn((tag: string) => `/doulas/tag/${tag.toLowerCase().replaceAll(/\s+/g, '-')}`),

--- a/members/src/app/edit-profile/edit-profile.spec.ts
+++ b/members/src/app/edit-profile/edit-profile.spec.ts
@@ -78,7 +78,7 @@ describe('EditProfile', () => {
       // Simulate fast retries exhausting by cycling through loading → error transitions.
       // First error fires in constructor (autoRetryCount → 1).
       // Each cycle increments the counter until sync-pending kicks in.
-      for (let i = 0; i < 3; i++) {
+      for (let index = 0; index < 3; index++) {
         mockProfileService.profileResource.status.set('loading');
         TestBed.flushEffects();
         mockProfileService.profileResource.status.set('error');
@@ -97,7 +97,7 @@ describe('EditProfile', () => {
       });
 
       // Exhaust auto-retries to trigger sync-pending
-      for (let i = 0; i < 3; i++) {
+      for (let index = 0; index < 3; index++) {
         mockProfileService.profileResource.status.set('loading');
         TestBed.flushEffects();
         mockProfileService.profileResource.status.set('error');

--- a/members/src/app/edit-profile/edit-profile.ts
+++ b/members/src/app/edit-profile/edit-profile.ts
@@ -33,7 +33,7 @@ export class EditProfile {
   readonly profileService = inject(ProfileService);
   readonly membershipService = inject(MembershipService);
   private fb = inject(FormBuilder);
-  private destroyReference = inject(DestroyRef);
+  private destroyRef = inject(DestroyRef);
 
   protected profile = this.profileService.profile;
   protected availableTags = PROFILE_TAGS;
@@ -52,12 +52,11 @@ export class EditProfile {
   private autoRetryCount = 0;
   private slowRetryCount = 0;
   private slowRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  private fastRetryTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
-    this.destroyReference.onDestroy(() => {
-      if (this.slowRetryTimer !== undefined) {
-        clearTimeout(this.slowRetryTimer);
-      }
+    this.destroyRef.onDestroy(() => {
+      this.clearTimers();
     });
 
     effect(() => {
@@ -67,46 +66,59 @@ export class EditProfile {
       }
     });
 
-    // Reset sync state when resource successfully resolves
+    // Handle resource status transitions for retry logic and sync-pending state
     effect(() => {
       const status = this.profileService.profileResource.status();
+
       if (status === 'resolved') {
         this.syncPending.set(false);
         this.autoRetryCount = 0;
         this.slowRetryCount = 0;
-        if (this.slowRetryTimer !== undefined) {
-          clearTimeout(this.slowRetryTimer);
-          this.slowRetryTimer = undefined;
+        this.clearTimers();
+      } else if (status === 'error') {
+        if (this.autoRetryCount < MAX_AUTO_RETRIES) {
+          this.autoRetryCount++;
+          this.fastRetryTimer = setTimeout(() => {
+            this.profileService.profileResource.reload();
+          }, RETRY_DELAY_MS);
+        } else if (this.profile() !== undefined) {
+          // Optimistic data exists — the user just created/updated their profile.
+          // Show sync-pending banner and continue slow background retries.
+          this.syncPending.set(true);
+          this.scheduleSlowRetry();
         }
+        // If no optimistic data, fall through to the error UI (genuine failure).
       }
-    });
-
-    effect(() => {
-      const status = this.profileService.profileResource.status();
-      if (status !== 'error') return;
-
-      if (this.autoRetryCount < MAX_AUTO_RETRIES) {
-        this.autoRetryCount++;
-        setTimeout(() => {
-          this.profileService.profileResource.reload();
-        }, RETRY_DELAY_MS);
-      } else if (this.profile() !== undefined) {
-        // Optimistic data exists — the user just created/updated their profile.
-        // Show sync-pending banner and continue slow background retries.
-        this.syncPending.set(true);
-        this.scheduleSlowRetry();
-      }
-      // If no optimistic data, fall through to the error UI (genuine failure).
     });
   }
 
   private scheduleSlowRetry(): void {
-    if (this.slowRetryCount >= MAX_SLOW_RETRIES) return;
+    if (this.slowRetryCount >= MAX_SLOW_RETRIES) {
+      this.syncPending.set(false);
+      this.infoMessage.set(
+        'Your changes were saved but may take longer than usual to sync. Try refreshing in a few minutes.',
+      );
+      return;
+    }
 
+    if (this.slowRetryTimer !== undefined) {
+      clearTimeout(this.slowRetryTimer);
+    }
     this.slowRetryTimer = setTimeout(() => {
       this.slowRetryCount++;
       this.profileService.profileResource.reload();
     }, SLOW_RETRY_DELAY_MS);
+  }
+
+  private clearTimers(): void {
+    if (this.slowRetryTimer !== undefined) {
+      clearTimeout(this.slowRetryTimer);
+      this.slowRetryTimer = undefined;
+    }
+    if (this.fastRetryTimer !== undefined) {
+      clearTimeout(this.fastRetryTimer);
+      this.fastRetryTimer = undefined;
+    }
   }
 
   protected retryLoadProfile(): void {

--- a/members/src/app/edit-profile/edit-profile.ts
+++ b/members/src/app/edit-profile/edit-profile.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   signal,
@@ -19,6 +20,8 @@ import {
 
 const MAX_AUTO_RETRIES = 3;
 const RETRY_DELAY_MS = 2000;
+const SLOW_RETRY_DELAY_MS = 15_000;
+const MAX_SLOW_RETRIES = 10;
 
 @Component({
   imports: [ReactiveFormsModule, AlertBanner],
@@ -30,6 +33,7 @@ export class EditProfile {
   readonly profileService = inject(ProfileService);
   readonly membershipService = inject(MembershipService);
   private fb = inject(FormBuilder);
+  private destroyReference = inject(DestroyRef);
 
   protected profile = this.profileService.profile;
   protected availableTags = PROFILE_TAGS;
@@ -39,14 +43,23 @@ export class EditProfile {
   protected errorMessage = signal('');
   protected successMessage = signal('');
   protected infoMessage = signal('');
+  protected syncPending = signal(false);
 
   protected isMembershipInactive = computed(() => {
     const user = this.membershipService.userDocument();
     return user !== undefined && !user.membershipActive;
   });
   private autoRetryCount = 0;
+  private slowRetryCount = 0;
+  private slowRetryTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
+    this.destroyReference.onDestroy(() => {
+      if (this.slowRetryTimer !== undefined) {
+        clearTimeout(this.slowRetryTimer);
+      }
+    });
+
     effect(() => {
       const profile = this.profile();
       if (profile && !this.profileForm.dirty) {
@@ -54,17 +67,46 @@ export class EditProfile {
       }
     });
 
+    // Reset sync state when resource successfully resolves
     effect(() => {
       const status = this.profileService.profileResource.status();
-      if (status === 'error' && this.autoRetryCount < MAX_AUTO_RETRIES) {
+      if (status === 'resolved') {
+        this.syncPending.set(false);
+        this.autoRetryCount = 0;
+        this.slowRetryCount = 0;
+        if (this.slowRetryTimer !== undefined) {
+          clearTimeout(this.slowRetryTimer);
+          this.slowRetryTimer = undefined;
+        }
+      }
+    });
+
+    effect(() => {
+      const status = this.profileService.profileResource.status();
+      if (status !== 'error') return;
+
+      if (this.autoRetryCount < MAX_AUTO_RETRIES) {
         this.autoRetryCount++;
         setTimeout(() => {
           this.profileService.profileResource.reload();
         }, RETRY_DELAY_MS);
-      } else if (status === 'error' && this.autoRetryCount >= MAX_AUTO_RETRIES) {
-        this.profileService.clearOptimisticProfile();
+      } else if (this.profile() !== undefined) {
+        // Optimistic data exists — the user just created/updated their profile.
+        // Show sync-pending banner and continue slow background retries.
+        this.syncPending.set(true);
+        this.scheduleSlowRetry();
       }
+      // If no optimistic data, fall through to the error UI (genuine failure).
     });
+  }
+
+  private scheduleSlowRetry(): void {
+    if (this.slowRetryCount >= MAX_SLOW_RETRIES) return;
+
+    this.slowRetryTimer = setTimeout(() => {
+      this.slowRetryCount++;
+      this.profileService.profileResource.reload();
+    }, SLOW_RETRY_DELAY_MS);
   }
 
   protected retryLoadProfile(): void {

--- a/members/src/app/services/profile.service.ts
+++ b/members/src/app/services/profile.service.ts
@@ -118,7 +118,9 @@ export class ProfileService {
     try {
       await firstValueFrom(this.http.put<{ success: boolean }>(`/api/profiles/${slug}`, data));
 
-      // Only reload on success
+      // Set optimistic data so the form shows submitted values even if
+      // the reload 404s due to GitHub eventual consistency.
+      this.optimisticProfile.set(data);
       this.profileResource.reload();
     } catch (error: unknown) {
       console.error('Profile update failed:', {
@@ -215,10 +217,6 @@ export class ProfileService {
 
   private async fetchProfileFromServer(slug: string): Promise<ProfileData> {
     return firstValueFrom(this.http.get<ProfileData>(`/api/profiles/${slug}`));
-  }
-
-  clearOptimisticProfile(): void {
-    this.optimisticProfile.set(undefined);
   }
 
   getTagUrl(tag: string): string {


### PR DESCRIPTION
## Summary

- **Keeps optimistic profile data alive** after create/update when GitHub has not synced yet, instead of clearing it and showing Profile Load Error
- **Sets optimistic data in updateProfile()** (previously only createProfileContent() did this), so edits also survive reload 404s
- **Adds sync-pending info banner** when fast retries exhaust but optimistic data exists
- **Adds slow background retries** (15s intervals, up to 10 attempts) to eventually sync with the server without user intervention
- **Removes clearOptimisticProfile()** — the existing effect that clears optimistic data on successful resource load is the correct cleanup path

## Test plan

- [x] Angular production build passes
- [x] Unit tests: 30/30 pass (includes new sync-pending banner test)
- [x] E2E tests: 3/3 pass (updated exhausted-retries test expects form + info banner)
- [ ] Manual test: create a profile, verify form stays visible with info banner if GET 404s persist

Generated with [Claude Code](https://claude.com/claude-code)