### PR TITLE
fix admin preview image fallback

### DIFF
--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
@@ -50,7 +50,7 @@ export class AdminMemberDetailService {
     const profile = this.profileResource.hasValue() ? this.profileResource.value() : undefined;
 
     if (!member?.slug || !profile) {
-      return undefined;
+      return;
     }
 
     return buildImageKitDisplayUrl(member.slug, 300, 300);

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, computed, inject, resource, signal, type Signal } from '@angular/core';
 import type { ApiMemberResponse } from '../../../api-types/api-member-response';
+import { buildImageKitDisplayUrl } from '../../../shared/profile-image-url';
 import type { ProfileData } from '../../../types/profile-data';
 
 import { AdminMembersService } from '../../services/admin-members.service';
@@ -42,6 +43,17 @@ export class AdminMemberDetailService {
   readonly profileErrorMessage = computed(() => {
     const error = this.profileResource.error();
     return error ? 'Failed to load profile content. Please try again.' : undefined;
+  });
+
+  readonly profileImageUrl = computed(() => {
+    const member = this.memberResource.hasValue() ? this.memberResource.value() : undefined;
+    const profile = this.profileResource.hasValue() ? this.profileResource.value() : undefined;
+
+    if (!member?.slug || !profile) {
+      return undefined;
+    }
+
+    return buildImageKitDisplayUrl(member.slug, 300, 300);
   });
 
   // Unlinked profiles resource — loads when member has no slug

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
@@ -318,6 +318,27 @@ describe('AdminUserDetail', () => {
     });
   });
 
+  it('should build the admin profile image URL after loading profile status', async () => {
+    const member = createMockMember({ slug: 'jane-doe' });
+    const { user, component } = await setup({ member });
+
+    const loadStatusButton = await screen.findByRole('button', { name: 'Load Profile Status' });
+    await user.click(loadStatusButton);
+
+    const service = component.fixture.componentRef.injector.get(AdminMemberDetailService);
+    expect(service.profileImageUrl()).toBe(
+      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+    );
+  });
+
+  it('should leave the admin profile image URL undefined before profile status loads', async () => {
+    const member = createMockMember({ slug: 'jane-doe' });
+    const { component } = await setup({ member });
+
+    const service = component.fixture.componentRef.injector.get(AdminMemberDetailService);
+    expect(service.profileImageUrl()).toBeUndefined();
+  });
+
   it('should display loading state initially', async () => {
     const { resolveMemberPromise } = await setup({ shouldKeepLoading: true });
 

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
@@ -318,27 +318,6 @@ describe('AdminUserDetail', () => {
     });
   });
 
-  it('should build the admin profile image URL after loading profile status', async () => {
-    const member = createMockMember({ slug: 'jane-doe' });
-    const { user, component } = await setup({ member });
-
-    const loadStatusButton = await screen.findByRole('button', { name: 'Load Profile Status' });
-    await user.click(loadStatusButton);
-
-    const service = component.fixture.componentRef.injector.get(AdminMemberDetailService);
-    expect(service.profileImageUrl()).toBe(
-      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
-    );
-  });
-
-  it('should leave the admin profile image URL undefined before profile status loads', async () => {
-    const member = createMockMember({ slug: 'jane-doe' });
-    const { component } = await setup({ member });
-
-    const service = component.fixture.componentRef.injector.get(AdminMemberDetailService);
-    expect(service.profileImageUrl()).toBeUndefined();
-  });
-
   it('should display loading state initially', async () => {
     const { resolveMemberPromise } = await setup({ shouldKeepLoading: true });
 

--- a/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.html
+++ b/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.html
@@ -23,5 +23,5 @@
 } @else if (profileError) {
   <app-alert-banner variant="error">{{ profileError }}</app-alert-banner>
 } @else if (profile) {
-  <app-profile-preview [profile]="profile" [imageUrl]="profile.image" />
+  <app-profile-preview [profile]="profile" [imageUrl]="service.profileImageUrl()" />
 }

--- a/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
+++ b/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
@@ -1,38 +1,18 @@
-import { signal } from '@angular/core';
 import { render, screen } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
-import { AdminMemberDetailService } from '../admin-member-detail/admin-member-detail.service';
-import { AdminProfilePreview } from './admin-profile-preview';
+import { ProfilePreview } from '../../../shared/profile-preview/profile-preview';
 
-describe('AdminProfilePreview', () => {
-  it('passes the computed profile image URL to the shared preview', async () => {
-    await render(AdminProfilePreview, {
-      providers: [
-        {
-          provide: AdminMemberDetailService,
-          useValue: {
-            init: () => {},
-            loadProfile: () => {},
-            memberResource: {
-              value: signal({ uid: 'uid-1', slug: 'jane-doe' }),
-              isLoading: signal(false),
-            },
-            profileResource: {
-              value: signal({ title: 'Jane Doe', bio: 'Bio text.' }),
-              isLoading: signal(false),
-            },
-            errorMessage: signal(undefined),
-            profileErrorMessage: signal(undefined),
-            profileImageUrl: signal(
-              'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
-            ),
-          },
-        },
-      ],
-      inputs: { uid: 'uid-1' },
+describe('AdminProfilePreview integration', () => {
+  it('renders the computed profile image URL through the shared preview component', async () => {
+    await render(ProfilePreview, {
+      inputs: {
+        profile: { title: 'Jane Doe', bio: 'Bio text.' },
+        imageUrl:
+          'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+      },
     });
 
-    const image = screen.getByAltText('Headshot of Jane Doe');
+    const image = screen.getByRole('img', { name: 'Headshot of Jane Doe' });
     expect(image).toHaveAttribute(
       'src',
       'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',

--- a/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
+++ b/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
@@ -1,21 +1,80 @@
-import { render, screen } from '@testing-library/angular';
-import { describe, expect, it } from 'vitest';
-import { ProfilePreview } from '../../../shared/profile-preview/profile-preview';
+import { provideRouter } from '@angular/router';
+import { render, screen, waitFor } from '@testing-library/angular';
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiMemberResponse } from '../../../api-types/api-member-response';
+import { AdminMembersService } from '../../services/admin-members.service';
+import { AdminProfilePreview } from './admin-profile-preview';
 
-describe('AdminProfilePreview integration', () => {
-  it('renders the computed profile image URL through the shared preview component', async () => {
-    await render(ProfilePreview, {
-      inputs: {
-        profile: { title: 'Jane Doe', bio: 'Bio text.' },
-        imageUrl:
-          'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
-      },
+interface SetupOptions {
+  uid?: string;
+  member?: ApiMemberResponse;
+  profileTitle?: string;
+}
+
+async function setup({
+  uid = 'test-uid',
+  member = {
+    uid: 'test-uid',
+    email: 'jane@example.com',
+    name: 'Jane Doe',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    isAdmin: false,
+    membershipActive: true,
+    subscriptionStart: '2024-01-01T00:00:00.000Z',
+    membershipExpiresAt: '2025-01-01T00:00:00.000Z',
+    slug: 'jane-doe',
+  },
+  profileTitle = 'Jane Doe',
+}: SetupOptions = {}): Promise<void> {
+  const mockAdminMembersService = {
+    getMember: vi.fn().mockResolvedValue(member),
+    readMemberProfile: vi.fn().mockResolvedValue({
+      title: profileTitle,
+      bio: 'A passionate doula serving the community.',
+      slug: member.slug ?? 'jane-doe',
+    }),
+  };
+
+  await render(AdminProfilePreview, {
+    inputs: { uid },
+    providers: [
+      { provide: AdminMembersService, useValue: mockAdminMembersService },
+      provideRouter([]),
+    ],
+  });
+}
+
+describe('AdminProfilePreview', () => {
+  it('renders the profile image with the computed ImageKit URL', async () => {
+    await setup();
+
+    await waitFor(() => {
+      const image = screen.getByRole('img', { name: 'Headshot of Jane Doe' });
+      expect(image).toHaveAttribute(
+        'src',
+        'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+      );
     });
+  });
 
-    const image = screen.getByRole('img', { name: 'Headshot of Jane Doe' });
-    expect(image).toHaveAttribute(
-      'src',
-      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
-    );
+  it('shows a warning when the member has no linked profile', async () => {
+    const memberWithoutSlug: ApiMemberResponse = {
+      uid: 'test-uid',
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      isAdmin: false,
+      membershipActive: true,
+      subscriptionStart: '2024-01-01T00:00:00.000Z',
+      membershipExpiresAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    await setup({ member: memberWithoutSlug });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This member does not have a linked profile.'),
+      ).toBeVisible();
+    });
   });
 });

--- a/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
+++ b/members/src/app/admin/users/admin-profile-preview/admin-profile-preview.spec.ts
@@ -1,0 +1,41 @@
+import { signal } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { AdminMemberDetailService } from '../admin-member-detail/admin-member-detail.service';
+import { AdminProfilePreview } from './admin-profile-preview';
+
+describe('AdminProfilePreview', () => {
+  it('passes the computed profile image URL to the shared preview', async () => {
+    await render(AdminProfilePreview, {
+      providers: [
+        {
+          provide: AdminMemberDetailService,
+          useValue: {
+            init: () => {},
+            loadProfile: () => {},
+            memberResource: {
+              value: signal({ uid: 'uid-1', slug: 'jane-doe' }),
+              isLoading: signal(false),
+            },
+            profileResource: {
+              value: signal({ title: 'Jane Doe', bio: 'Bio text.' }),
+              isLoading: signal(false),
+            },
+            errorMessage: signal(undefined),
+            profileErrorMessage: signal(undefined),
+            profileImageUrl: signal(
+              'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+            ),
+          },
+        },
+      ],
+      inputs: { uid: 'uid-1' },
+    });
+
+    const image = screen.getByAltText('Headshot of Jane Doe');
+    expect(image).toHaveAttribute(
+      'src',
+      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+    );
+  });
+});

--- a/members/src/app/services/profile.service.ts
+++ b/members/src/app/services/profile.service.ts
@@ -1,11 +1,9 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, computed, effect, inject, resource, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { buildImageKitDisplayUrl } from '../shared/profile-image-url';
+import { buildImageKitDisplayUrl, IMAGEKIT_BASE_URL } from '../shared/profile-image-url';
 import { type ProfileData } from '../types/profile-data';
 import { MembershipService } from './membership.service';
-
-const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
 
 interface ProfileResponse {
   success: true;

--- a/members/src/app/services/profile.service.ts
+++ b/members/src/app/services/profile.service.ts
@@ -1,18 +1,11 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, computed, effect, inject, resource, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
+import { buildImageKitDisplayUrl } from '../shared/profile-image-url';
 import { type ProfileData } from '../types/profile-data';
 import { MembershipService } from './membership.service';
 
 const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
-
-/**
- * Build an ImageKit display URL with transformations and default image fallback.
- * Matches the Hugo site's URL pattern so missing images show a default placeholder.
- */
-function buildImageKitDisplayUrl(slug: string, width: number, height: number): string {
-  return `${IMAGEKIT_BASE_URL}/tr:w-${width},h-${height},fo-face,z-0.5,di-default-profile.png/doulas/${slug}/${slug}-profile`;
-}
 
 interface ProfileResponse {
   success: true;

--- a/members/src/app/shared/profile-image-url.spec.ts
+++ b/members/src/app/shared/profile-image-url.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { buildImageKitDisplayUrl } from './profile-image-url';
+
+describe('buildImageKitDisplayUrl', () => {
+  it('builds the ImageKit URL with fallback image and face crop', () => {
+    expect(buildImageKitDisplayUrl('jane-doe', 300, 300)).toBe(
+      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+    );
+  });
+});

--- a/members/src/app/shared/profile-image-url.spec.ts
+++ b/members/src/app/shared/profile-image-url.spec.ts
@@ -7,4 +7,16 @@ describe('buildImageKitDisplayUrl', () => {
       'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
     );
   });
+
+  it('handles non-square dimensions', () => {
+    expect(buildImageKitDisplayUrl('jane-doe', 200, 400)).toBe(
+      'https://ik.imagekit.io/doulacoop/tr:w-200,h-400,fo-face,z-0.5,di-default-profile.png/doulas/jane-doe/jane-doe-profile',
+    );
+  });
+
+  it('handles multi-hyphen slugs', () => {
+    expect(buildImageKitDisplayUrl('mary-jane-watson-smith', 300, 300)).toBe(
+      'https://ik.imagekit.io/doulacoop/tr:w-300,h-300,fo-face,z-0.5,di-default-profile.png/doulas/mary-jane-watson-smith/mary-jane-watson-smith-profile',
+    );
+  });
 });

--- a/members/src/app/shared/profile-image-url.ts
+++ b/members/src/app/shared/profile-image-url.ts
@@ -1,0 +1,9 @@
+const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
+
+/**
+ * Build an ImageKit display URL with transformations and default image fallback.
+ * Matches the Hugo site's URL pattern so missing images show a default placeholder.
+ */
+export function buildImageKitDisplayUrl(slug: string, width: number, height: number): string {
+  return `${IMAGEKIT_BASE_URL}/tr:w-${width},h-${height},fo-face,z-0.5,di-default-profile.png/doulas/${slug}/${slug}-profile`;
+}

--- a/members/src/app/shared/profile-image-url.ts
+++ b/members/src/app/shared/profile-image-url.ts
@@ -1,8 +1,11 @@
-const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
+export const IMAGEKIT_BASE_URL = 'https://ik.imagekit.io/doulacoop';
 
 /**
  * Build an ImageKit display URL with transformations and default image fallback.
- * Matches the Hugo site's URL pattern so missing images show a default placeholder.
+ *
+ * The URL pattern must stay in sync with the Hugo site templates in
+ * `layouts/doulas/` so that missing images fall back to the same default
+ * placeholder on both the public site and the members app.
  */
 export function buildImageKitDisplayUrl(slug: string, width: number, height: number): string {
   return `${IMAGEKIT_BASE_URL}/tr:w-${width},h-${height},fo-face,z-0.5,di-default-profile.png/doulas/${slug}/${slug}-profile`;


### PR DESCRIPTION
## Summary
- extract the ImageKit display URL builder into a shared helper
- use the shared helper for the admin member detail preview image URL
- add coverage for the shared helper and admin preview image behavior

## Test plan
- [ ] bun run lint *(blocked locally: `ng` command not found in this worktree)*
- [ ] bun run test *(not run)*
- [ ] bun run build *(not run)*
- [ ] bun run e2e *(not run)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)