### PR TITLE
feat: add profile preview page

### DIFF
--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -67,6 +67,12 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'profile/preview',
+    loadComponent: () =>
+      import('./profile-preview-page/profile-preview-page').then((m) => m.ProfilePreviewPage),
+    ...canActivate(redirectUnauthorizedToSignIn),
+  },
+  {
     path: 'profile',
     loadComponent: () => import('./edit-profile/edit-profile').then((m) => m.EditProfile),
     ...canActivate(redirectUnauthorizedToSignIn),

--- a/members/src/app/edit-profile/edit-profile.html
+++ b/members/src/app/edit-profile/edit-profile.html
@@ -1,5 +1,10 @@
 <h1>Edit Profile</h1>
 
+<nav class="profile-nav">
+  <a href="/profile/preview">Preview Profile</a>
+  <a href="/profile/image">Edit Profile Image</a>
+</nav>
+
 @let profileResource = profileService.profileResource;
 @let user = membershipService.userDocument();
 
@@ -200,7 +205,7 @@
       </div>
     </fieldset>
 
-    <!-- Profile Image Link -->
+    <!-- Profile Image -->
     <div class="form-group">
       <span class="form__label">Profile Image</span>
       @if (profileService.profileImageUrl()) {
@@ -220,7 +225,6 @@
           No custom profile image set. A default placeholder is shown on your public profile.
         </p>
       }
-      <a href="/profile/image">Edit Profile Image</a>
     </div>
 
     <!-- Form Actions -->

--- a/members/src/app/edit-profile/edit-profile.scss
+++ b/members/src/app/edit-profile/edit-profile.scss
@@ -5,6 +5,12 @@
   container: profileform / inline-size;
 }
 
+.profile-nav {
+  display: flex;
+  gap: var(--space-md);
+  margin-block-end: var(--space-md);
+}
+
 // Profile Image Preview
 .profile-image-preview {
   width: 200px;

--- a/members/src/app/profile-preview-page/profile-preview-page.html
+++ b/members/src/app/profile-preview-page/profile-preview-page.html
@@ -1,0 +1,27 @@
+<nav>
+  <a routerLink="/profile">Back to Edit Profile</a>
+</nav>
+
+<h1>Profile Preview</h1>
+
+@let user = membershipService.userDocument();
+
+@if (!user) {
+  <p>Loading your profile...</p>
+} @else if (!user.slug) {
+  <app-alert-banner variant="warning">
+    <h2>Profile Setup Required</h2>
+    <p>You don't have a doula profile set up yet.</p>
+    <p>Visit the <a href="/membership">Membership page</a> for more information.</p>
+  </app-alert-banner>
+} @else if (profile()) {
+  <app-profile-preview [profile]="profile()!" [imageUrl]="profileImageUrl()" />
+} @else if (profileResource.isLoading()) {
+  <p>Loading your profile...</p>
+} @else {
+  <app-alert-banner variant="error">
+    <h2>Profile Load Error</h2>
+    <p>We encountered an issue loading your profile.</p>
+    <button class="button button--primary" (click)="retryLoadProfile()">Retry</button>
+  </app-alert-banner>
+}

--- a/members/src/app/profile-preview-page/profile-preview-page.scss
+++ b/members/src/app/profile-preview-page/profile-preview-page.scss
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+
+nav {
+  margin-block-end: var(--space-sm);
+}

--- a/members/src/app/profile-preview-page/profile-preview-page.ts
+++ b/members/src/app/profile-preview-page/profile-preview-page.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MembershipService } from '../services/membership.service';
+import { ProfileService } from '../services/profile.service';
+import { AlertBanner } from '../shared/alert-banner/alert-banner';
+import { ProfilePreview } from '../shared/profile-preview/profile-preview';
+
+@Component({
+  imports: [ProfilePreview, AlertBanner, RouterLink],
+  templateUrl: './profile-preview-page.html',
+  styleUrl: './profile-preview-page.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfilePreviewPage {
+  protected readonly profileService = inject(ProfileService);
+  protected readonly membershipService = inject(MembershipService);
+
+  protected readonly profile = this.profileService.profile;
+  protected readonly profileImageUrl = this.profileService.profileImageUrl;
+  protected readonly profileResource = this.profileService.profileResource;
+
+  constructor() {
+    this.profileService.loadProfile();
+  }
+
+  protected retryLoadProfile(): void {
+    this.profileService.profileResource.reload();
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new `/profile/preview` route that renders the existing `ProfilePreview` component with the user's saved profile data
- Add navigation links ("Preview Profile" and "Edit Profile Image") at the top of the edit profile page
- Remove the duplicate "Edit Profile Image" link from the Profile Image section since it's now in the top nav

## Test plan

- [ ] Navigate to `/profile` (edit profile) — verify "Preview Profile" and "Edit Profile Image" links appear at the top
- [ ] Click "Preview Profile" — verify the profile preview page loads with the user's data
- [ ] Click "Back to Edit Profile" on the preview page — verify navigation back to edit profile
- [ ] Verify loading, error, and no-profile states render correctly on the preview page
- [ ] Angular build passes (`cd members && bun run build`)
- [ ] All 356 existing tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)