### PR TITLE
fix: match profile preview styling to Hugo doula profile pages

### DIFF
--- a/members/src/app/profile-preview-page/profile-preview-page.html
+++ b/members/src/app/profile-preview-page/profile-preview-page.html
@@ -2,8 +2,6 @@
   <a routerLink="/profile">Back to Edit Profile</a>
 </nav>
 
-<h1>Profile Preview</h1>
-
 @let user = membershipService.userDocument();
 
 @if (!user) {

--- a/members/src/app/profile-preview-page/profile-preview-page.scss
+++ b/members/src/app/profile-preview-page/profile-preview-page.scss
@@ -3,5 +3,10 @@
 }
 
 nav {
-  margin-block-end: var(--space-sm);
+  margin-block-end: var(--space-s);
+}
+
+app-profile-preview {
+  margin-block-start: var(--space-xl);
+  padding-block-end: var(--space-xl);
 }

--- a/members/src/app/shared/profile-preview/profile-preview.html
+++ b/members/src/app/shared/profile-preview/profile-preview.html
@@ -1,17 +1,16 @@
-<section class="title-section">
-  <div class="title-header">
-    <h2 class="profile-title">{{ profile().title }}</h2>
-    @if (showEditLinks()) {
-      <button
-        type="button"
-        class="edit-link"
-        (click)="editSection.emit('personal')"
-        aria-label="Edit personal info"
-      >
-        Edit
-      </button>
-    }
-  </div>
+<section class="title">
+  <h1>{{ profile().title }}</h1>
+
+  @if (showEditLinks()) {
+    <button
+      type="button"
+      class="edit-link"
+      (click)="editSection.emit('personal')"
+      aria-label="Edit personal info"
+    >
+      Edit
+    </button>
+  }
 
   @if (profile().credentials) {
     <p class="credentials">{{ profile().credentials }}</p>
@@ -42,58 +41,54 @@
     </button>
   }
 
-  @if (profile().tags?.length) {
-    <div class="tags-section">
-      @if (showEditLinks()) {
-        <button
-          type="button"
-          class="edit-link"
-          (click)="editSection.emit('tags')"
-          aria-label="Edit services"
-        >
-          Edit
-        </button>
-      }
+  <div class="tags">
+    @if (showEditLinks() && profile().tags?.length) {
+      <button
+        type="button"
+        class="edit-link"
+        (click)="editSection.emit('tags')"
+        aria-label="Edit services"
+      >
+        Edit
+      </button>
+    }
+    @if (profile().tags?.length) {
       <ul class="tag-group">
         @for (tag of profile().tags; track tag) {
           <li class="tag">{{ tag }}</li>
         }
       </ul>
-    </div>
-  }
+    }
+  </div>
 </section>
 
 <section class="bio">
-  <div class="bio-header">
-    @if (showEditLinks()) {
-      <button
-        type="button"
-        class="edit-link"
-        (click)="editSection.emit('bio')"
-        aria-label="Edit bio"
-      >
-        Edit
-      </button>
-    }
-  </div>
+  @if (showEditLinks()) {
+    <button
+      type="button"
+      class="edit-link"
+      (click)="editSection.emit('bio')"
+      aria-label="Edit bio"
+    >
+      Edit
+    </button>
+  }
   <p class="bio-text">{{ profile().bio }}</p>
 </section>
 
 @if (profile().contact) {
   <section class="contact-info">
-    <div class="contact-header">
-      <h3>{{ profile().contact?.business_name || 'Contact Information' }}</h3>
-      @if (showEditLinks()) {
-        <button
-          type="button"
-          class="edit-link"
-          (click)="editSection.emit('contact')"
-          aria-label="Edit contact info"
-        >
-          Edit
-        </button>
-      }
-    </div>
+    <h3>{{ profile().contact?.business_name || 'Contact Information' }}</h3>
+    @if (showEditLinks()) {
+      <button
+        type="button"
+        class="edit-link"
+        (click)="editSection.emit('contact')"
+        aria-label="Edit contact info"
+      >
+        Edit
+      </button>
+    }
     <ul>
       @if (profile().contact?.website) {
         <li>

--- a/members/src/app/shared/profile-preview/profile-preview.scss
+++ b/members/src/app/shared/profile-preview/profile-preview.scss
@@ -1,31 +1,27 @@
-// Profile preview styles matching the Hugo doula profile layout.
+// Profile preview styles matching the Hugo doula-profile.scss layout exactly.
 
 :host {
   display: grid;
   grid-template-columns: 1fr;
   align-content: start;
-  gap: var(--space-m);
 }
 
-.title-header,
-.bio-header,
-.contact-header {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-s);
-}
-
-.profile-title {
-  font-size: var(--step-4);
-  margin: 0;
-  text-align: left;
+.title {
+  h1 {
+    text-align: left;
+    font-size: var(--step-4);
+    margin: 0;
+  }
 }
 
 .credentials {
   font-size: var(--step--1);
   font-weight: 300;
   font-variation-settings: 'slnt' -12;
-  margin: 0;
+}
+
+.credentials:empty {
+  display: none;
 }
 
 .pronouns {
@@ -36,6 +32,10 @@
 
 .headshot {
   padding-block-end: var(--space-l);
+}
+
+.headshot .tag-group {
+  justify-content: center;
 }
 
 .headshot__image {
@@ -72,7 +72,7 @@
   padding: 0;
   margin: 0;
   width: 100%;
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 .tag {
@@ -85,12 +85,6 @@
   font-size: var(--step--1);
 }
 
-.tags-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs);
-}
-
 .bio-text {
   max-width: 60ch;
   white-space: pre-wrap;
@@ -99,9 +93,10 @@
 .contact-info {
   overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 
   h3 {
-    margin: 0;
+    margin-block-start: var(--space-s);
   }
 }
 
@@ -124,7 +119,11 @@
   li {
     display: flex;
     gap: var(--space-2xs);
-    align-items: center;
+    align-items: self-end;
+  }
+
+  span {
+    align-self: baseline;
   }
 }
 
@@ -149,7 +148,7 @@
   }
 }
 
-@container profileform (min-width: 35em) {
+@container (min-width: 35em) {
   :host {
     column-gap: var(--space-s);
     grid-template-columns: minmax(300px, 1fr) 1fr;
@@ -171,11 +170,17 @@
     grid-area: contact-info;
   }
 
-  .title-section {
+  .title {
     grid-area: title;
   }
 
   .bio {
     grid-area: bio;
+  }
+}
+
+@container (min-width: 78rem) {
+  :host {
+    grid-template-columns: 600px 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Aligns the Angular `/profile/preview` page with the Hugo doula profile pages so they render identically
- Uses `<h1>` for profile name, removes separate page heading, matches Hugo's CSS grid layout, container queries, tag centering, contact spacing, and responsive breakpoints
- Flattens HTML structure by removing unnecessary wrapper divs to match Hugo's template

## Test plan
- [ ] Visit `/profile/preview` in the members app and compare against a Hugo doula profile page — layout, spacing, headings, tag placement, and contact section should match
- [ ] Verify the create-profile wizard preview step still renders correctly with edit links
- [ ] Test responsive behavior: single-column on small screens, two-column at 35em, wider headshot at 78rem

🤖 Generated with [Claude Code](https://claude.com/claude-code)