### PR TITLE
fix profile webhook notification payloads

### DIFF
--- a/.github/workflows/hugo-hosting-merge.yml
+++ b/.github/workflows/hugo-hosting-merge.yml
@@ -46,13 +46,13 @@ jobs:
         if: >-
           success() &&
           github.event_name == 'repository_dispatch' &&
-          github.event.client_payload.commitMessage
+          github.event.client_payload.notificationType
         run: |
           curl -s -X POST https://doulacooperative.com/api/profile-webhook \
             -H "Content-Type: application/json" \
             -d '{
               "slug": "${{ github.event.client_payload.slug }}",
-              "commitMessage": "${{ github.event.client_payload.commitMessage }}",
+              "notificationType": "${{ github.event.client_payload.notificationType }}",
               "commitSha": "${{ github.sha }}",
               "secret": "${{ secrets.DEPLOY_WEBHOOK_SECRET }}"
             }'

--- a/.github/workflows/hugo-hosting-merge.yml
+++ b/.github/workflows/hugo-hosting-merge.yml
@@ -42,18 +42,3 @@ jobs:
           channelId: live
           projectId: doula-cooperative
           target: main-site
-      - name: Notify Profile Updates
-        if: >-
-          success() &&
-          github.event_name == 'repository_dispatch' &&
-          github.event.client_payload.notificationType
-        run: |
-          curl -s -X POST https://doulacooperative.com/api/profile-webhook \
-            -H "Content-Type: application/json" \
-            -d '{
-              "slug": "${{ github.event.client_payload.slug }}",
-              "notificationType": "${{ github.event.client_payload.notificationType }}",
-              "commitSha": "${{ github.sha }}",
-              "secret": "${{ secrets.DEPLOY_WEBHOOK_SECRET }}"
-            }'
-        continue-on-error: true

--- a/.github/workflows/hugo-hosting-merge.yml
+++ b/.github/workflows/hugo-hosting-merge.yml
@@ -42,3 +42,17 @@ jobs:
           channelId: live
           projectId: doula-cooperative
           target: main-site
+      - name: Notify Profile Updates
+        if: >-
+          success() &&
+          github.event_name == 'repository_dispatch' &&
+          github.event.client_payload.notificationType
+        run: |
+          curl -s -X POST https://doulacooperative.com/api/profile-webhook \
+            -H "Content-Type: application/json" \
+            -d '{
+              "slug": "${{ github.event.client_payload.slug }}",
+              "notificationType": "${{ github.event.client_payload.notificationType }}",
+              "secret": "${{ secrets.DEPLOY_WEBHOOK_SECRET }}"
+            }'
+        continue-on-error: true

--- a/functions/src/admin-members-api/services/toggle-profile-draft.ts
+++ b/functions/src/admin-members-api/services/toggle-profile-draft.ts
@@ -69,7 +69,7 @@ export async function toggleProfileDraft(options: {
       await triggerHugoRebuild({
         slug,
         action: newDraft ? "draft" : "publish",
-        notificationType: newDraft ? undefined : "publish",
+        ...(!newDraft && { notificationType: "publish" }),
       });
       hugoRebuildTriggered = true;
     } catch (error) {

--- a/functions/src/admin-members-api/services/toggle-profile-draft.ts
+++ b/functions/src/admin-members-api/services/toggle-profile-draft.ts
@@ -69,6 +69,7 @@ export async function toggleProfileDraft(options: {
       await triggerHugoRebuild({
         slug,
         action: newDraft ? "draft" : "publish",
+        notificationType: newDraft ? undefined : "publish",
       });
       hugoRebuildTriggered = true;
     } catch (error) {

--- a/functions/src/profile-webhook-api/routes/handle-webhook.test.ts
+++ b/functions/src/profile-webhook-api/routes/handle-webhook.test.ts
@@ -6,7 +6,6 @@ describe("POST /", () => {
   interface SetupOptions {
     body?: {
       notificationType?: string;
-      commitSha?: string;
       slug?: string;
       secret?: string;
     };
@@ -19,7 +18,6 @@ describe("POST /", () => {
   function setup({
     body = {
       notificationType: "publish",
-      commitSha: "abc123",
       slug: "jane-doe",
       secret: "test-secret",
     },
@@ -88,7 +86,6 @@ describe("POST /", () => {
     const { testApp, request } = setup({
       body: {
         notificationType: "update",
-        commitSha: "abc123",
         slug: "jane-doe",
         secret: "test-secret",
       },
@@ -107,10 +104,101 @@ describe("POST /", () => {
     expect(responseBody.notified).toBe(true);
   });
 
+  it("should return 200 and notified:true for valid image-update payload", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "image-update",
+        slug: "jane-doe",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(true);
+  });
+
+  it("should return 200 and notified:true for valid image-delete payload", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "image-delete",
+        slug: "jane-doe",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(true);
+  });
+
+  it("should return 200 with not_single_profile when slug is empty", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "update",
+        slug: "",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+      reason?: string;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(false);
+    expect(responseBody.reason).toBe("not_single_profile");
+  });
+
+  it("should return 200 with not_profile_related for unsupported notification type", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "delete",
+        slug: "jane-doe",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+      reason?: string;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(false);
+    expect(responseBody.reason).toBe("not_profile_related");
+  });
+
   it("should return 200 with invalid_payload when notificationType is missing", async () => {
     const { testApp, request } = setup({
       body: {
-        commitSha: "abc123",
         slug: "jane-doe",
         secret: "test-secret",
       },
@@ -129,6 +217,25 @@ describe("POST /", () => {
     expect(responseBody.received).toBe(true);
     expect(responseBody.notified).toBe(false);
     expect(responseBody.reason).toBe("invalid_payload");
+  });
+
+  it("should return 401 for missing secret", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "publish",
+        slug: "jane-doe",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(401);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      error?: string;
+    };
+    expect(responseBody.status).toBe("error");
+    expect(responseBody.error).toBe("Unauthorized");
   });
 
   it("should return 401 for invalid secret", async () => {

--- a/functions/src/profile-webhook-api/routes/handle-webhook.test.ts
+++ b/functions/src/profile-webhook-api/routes/handle-webhook.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, mock } from "bun:test";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import { createProfileWebhookTestPlugin } from "../test-utils/create-profile-webhook-test-plugin.js";
+
+describe("POST /", () => {
+  interface SetupOptions {
+    body?: {
+      notificationType?: string;
+      commitSha?: string;
+      slug?: string;
+      secret?: string;
+    };
+    deployWebhookSecret?: string | null;
+    invalidSecret?: boolean;
+    memberNotFound?: boolean;
+    emailFails?: boolean;
+  }
+
+  function setup({
+    body = {
+      notificationType: "publish",
+      commitSha: "abc123",
+      slug: "jane-doe",
+      secret: "test-secret",
+    },
+    deployWebhookSecret = "test-secret",
+    invalidSecret = false,
+    memberNotFound = false,
+    emailFails = false,
+  }: SetupOptions = {}) {
+    if (deployWebhookSecret === null) {
+      delete process.env["DEPLOY_WEBHOOK_SECRET"];
+    } else {
+      process.env["DEPLOY_WEBHOOK_SECRET"] = deployWebhookSecret;
+    }
+
+    const testApp = createProfileWebhookTestPlugin({
+      profileWebhookService: {
+        verifySecret: mock(() => !invalidSecret),
+        findMemberBySlug: mock(({ slug }: { slug: string }) => {
+          if (memberNotFound) {
+            return Promise.resolve(undefined);
+          }
+          return Promise.resolve({
+            uid: "member-123",
+            email: "jane@example.com",
+            name: "Jane Doe",
+            slug,
+          });
+        }),
+        sendNotificationEmail: mock(() => {
+          if (emailFails) {
+            return Promise.reject(new Error("SMTP failed"));
+          }
+          return Promise.resolve();
+        }),
+      },
+    });
+
+    const request = new Request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    return { testApp, request };
+  }
+
+  it("should return 200 and notified:true for valid publish payload", async () => {
+    const { testApp, request } = setup();
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(true);
+  });
+
+  it("should return 200 and notified:true for valid update payload", async () => {
+    const { testApp, request } = setup({
+      body: {
+        notificationType: "update",
+        commitSha: "abc123",
+        slug: "jane-doe",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(true);
+  });
+
+  it("should return 200 with invalid_payload when notificationType is missing", async () => {
+    const { testApp, request } = setup({
+      body: {
+        commitSha: "abc123",
+        slug: "jane-doe",
+        secret: "test-secret",
+      },
+    });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+      reason?: string;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(false);
+    expect(responseBody.reason).toBe("invalid_payload");
+  });
+
+  it("should return 401 for invalid secret", async () => {
+    const { testApp, request } = setup({ invalidSecret: true });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(401);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      error?: string;
+    };
+    expect(responseBody.status).toBe("error");
+    expect(responseBody.error).toBe("Unauthorized");
+  });
+
+  it("should return 200 with member_not_found when member does not exist", async () => {
+    const { testApp, request } = setup({ memberNotFound: true });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+      reason?: string;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(false);
+    expect(responseBody.reason).toBe("member_not_found");
+  });
+
+  it("should return 200 with email_failed when email sending fails", async () => {
+    const { testApp, request } = setup({ emailFails: true });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(200);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      received?: boolean;
+      notified?: boolean;
+      reason?: string;
+    };
+    expect(responseBody.status).toBe("success");
+    expect(responseBody.received).toBe(true);
+    expect(responseBody.notified).toBe(false);
+    expect(responseBody.reason).toBe("email_failed");
+  });
+
+  it("should return 500 when deploy webhook secret is not configured", async () => {
+    const { testApp, request } = setup({ deployWebhookSecret: null });
+
+    const response = await handleRequest(testApp, request);
+
+    expect(response.status).toBe(500);
+    const responseBody = (await response.json()) as {
+      status?: string;
+      error?: string;
+    };
+    expect(responseBody.status).toBe("error");
+    expect(responseBody.error).toBe("Server configuration error");
+  });
+});

--- a/functions/src/profile-webhook-api/routes/handle-webhook.ts
+++ b/functions/src/profile-webhook-api/routes/handle-webhook.ts
@@ -7,6 +7,7 @@ import type {
   ProfileWebhookSuccessResponse,
 } from "../schemas/profile-webhook-schemas.js";
 import type { ProfileWebhookService } from "../services/index.js";
+import type { WebhookPayload } from "../services/types.js";
 
 export async function handleProfileWebhookLogic({
   payload,
@@ -16,12 +17,7 @@ export async function handleProfileWebhookLogic({
   logger,
   set,
 }: {
-  payload: {
-    notificationType?: string;
-    commitSha?: string;
-    slug?: string;
-    secret?: string;
-  };
+  payload: WebhookPayload;
   webhookSecret: string;
   profileWebhookService: typeof ProfileWebhookService;
   emailService: EmailServiceInterface;
@@ -55,32 +51,20 @@ export async function handleProfileWebhookLogic({
     const validation = profileWebhookService.validatePayload({ payload });
 
     if (!validation.isValid) {
-      logger.info("Webhook received but not processing", {
+      logger.info("Webhook received but not processing notification", {
         reason: validation.reason,
         notificationType: payload.notificationType,
-        commitSha: payload.commitSha,
       });
       set.status = 200;
-      const response: ProfileWebhookSuccessResponse = {
+      return {
         status: "success",
         received: true,
         notified: false,
+        reason: validation.reason,
       };
-
-      if (validation.reason !== undefined) {
-        response.reason = validation.reason;
-      }
-
-      return response;
     }
 
-    const notificationType = payload.notificationType as
-      | "publish"
-      | "update"
-      | "image-update"
-      | "image-delete";
-    const commitSha = payload.commitSha as string;
-    const slug = payload.slug as string;
+    const { notificationType, slug } = validation.payload;
 
     // Find member by slug
     const member = await profileWebhookService.findMemberBySlug({
@@ -89,10 +73,9 @@ export async function handleProfileWebhookLogic({
     });
 
     if (!member) {
-      logger.warn("Member not found for profile update notification", {
+      logger.warn("Member not found for profile notification", {
         errorId: ERROR_IDS.PROFILE_DEPLOY_WEBHOOK_MEMBER_NOT_FOUND,
         slug,
-        commitSha,
       });
       set.status = 200;
       return {
@@ -129,10 +112,9 @@ export async function handleProfileWebhookLogic({
         logger,
       });
 
-      logger.info("Profile update notification sent", {
+      logger.info("Profile notification sent", {
         email: member.email,
         slug,
-        commitSha,
       });
 
       set.status = 200;
@@ -142,12 +124,11 @@ export async function handleProfileWebhookLogic({
         notified: true,
       };
     } catch (emailError) {
-      logger.error("Failed to send profile update notification", {
+      logger.error("Failed to send profile notification", {
         error: emailError,
         errorId: ERROR_IDS.PROFILE_DEPLOY_WEBHOOK_EMAIL_FAILED,
         email: member.email,
         slug,
-        commitSha,
       });
       set.status = 200;
       return {

--- a/functions/src/profile-webhook-api/routes/handle-webhook.ts
+++ b/functions/src/profile-webhook-api/routes/handle-webhook.ts
@@ -17,7 +17,7 @@ export async function handleProfileWebhookLogic({
   set,
 }: {
   payload: {
-    commitMessage?: string;
+    notificationType?: string;
     commitSha?: string;
     slug?: string;
     secret?: string;
@@ -57,7 +57,7 @@ export async function handleProfileWebhookLogic({
     if (!validation.isValid) {
       logger.info("Webhook received but not processing", {
         reason: validation.reason,
-        commitMessage: payload.commitMessage,
+        notificationType: payload.notificationType,
         commitSha: payload.commitSha,
       });
       set.status = 200;
@@ -74,16 +74,13 @@ export async function handleProfileWebhookLogic({
       return response;
     }
 
-    const { commitMessage, commitSha, slug } = payload;
-
-    // Type assertion safe here: validation.isValid guarantees these exist
-    if (!commitMessage || !commitSha || !slug) {
-      set.status = 500;
-      return {
-        status: "error",
-        error: "Validation passed but payload incomplete",
-      };
-    }
+    const notificationType = payload.notificationType as
+      | "publish"
+      | "update"
+      | "image-update"
+      | "image-delete";
+    const commitSha = payload.commitSha as string;
+    const slug = payload.slug as string;
 
     // Find member by slug
     const member = await profileWebhookService.findMemberBySlug({
@@ -127,7 +124,7 @@ export async function handleProfileWebhookLogic({
         memberEmail: member.email,
         memberName: member.name,
         slug: member.slug,
-        commitMessage,
+        notificationType,
         emailService,
         logger,
       });

--- a/functions/src/profile-webhook-api/schemas/profile-webhook-schemas.ts
+++ b/functions/src/profile-webhook-api/schemas/profile-webhook-schemas.ts
@@ -4,7 +4,7 @@ import { t, type Static } from "elysia";
  * Profile webhook request body schema.
  */
 export const ProfileWebhookBodySchema = t.Object({
-  commitMessage: t.Optional(t.String()),
+  notificationType: t.Optional(t.String()),
   commitSha: t.Optional(t.String()),
   slug: t.Optional(t.String()),
   secret: t.Optional(t.String()),

--- a/functions/src/profile-webhook-api/schemas/profile-webhook-schemas.ts
+++ b/functions/src/profile-webhook-api/schemas/profile-webhook-schemas.ts
@@ -5,7 +5,6 @@ import { t, type Static } from "elysia";
  */
 export const ProfileWebhookBodySchema = t.Object({
   notificationType: t.Optional(t.String()),
-  commitSha: t.Optional(t.String()),
   slug: t.Optional(t.String()),
   secret: t.Optional(t.String()),
 });

--- a/functions/src/profile-webhook-api/services/interface.ts
+++ b/functions/src/profile-webhook-api/services/interface.ts
@@ -4,6 +4,7 @@ import type {
   MemberInfo,
   NotificationParameters,
   ValidationResult,
+  WebhookPayload,
 } from "./types.js";
 
 /**
@@ -25,13 +26,7 @@ export interface ProfileWebhookService {
    * @param options - Payload to validate
    * @returns Validation result with success status and optional reason
    */
-  validatePayload(options: {
-    payload: {
-      notificationType?: string;
-      commitSha?: string;
-      slug?: string;
-    };
-  }): ValidationResult;
+  validatePayload(options: { payload: WebhookPayload }): ValidationResult;
 
   /**
    * Find a member by their profile slug.

--- a/functions/src/profile-webhook-api/services/interface.ts
+++ b/functions/src/profile-webhook-api/services/interface.ts
@@ -27,7 +27,7 @@ export interface ProfileWebhookService {
    */
   validatePayload(options: {
     payload: {
-      commitMessage?: string;
+      notificationType?: string;
       commitSha?: string;
       slug?: string;
     };

--- a/functions/src/profile-webhook-api/services/send-notification-email.ts
+++ b/functions/src/profile-webhook-api/services/send-notification-email.ts
@@ -7,17 +7,25 @@ import type { Logger } from "../../shared-api/types/logger.js";
 import type { NotificationParameters } from "./types.js";
 
 /**
- * Determine email content based on commit message type.
+ * Determine email content based on notification type.
  */
-function getEmailContent(commitMessage: string): {
+function getEmailContent(notificationType: string): {
   subject: string;
   heading: string;
   description: string;
 } {
-  const isImageDeletion = commitMessage.startsWith(
-    "Delete all profile images for ",
-  );
-  const isImageUpdate = commitMessage.startsWith("Update profile image for ");
+  const isProfilePublish = notificationType === "publish";
+  const isImageDeletion = notificationType === "image-delete";
+  const isImageUpdate = notificationType === "image-update";
+
+  if (isProfilePublish) {
+    return {
+      subject: "Your profile is now live",
+      heading: "Your profile is now live!",
+      description:
+        "Your public doula profile on the Rochester Doula Cooperative website has been published and is now live.",
+    };
+  }
 
   if (isImageDeletion) {
     return {
@@ -55,7 +63,7 @@ export async function sendNotificationEmail({
   memberEmail,
   memberName,
   slug,
-  commitMessage,
+  notificationType,
   emailService,
   logger,
 }: NotificationParameters & {
@@ -63,7 +71,7 @@ export async function sendNotificationEmail({
   logger: Logger;
 }): Promise<void> {
   const profileUrl = `https://doulacooperative.com/doulas/${slug}/`;
-  const { subject, heading, description } = getEmailContent(commitMessage);
+  const { subject, heading, description } = getEmailContent(notificationType);
 
   const emailMessage: EmailMessage = {
     from: `Rochester Doula Cooperative <${NO_REPLY_EMAIL}>`,

--- a/functions/src/profile-webhook-api/services/send-notification-email.ts
+++ b/functions/src/profile-webhook-api/services/send-notification-email.ts
@@ -4,57 +4,55 @@ import type {
   EmailServiceInterface,
 } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
-import type { NotificationParameters } from "./types.js";
+import type {
+  NotificationParameters,
+  ProfileNotificationType,
+} from "./types.js";
 
 /**
- * Determine email content based on notification type.
+ * Determine email content for a supported profile notification type.
  */
-function getEmailContent(notificationType: string): {
+function getEmailContent(notificationType: ProfileNotificationType): {
   subject: string;
   heading: string;
   description: string;
 } {
-  const isProfilePublish = notificationType === "publish";
-  const isImageDeletion = notificationType === "image-delete";
-  const isImageUpdate = notificationType === "image-update";
-
-  if (isProfilePublish) {
-    return {
+  const emailContentByType: Record<
+    ProfileNotificationType,
+    { subject: string; heading: string; description: string }
+  > = {
+    publish: {
       subject: "Your profile is now live",
       heading: "Your profile is now live!",
       description:
         "Your public doula profile on the Rochester Doula Cooperative website has been published and is now live.",
-    };
-  }
-
-  if (isImageDeletion) {
-    return {
-      subject: "Your profile photo has been removed",
-      heading: "Your profile photo has been removed",
+    },
+    update: {
+      subject: "Your Doula Cooperative profile has been updated",
+      heading: "Your profile has been updated!",
       description:
-        "Your profile photo on the Rochester Doula Cooperative website has been successfully removed. Your profile is still active and visible without a photo.",
-    };
-  }
-
-  if (isImageUpdate) {
-    return {
+        "Your public doula profile on the Rochester Doula Cooperative website has been successfully updated and is now live.",
+    },
+    "image-update": {
       subject: "Your profile photo has been updated",
       heading: "Your profile photo has been updated!",
       description:
         "Your profile photo on the Rochester Doula Cooperative website has been successfully updated and is now live.",
-    };
-  }
-
-  return {
-    subject: "Your Doula Cooperative profile has been updated",
-    heading: "Your profile has been updated!",
-    description:
-      "Your public doula profile on the Rochester Doula Cooperative website has been successfully updated and is now live.",
+    },
+    "image-delete": {
+      subject: "Your profile photo has been removed",
+      heading: "Your profile photo has been removed",
+      description:
+        "Your profile photo on the Rochester Doula Cooperative website has been successfully removed. Your profile is still active and visible without a photo.",
+    },
   };
+
+  return emailContentByType[notificationType];
 }
 
 /**
- * Send profile update notification email to member.
+ * Send a member notification email for publish, update, image-update,
+ * or image-delete profile events.
  *
  * @param params - Notification parameters
  * @throws Error if email fails to send

--- a/functions/src/profile-webhook-api/services/types.ts
+++ b/functions/src/profile-webhook-api/services/types.ts
@@ -5,10 +5,14 @@ export type ProfileNotificationType =
   | "image-delete";
 
 export interface WebhookPayload {
+  notificationType?: string;
+  slug?: string;
+  secret?: string;
+}
+
+export interface ValidatedWebhookPayload {
   notificationType: ProfileNotificationType;
-  commitSha: string;
-  slug: string; // Empty string if not single profile update
-  secret: string;
+  slug: string;
 }
 
 export interface MemberInfo {
@@ -25,7 +29,30 @@ export interface NotificationParameters {
   notificationType: ProfileNotificationType;
 }
 
-export interface ValidationResult {
-  isValid: boolean;
-  reason: string | undefined;
+export type ValidationFailureReason =
+  | "invalid_payload"
+  | "not_single_profile"
+  | "not_profile_related";
+
+export type ValidationResult =
+  | {
+      isValid: false;
+      reason: ValidationFailureReason;
+    }
+  | {
+      isValid: true;
+      payload: ValidatedWebhookPayload;
+    };
+
+export const PROFILE_NOTIFICATION_TYPES: readonly ProfileNotificationType[] = [
+  "publish",
+  "update",
+  "image-update",
+  "image-delete",
+] as const;
+
+export function isProfileNotificationType(
+  value: string,
+): value is ProfileNotificationType {
+  return PROFILE_NOTIFICATION_TYPES.includes(value as ProfileNotificationType);
 }

--- a/functions/src/profile-webhook-api/services/types.ts
+++ b/functions/src/profile-webhook-api/services/types.ts
@@ -1,5 +1,11 @@
+export type ProfileNotificationType =
+  | "publish"
+  | "update"
+  | "image-update"
+  | "image-delete";
+
 export interface WebhookPayload {
-  commitMessage: string;
+  notificationType: ProfileNotificationType;
   commitSha: string;
   slug: string; // Empty string if not single profile update
   secret: string;
@@ -16,7 +22,7 @@ export interface NotificationParameters {
   memberEmail: string;
   memberName: string | undefined;
   slug: string;
-  commitMessage: string;
+  notificationType: ProfileNotificationType;
 }
 
 export interface ValidationResult {

--- a/functions/src/profile-webhook-api/services/validate-payload.ts
+++ b/functions/src/profile-webhook-api/services/validate-payload.ts
@@ -1,4 +1,11 @@
-import type { ValidationResult } from "./types.js";
+import type { ProfileNotificationType, ValidationResult } from "./types.js";
+
+const VALID_NOTIFICATION_TYPES = new Set<ProfileNotificationType>([
+  "publish",
+  "update",
+  "image-update",
+  "image-delete",
+]);
 
 /**
  * Validate webhook payload structure and determine if notification should be sent.
@@ -10,15 +17,15 @@ export function validatePayload({
   payload,
 }: {
   payload: {
-    commitMessage?: string;
+    notificationType?: string;
     commitSha?: string;
     slug?: string;
   };
 }): ValidationResult {
-  const { commitMessage, commitSha, slug } = payload;
+  const { notificationType, commitSha, slug } = payload;
 
   // Validate required fields
-  if (!commitMessage || !commitSha || slug === undefined) {
+  if (!notificationType || !commitSha || slug === undefined) {
     return {
       isValid: false,
       reason: "invalid_payload",
@@ -26,21 +33,15 @@ export function validatePayload({
   }
 
   // Check if this is a single profile update
-  if (!slug || slug === "") {
+  if (slug === "") {
     return {
       isValid: false,
       reason: "not_single_profile",
     };
   }
 
-  // Check if commit message indicates a profile or image update/deletion (not creation)
-  const isProfileUpdate = commitMessage.startsWith("Update profile for ");
-  const isImageUpdate = commitMessage.startsWith("Update profile image for ");
-  const isImageDeletion = commitMessage.startsWith(
-    "Delete all profile images for ",
-  );
-
-  if (!isProfileUpdate && !isImageUpdate && !isImageDeletion) {
+  // Check if notification type indicates a supported profile event
+  if (!VALID_NOTIFICATION_TYPES.has(notificationType as ProfileNotificationType)) {
     return {
       isValid: false,
       reason: "not_profile_related",

--- a/functions/src/profile-webhook-api/services/validate-payload.ts
+++ b/functions/src/profile-webhook-api/services/validate-payload.ts
@@ -1,11 +1,8 @@
-import type { ProfileNotificationType, ValidationResult } from "./types.js";
-
-const VALID_NOTIFICATION_TYPES = new Set<ProfileNotificationType>([
-  "publish",
-  "update",
-  "image-update",
-  "image-delete",
-]);
+import {
+  isProfileNotificationType,
+  type ValidationResult,
+  type WebhookPayload,
+} from "./types.js";
 
 /**
  * Validate webhook payload structure and determine if notification should be sent.
@@ -16,16 +13,12 @@ const VALID_NOTIFICATION_TYPES = new Set<ProfileNotificationType>([
 export function validatePayload({
   payload,
 }: {
-  payload: {
-    notificationType?: string;
-    commitSha?: string;
-    slug?: string;
-  };
+  payload: WebhookPayload;
 }): ValidationResult {
-  const { notificationType, commitSha, slug } = payload;
+  const { notificationType, slug } = payload;
 
   // Validate required fields
-  if (!notificationType || !commitSha || slug === undefined) {
+  if (!notificationType || slug === undefined) {
     return {
       isValid: false,
       reason: "invalid_payload",
@@ -41,12 +34,18 @@ export function validatePayload({
   }
 
   // Check if notification type indicates a supported profile event
-  if (!VALID_NOTIFICATION_TYPES.has(notificationType as ProfileNotificationType)) {
+  if (!isProfileNotificationType(notificationType)) {
     return {
       isValid: false,
       reason: "not_profile_related",
     };
   }
 
-  return { isValid: true, reason: undefined };
+  return {
+    isValid: true,
+    payload: {
+      notificationType,
+      slug,
+    },
+  };
 }

--- a/functions/src/profile-webhook-api/test-utils/create-profile-webhook-test-plugin.ts
+++ b/functions/src/profile-webhook-api/test-utils/create-profile-webhook-test-plugin.ts
@@ -1,0 +1,84 @@
+import { mock } from "bun:test";
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
+import { createProfileWebhookPlugin } from "../plugins/profile-webhook-plugin.js";
+import type { ProfileWebhookService } from "../services/interface.js";
+import type {
+  MemberInfo,
+  ProfileNotificationType,
+} from "../services/types.js";
+
+/**
+ * Creates the profile-webhook plugin with default mock services for testing.
+ * Tests only the profile-webhook plugin in isolation - no full app composition needed.
+ *
+ * @param overrides - Partial method overrides for services
+ * @returns Configured profile-webhook plugin with mocked services
+ */
+export function createProfileWebhookTestPlugin(overrides?: {
+  profileWebhookService?: Partial<ProfileWebhookService>;
+  emailService?: Partial<EmailServiceInterface>;
+}) {
+  const defaultProfileWebhookService: ProfileWebhookService = {
+    verifySecret: mock(
+      ({ provided, expected }: { provided: string; expected: string }) =>
+        provided === expected,
+    ),
+    validatePayload: mock(
+      ({
+        payload,
+      }: {
+        payload: {
+          notificationType?: string;
+          commitSha?: string;
+          slug?: string;
+        };
+      }) => {
+        const validNotificationTypes: ProfileNotificationType[] = [
+          "publish",
+          "update",
+          "image-update",
+          "image-delete",
+        ];
+        if (
+          !payload.notificationType ||
+          !payload.commitSha ||
+          payload.slug === undefined
+        ) {
+          return { isValid: false, reason: "invalid_payload" };
+        }
+        if (!payload.slug) {
+          return { isValid: false, reason: "not_single_profile" };
+        }
+        if (
+          !validNotificationTypes.includes(
+            payload.notificationType as ProfileNotificationType,
+          )
+        ) {
+          return { isValid: false, reason: "not_profile_related" };
+        }
+        return { isValid: true, reason: undefined };
+      },
+    ),
+    findMemberBySlug: mock(
+      ({ slug }: { slug: string; logger: Logger }) =>
+        Promise.resolve({
+          uid: "member-123",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          slug,
+        } satisfies MemberInfo),
+    ),
+    sendNotificationEmail: mock(() => Promise.resolve()),
+    ...overrides?.profileWebhookService,
+  };
+
+  const defaultEmailService: EmailServiceInterface = {
+    sendEmail: mock(() => Promise.resolve()),
+    ...overrides?.emailService,
+  };
+
+  return createProfileWebhookPlugin({
+    profileWebhookService: defaultProfileWebhookService,
+    emailService: defaultEmailService,
+  });
+}

--- a/functions/src/profile-webhook-api/test-utils/create-profile-webhook-test-plugin.ts
+++ b/functions/src/profile-webhook-api/test-utils/create-profile-webhook-test-plugin.ts
@@ -2,9 +2,11 @@ import { mock } from "bun:test";
 import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import { createProfileWebhookPlugin } from "../plugins/profile-webhook-plugin.js";
 import type { ProfileWebhookService } from "../services/interface.js";
-import type {
-  MemberInfo,
-  ProfileNotificationType,
+import {
+  isProfileNotificationType,
+  type MemberInfo,
+  type ValidationResult,
+  type WebhookPayload,
 } from "../services/types.js";
 
 /**
@@ -24,43 +26,27 @@ export function createProfileWebhookTestPlugin(overrides?: {
         provided === expected,
     ),
     validatePayload: mock(
-      ({
-        payload,
-      }: {
-        payload: {
-          notificationType?: string;
-          commitSha?: string;
-          slug?: string;
-        };
-      }) => {
-        const validNotificationTypes: ProfileNotificationType[] = [
-          "publish",
-          "update",
-          "image-update",
-          "image-delete",
-        ];
-        if (
-          !payload.notificationType ||
-          !payload.commitSha ||
-          payload.slug === undefined
-        ) {
+      ({ payload }: { payload: WebhookPayload }): ValidationResult => {
+        if (!payload.notificationType || payload.slug === undefined) {
           return { isValid: false, reason: "invalid_payload" };
         }
         if (!payload.slug) {
           return { isValid: false, reason: "not_single_profile" };
         }
-        if (
-          !validNotificationTypes.includes(
-            payload.notificationType as ProfileNotificationType,
-          )
-        ) {
+        if (!isProfileNotificationType(payload.notificationType)) {
           return { isValid: false, reason: "not_profile_related" };
         }
-        return { isValid: true, reason: undefined };
+        return {
+          isValid: true,
+          payload: {
+            notificationType: payload.notificationType,
+            slug: payload.slug,
+          },
+        };
       },
     ),
     findMemberBySlug: mock(
-      ({ slug }: { slug: string; logger: Logger }) =>
+      ({ slug }: { slug: string }) =>
         Promise.resolve({
           uid: "member-123",
           email: "jane@example.com",

--- a/functions/src/profiles-api/routes/profile-route-handler-factory.ts
+++ b/functions/src/profiles-api/routes/profile-route-handler-factory.ts
@@ -1,10 +1,34 @@
-import type { ErrorId } from "../../constants/error-ids.js";
+import { ERROR_IDS, type ErrorId } from "../../constants/error-ids.js";
 import { ForbiddenError } from "../../shared-api/errors/http-error.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import { handleRouteError } from "../../shared-api/utils/route-error-handler.js";
 import type { ProfileData } from "../schemas/profile-schemas.js";
 import type { ProfileMemberService } from "../services/member/interface.js";
 import type { ProfileStoreService } from "../services/profile-store/interface.js";
+import { triggerHugoRebuild } from "../services/profile-store/trigger-rebuild.js";
+
+const NOTIFICATION_TYPES = new Set([
+  "publish",
+  "update",
+  "image-update",
+  "image-delete",
+]);
+
+type NotificationType = "publish" | "update" | "image-update" | "image-delete";
+
+function isNotificationType(value: string): value is NotificationType {
+  return NOTIFICATION_TYPES.has(value);
+}
+
+function getNotificationType(
+  buildNotificationType: (() => string) | undefined,
+): NotificationType | undefined {
+  const notificationType = buildNotificationType?.();
+  if (!notificationType || !isNotificationType(notificationType)) {
+    return undefined;
+  }
+  return notificationType;
+}
 
 /**
  * Configuration for profile route handler factory.
@@ -14,10 +38,10 @@ export interface ProfileRouteHandlerConfig<TResponse> {
   errorId: ErrorId;
   slugNotFoundMessage: string;
   successStatus?: number;
-  /** Build the commitMessage for the deployment webhook notification email.
-   *  When provided, the slug is passed so the message can include the doula name.
-   *  Example: (slug) => `Update profile for ${slug}` */
-  buildCommitMessage?: (slug: string) => string;
+  /** Build the notification type for the deployment webhook notification email.
+   *  When provided, the webhook sends a member notification after deploy.
+   *  Example: () => "update" */
+  buildNotificationType?: () => string;
   storeOperation: (
     service: ProfileStoreService,
     slug: string,
@@ -83,15 +107,18 @@ export function createProfileRouteHandler<TResponse>(
         } else {
           const { triggerHugoRebuild } =
             await import("../services/profile-store/trigger-rebuild.js");
-          const commitMessage = config.buildCommitMessage?.(slug);
+          const notificationType = getNotificationType(
+            config.buildNotificationType,
+          );
           await triggerHugoRebuild({
             slug,
             action: config.operation,
-            ...(commitMessage && { commitMessage }),
+            ...(notificationType && { notificationType }),
           });
         }
       } catch (error: unknown) {
         logger.error("Failed to trigger Hugo rebuild after write", {
+          errorId: ERROR_IDS.API_HUGO_REBUILD_FAILED,
           uid,
           slug,
           error,

--- a/functions/src/profiles-api/routes/profile-route-handler-factory.ts
+++ b/functions/src/profiles-api/routes/profile-route-handler-factory.ts
@@ -5,29 +5,12 @@ import { handleRouteError } from "../../shared-api/utils/route-error-handler.js"
 import type { ProfileData } from "../schemas/profile-schemas.js";
 import type { ProfileMemberService } from "../services/member/interface.js";
 import type { ProfileStoreService } from "../services/profile-store/interface.js";
-import { triggerHugoRebuild } from "../services/profile-store/trigger-rebuild.js";
-
-const NOTIFICATION_TYPES = new Set([
-  "publish",
-  "update",
-  "image-update",
-  "image-delete",
-]);
-
-type NotificationType = "publish" | "update" | "image-update" | "image-delete";
-
-function isNotificationType(value: string): value is NotificationType {
-  return NOTIFICATION_TYPES.has(value);
-}
+import type { ProfileNotificationType } from "../../profile-webhook-api/services/types.js";
 
 function getNotificationType(
-  buildNotificationType: (() => string) | undefined,
-): NotificationType | undefined {
-  const notificationType = buildNotificationType?.();
-  if (!notificationType || !isNotificationType(notificationType)) {
-    return undefined;
-  }
-  return notificationType;
+  buildNotificationType: (() => ProfileNotificationType) | undefined,
+): ProfileNotificationType | undefined {
+  return buildNotificationType?.();
 }
 
 /**
@@ -41,7 +24,7 @@ export interface ProfileRouteHandlerConfig<TResponse> {
   /** Build the notification type for the deployment webhook notification email.
    *  When provided, the webhook sends a member notification after deploy.
    *  Example: () => "update" */
-  buildNotificationType?: () => string;
+  buildNotificationType?: () => ProfileNotificationType;
   storeOperation: (
     service: ProfileStoreService,
     slug: string,

--- a/functions/src/profiles-api/routes/write-profile.ts
+++ b/functions/src/profiles-api/routes/write-profile.ts
@@ -8,7 +8,7 @@ export const writeProfileLogic =
     errorId: ERROR_IDS.API_PROFILE_WRITE_FAILED,
     slugNotFoundMessage:
       "Profile not found. User may need to claim their existing membership first.",
-    buildCommitMessage: slug => `Update profile for ${slug}`,
+    buildNotificationType: () => "update",
     storeOperation: (service, slug, data) =>
       service.writeProfile({ slug, data }),
     buildSuccessResponse: data => ({ success: true, profile: data }),

--- a/functions/src/profiles-api/services/profile-store/trigger-rebuild.ts
+++ b/functions/src/profiles-api/services/profile-store/trigger-rebuild.ts
@@ -11,20 +11,21 @@ import { getOctokit } from "./get-octokit.js";
  *
  * @param slug - The profile slug
  * @param action - Short description of the action (e.g., "updated profile")
- * @param commitMessage - Optional commit-style message for the deployment webhook
- *   notification email. When provided, the GitHub Actions workflow will POST
- *   this to the profile-webhook endpoint after a successful deploy, triggering
- *   a notification email to the member. Expected formats:
- *   - "Update profile for {name}" → generic profile update email
- *   - "Update profile image for {name}" → image update email
- *   - "Delete all profile images for {name}" → image deletion email
+ * @param notificationType - Optional notification type for the deployment webhook.
+ *   When provided, the GitHub Actions workflow will POST this to the
+ *   profile-webhook endpoint after a successful deploy, triggering a
+ *   notification email to the member. Expected values:
+ *   - "publish" → first-publish email
+ *   - "update" → generic profile update email
+ *   - "image-update" → image update email
+ *   - "image-delete" → image deletion email
  */
 export async function triggerHugoRebuild(options: {
   slug: string;
   action: string;
-  commitMessage?: string;
+  notificationType?: "publish" | "update" | "image-update" | "image-delete";
 }): Promise<void> {
-  const { slug, action, commitMessage } = options;
+  const { slug, action, notificationType } = options;
 
   if (process.env["FUNCTIONS_EMULATOR"]) {
     logger.info("Emulator detected, skipping Hugo rebuild trigger", {
@@ -41,7 +42,7 @@ export async function triggerHugoRebuild(options: {
       owner: GITHUB_OWNER,
       repo: GITHUB_REPO,
       event_type: "profile-update",
-      client_payload: { slug, action, commitMessage },
+      client_payload: { slug, action, notificationType },
     });
 
     logger.info("Triggered Hugo rebuild via repository_dispatch", {

--- a/functions/src/profiles-api/services/profile-store/trigger-rebuild.ts
+++ b/functions/src/profiles-api/services/profile-store/trigger-rebuild.ts
@@ -1,6 +1,7 @@
 import { logger } from "firebase-functions/v2";
 import { ERROR_IDS } from "../../../constants/error-ids.js";
 import { GITHUB_OWNER, GITHUB_REPO } from "../../../constants/github-config.js";
+import type { ProfileNotificationType } from "../../../profile-webhook-api/services/types.js";
 import { HttpError } from "../../../shared-api/errors/http-error.js";
 import { getOctokit } from "./get-octokit.js";
 
@@ -23,7 +24,7 @@ import { getOctokit } from "./get-octokit.js";
 export async function triggerHugoRebuild(options: {
   slug: string;
   action: string;
-  notificationType?: "publish" | "update" | "image-update" | "image-delete";
+  notificationType?: ProfileNotificationType;
 }): Promise<void> {
   const { slug, action, notificationType } = options;
 
@@ -42,7 +43,7 @@ export async function triggerHugoRebuild(options: {
       owner: GITHUB_OWNER,
       repo: GITHUB_REPO,
       event_type: "profile-update",
-      client_payload: { slug, action, notificationType },
+      client_payload: { slug, action, ...(notificationType && { notificationType }) },
     });
 
     logger.info("Triggered Hugo rebuild via repository_dispatch", {


### PR DESCRIPTION
## Summary
- replace the deploy webhook commitMessage payload with explicit notificationType values
- send publish notifications when admin draft toggles make a profile live and keep update notifications working
- add route-level profile webhook tests for publish, update, invalid payload, invalid secret, member missing, email failure, and missing secret config

## Test plan
- [x] cd functions && bun test src/profile-webhook-api/routes/handle-webhook.test.ts
- [x] cd functions && bun test src/admin-members-api/routes/toggle-profile-draft.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)