### PR TITLE
fix: prevent spurious GET on /profile/create page

### DIFF
--- a/members/src/app/create-profile/create-profile.spec.ts
+++ b/members/src/app/create-profile/create-profile.spec.ts
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { MembershipService, type Member } from '../services/membership.service';
-import { ProfileService } from '../services/profile.service';
+import { CreateProfileService } from '../services/create-profile.service';
 import { CreateProfile } from './create-profile';
 
 describe('CreateProfile', () => {
@@ -118,7 +118,7 @@ describe('CreateProfile', () => {
 
   describe('form submission', () => {
     it('should call createProfileContent with correct data', async () => {
-      const { user, mockProfileService } = await setup();
+      const { user, mockCreateProfileService } = await setup();
 
       const bioInput = screen.getByLabelText('Bio *');
       await user.type(bioInput, 'My bio');
@@ -130,7 +130,7 @@ describe('CreateProfile', () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(mockProfileService.createProfileContent).toHaveBeenCalledWith(
+        expect(mockCreateProfileService.createProfileContent).toHaveBeenCalledWith(
           expect.objectContaining({
             title: 'Test User',
             bio: 'My bio',
@@ -291,7 +291,7 @@ async function setup({
     userDocument: signal(mockMember),
   };
 
-  const mockProfileService = {
+  const mockCreateProfileService = {
     createProfileContent: vi.fn().mockImplementation(async () => {
       if (delayCreate) {
         await new Promise((resolve) => setTimeout(resolve, 100));
@@ -309,8 +309,8 @@ async function setup({
   const result = await render(CreateProfile, {
     providers: [
       {
-        provide: ProfileService,
-        useValue: mockProfileService,
+        provide: CreateProfileService,
+        useValue: mockCreateProfileService,
       },
       {
         provide: MembershipService,
@@ -326,5 +326,5 @@ async function setup({
   // IMPORTANT: Call userEvent.setup() AFTER render() to avoid ApplicationRef destroyed warnings
   const user = userEvent.setup();
 
-  return { ...result, user, mockProfileService, mockMembershipService, mockRouter };
+  return { ...result, user, mockCreateProfileService, mockMembershipService, mockRouter };
 }

--- a/members/src/app/create-profile/create-profile.ts
+++ b/members/src/app/create-profile/create-profile.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@ang
 import { FormArray, FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MembershipService } from '../services/membership.service';
-import { ProfileService } from '../services/profile.service';
+import { CreateProfileService } from '../services/create-profile.service';
 import { AlertBanner } from '../shared/alert-banner/alert-banner';
 import { createProfileFormGroup, PROFILE_TAGS } from '../shared/profile-form/profile-form-config';
 import {
@@ -18,7 +18,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CreateProfile {
-  private profileService = inject(ProfileService);
+  private createProfileService = inject(CreateProfileService);
   private membershipService = inject(MembershipService);
   private fb = inject(FormBuilder);
   private router = inject(Router);
@@ -54,7 +54,7 @@ export class CreateProfile {
 
     try {
       const profileData = extractProfileData(this.profileForm);
-      await this.profileService.createProfileContent(profileData);
+      await this.createProfileService.createProfileContent(profileData);
       this.successMessage.set('Profile created successfully!');
 
       // Navigate to edit mode after successful creation

--- a/members/src/app/services/create-profile.service.ts
+++ b/members/src/app/services/create-profile.service.ts
@@ -1,0 +1,85 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { type ProfileData } from '../types/profile-data';
+import { MembershipService } from './membership.service';
+
+/**
+ * Handles profile creation (HTTP POST) and stores optimistic data.
+ *
+ * Separated from ProfileService so that the create-profile page can inject
+ * this lightweight service without triggering ProfileService's profileResource,
+ * which would fire a spurious GET for a profile that doesn't exist yet.
+ *
+ * ProfileService injects this service to read the optimistic data.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CreateProfileService {
+  private http = inject(HttpClient);
+  private membershipService = inject(MembershipService);
+
+  /**
+   * Optimistic profile data set after successful creation.
+   * Used to render the edit form immediately without waiting for GitHub API.
+   */
+  readonly optimisticProfile = signal<ProfileData | undefined>(undefined);
+
+  clearOptimisticProfile(): void {
+    this.optimisticProfile.set(undefined);
+  }
+
+  async createProfileContent(data: ProfileData): Promise<void> {
+    const slug = this.membershipService.userDocument()?.slug;
+    if (!slug) {
+      throw new Error('User slug not found. Please refresh the page.');
+    }
+
+    try {
+      await firstValueFrom(this.http.post<{ success: boolean }>(`/api/profiles/${slug}`, data));
+
+      // Store submitted data as optimistic profile so the edit page can render
+      // immediately without waiting for GitHub API eventual consistency.
+      this.optimisticProfile.set(data);
+    } catch (error: unknown) {
+      console.error('Profile creation failed:', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      if (error instanceof HttpErrorResponse) {
+        switch (error.status) {
+          case 401: {
+            throw new Error('You must be signed in to create a profile.');
+          }
+
+          case 403: {
+            if (error.error?.error?.includes('slug')) {
+              throw new Error(
+                'You must set up your profile slug first. Please return to the membership page.',
+              );
+            }
+            if (error.error?.error?.includes('membership')) {
+              throw new Error('Active membership required to create a profile.');
+            }
+            throw new Error('You do not have permission to create a profile.');
+          }
+
+          case 409: {
+            throw new Error('Profile already exists. Try refreshing the page.');
+          }
+
+          case 429: {
+            throw new Error('Too many requests. Please try again in a few minutes.');
+          }
+
+          case 504: {
+            throw new Error('Request timed out. Please check your connection and try again.');
+          }
+        }
+      }
+
+      throw new Error('Failed to create profile. Please try again or contact support.');
+    }
+  }
+}

--- a/members/src/app/services/profile.service.ts
+++ b/members/src/app/services/profile.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, computed, effect, inject, resource, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { type ProfileData } from '../types/profile-data';
+import { CreateProfileService } from './create-profile.service';
 import { MembershipService } from './membership.service';
 
 const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
@@ -20,6 +21,7 @@ function buildImageKitDisplayUrl(slug: string, width: number, height: number): s
 export class ProfileService {
   private http = inject(HttpClient);
   private membershipService = inject(MembershipService);
+  private createProfileService = inject(CreateProfileService);
 
   /**
    * Whether the image actually exists on ImageKit (server-side check via HEAD request).
@@ -28,12 +30,6 @@ export class ProfileService {
   private readonly imageExistsOnServer = signal<boolean | undefined>(undefined);
 
   private readonly imageCacheBust = signal(Date.now());
-
-  /**
-   * Optimistic profile data set after successful creation.
-   * Used to render the edit form immediately without waiting for GitHub API.
-   */
-  private readonly optimisticProfile = signal<ProfileData | undefined>(undefined);
 
   constructor() {
     // Clean up any leftover optimistic state from the old implementation
@@ -46,7 +42,7 @@ export class ProfileService {
     // Clear optimistic data once the resource successfully loads from the server
     effect(() => {
       if (this.profileResource.hasValue()) {
-        this.optimisticProfile.set(undefined);
+        this.createProfileService.clearOptimisticProfile();
       }
     });
 
@@ -79,7 +75,7 @@ export class ProfileService {
   /** Profile data — prefers optimistic data after creation, falls back to server data. */
   readonly profile = computed((): ProfileData | undefined => {
     return (
-      this.optimisticProfile() ??
+      this.createProfileService.optimisticProfile() ??
       (this.profileResource.hasValue() ? this.profileResource.value() : undefined)
     );
   });
@@ -120,7 +116,7 @@ export class ProfileService {
 
       // Set optimistic data so the form shows submitted values even if
       // the reload 404s due to GitHub eventual consistency.
-      this.optimisticProfile.set(data);
+      this.createProfileService.optimisticProfile.set(data);
       this.profileResource.reload();
     } catch (error: unknown) {
       console.error('Profile update failed:', {
@@ -159,59 +155,6 @@ export class ProfileService {
       }
 
       throw new Error('Failed to update profile. Please try again.');
-    }
-  }
-
-  async createProfileContent(data: ProfileData): Promise<void> {
-    const slug = this.membershipService.userDocument()?.slug;
-    if (!slug) {
-      throw new Error('User slug not found. Please refresh the page.');
-    }
-
-    try {
-      await firstValueFrom(this.http.post<{ success: boolean }>(`/api/profiles/${slug}`, data));
-
-      // Store submitted data as optimistic profile so the edit page can render
-      // immediately without waiting for GitHub API eventual consistency.
-      this.optimisticProfile.set(data);
-    } catch (error: unknown) {
-      console.error('Profile creation failed:', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-
-      if (error instanceof HttpErrorResponse) {
-        switch (error.status) {
-          case 401: {
-            throw new Error('You must be signed in to create a profile.');
-          }
-
-          case 403: {
-            if (error.error?.error?.includes('slug')) {
-              throw new Error(
-                'You must set up your profile slug first. Please return to the membership page.',
-              );
-            }
-            if (error.error?.error?.includes('membership')) {
-              throw new Error('Active membership required to create a profile.');
-            }
-            throw new Error('You do not have permission to create a profile.');
-          }
-
-          case 409: {
-            throw new Error('Profile already exists. Try refreshing the page.');
-          }
-
-          case 429: {
-            throw new Error('Too many requests. Please try again in a few minutes.');
-          }
-
-          case 504: {
-            throw new Error('Request timed out. Please check your connection and try again.');
-          }
-        }
-      }
-
-      throw new Error('Failed to create profile. Please try again or contact support.');
     }
   }
 


### PR DESCRIPTION
## Summary

- Extracts `CreateProfileService` from `ProfileService` so the create-profile page doesn't trigger `ProfileService`'s `profileResource`, which fires a `GET /api/profiles/{slug}` for a profile that doesn't exist yet (404)
- `CreateProfileService` holds only the HTTP POST logic and the `optimisticProfile` signal — no `resource()` that would trigger a GET
- `ProfileService` now injects `CreateProfileService` to read optimistic data, preserving the existing optimistic-profile-after-creation behavior

## Test plan

- [x] All 301 Angular unit tests pass
- [x] Angular production build succeeds
- [ ] Navigate to `/profile/create` as a new member and verify no `GET /api/profiles/{slug}` request fires
- [ ] Create a profile and verify navigation to `/profile` shows the optimistic data immediately
- [ ] Edit an existing profile and verify optimistic data still works during GitHub sync delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)