### PR TITLE
Make profile editing a toggleable permission

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,8 @@
     "cleanup-test-data": "bun run src/scripts/cleanup-test-data.ts",
     "test-webhook": "bun run src/scripts/test-stripe-webhook.ts",
     "sync-profile-timestamps": "bun run src/scripts/sync-profile-timestamps.ts",
-    "seed-claim-test": "bun run src/scripts/seed-claim-test.ts"
+    "seed-claim-test": "bun run src/scripts/seed-claim-test.ts",
+    "backfill-allow-profile-editing": "bun run src/scripts/backfill-allow-profile-editing.ts"
   },
   "engines": {
     "node": "24"

--- a/functions/src/admin-members-api/plugins/admin-members-plugin.ts
+++ b/functions/src/admin-members-api/plugins/admin-members-plugin.ts
@@ -27,6 +27,7 @@ import {
   ActivateMembershipApiResponseSchema,
   ActivateMembershipBodySchema,
   ApproveProfileApiResponseSchema,
+  ApproveProfileBodySchema,
   CancelMembershipApiResponseSchema,
   CleanSlateApiResponseSchema,
   DeleteDraftProfileApiResponseSchema,
@@ -194,15 +195,17 @@ export function createAdminMembersPlugin(services?: PartialServices) {
           // POST /:memberId/profile/approve - Approve member for profile work (served at /api/admin/members/:memberId/profile/approve)
           .post(
             "/profile/approve",
-            async ({ params, adminToken, memberAdminService, logger, set }) =>
+            async ({ params, body, adminToken, memberAdminService, logger, set }) =>
               approveProfileLogic({
                 memberId: params.memberId,
+                allowProfileEditing: body.allowProfileEditing,
                 adminUid: getAdminUid(adminToken, logger),
                 memberAdminService,
                 logger,
                 set,
               }),
             {
+              body: ApproveProfileBodySchema,
               response: ApproveProfileApiResponseSchema,
             },
           )

--- a/functions/src/admin-members-api/plugins/admin-members-plugin.ts
+++ b/functions/src/admin-members-api/plugins/admin-members-plugin.ts
@@ -192,7 +192,7 @@ export function createAdminMembersPlugin(services?: PartialServices) {
               response: ToggleProfileDraftApiResponseSchema,
             },
           )
-          // POST /:memberId/profile/approve - Approve member for profile work (served at /api/admin/members/:memberId/profile/approve)
+          // POST /:memberId/profile/approve - Enable or disable profile editing permission (served at /api/admin/members/:memberId/profile/approve)
           .post(
             "/profile/approve",
             async ({ params, body, adminToken, memberAdminService, logger, set }) =>

--- a/functions/src/admin-members-api/routes/approve-profile.test.ts
+++ b/functions/src/admin-members-api/routes/approve-profile.test.ts
@@ -30,7 +30,7 @@ describe("POST /:memberId/profile/approve", () => {
       email: "member@example.com",
       createdAt: Timestamp.now(),
       membershipActive: true,
-      profileApprovedAt: Timestamp.now(),
+      allowProfileEditing: true,
     };
 
     const mockApproveProfile = mock(
@@ -68,7 +68,11 @@ describe("POST /:memberId/profile/approve", () => {
       `http://localhost/${memberId}/profile/approve`,
       {
         method: "POST",
-        headers,
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ allowProfileEditing: true }),
       },
     );
 
@@ -106,14 +110,14 @@ describe("POST /:memberId/profile/approve", () => {
       member?: {
         uid?: string;
         email?: string;
-        profileApprovedAt?: string;
+        allowProfileEditing?: boolean;
         isAdmin?: boolean;
       };
     };
     expect(body.success).toBe(true);
     expect(body.member?.uid).toBe("test-member-id");
     expect(body.member?.email).toBe("member@example.com");
-    expect(body.member?.profileApprovedAt).toBeDefined();
+    expect(body.member?.allowProfileEditing).toBe(true);
     expect(body.member?.isAdmin).toBe(false);
   });
 
@@ -126,12 +130,12 @@ describe("POST /:memberId/profile/approve", () => {
     const body = (await response.json()) as {
       success?: boolean;
       member?: {
-        profileApprovedAt?: string;
+        allowProfileEditing?: boolean;
         isAdmin?: boolean;
       };
     };
     expect(body.success).toBe(true);
-    expect(body.member?.profileApprovedAt).toBeDefined();
+    expect(body.member?.allowProfileEditing).toBe(true);
     expect(body.member?.isAdmin).toBe(false);
   });
 

--- a/functions/src/admin-members-api/routes/approve-profile.test.ts
+++ b/functions/src/admin-members-api/routes/approve-profile.test.ts
@@ -11,6 +11,7 @@ import { createAdminTestPlugin } from "../test-utils/create-admin-test-plugin.js
 
 describe("POST /:memberId/profile/approve", () => {
   interface SetupOptions {
+    body?: Record<string, unknown>;
     memberId?: string;
     authToken?: string | null;
     memberNotFound?: boolean;
@@ -19,22 +20,21 @@ describe("POST /:memberId/profile/approve", () => {
   }
 
   function setup({
+    body = { allowProfileEditing: true },
     memberId = "test-member-id",
     authToken = "admin-token",
     memberNotFound = false,
     serverError = false,
     isAdminLookupFails = false,
   }: SetupOptions = {}) {
-    const defaultMember: MemberDocument = {
-      uid: memberId,
-      email: "member@example.com",
-      createdAt: Timestamp.now(),
-      membershipActive: true,
-      allowProfileEditing: true,
-    };
-
     const mockApproveProfile = mock(
-      (): Promise<SetProfileEditingPermissionResult> => {
+      ({
+        memberId: approvedMemberId,
+        allowProfileEditing,
+      }: {
+        memberId: string;
+        allowProfileEditing: boolean;
+      }): Promise<SetProfileEditingPermissionResult> => {
         if (memberNotFound) {
           return Promise.reject(
             new NotFoundError(`Member with ID ${memberId} not found`),
@@ -43,7 +43,14 @@ describe("POST /:memberId/profile/approve", () => {
         if (serverError) {
           return Promise.reject(new Error("Firestore unavailable"));
         }
-        return Promise.resolve({ member: defaultMember });
+        const member: MemberDocument = {
+          uid: approvedMemberId,
+          email: "member@example.com",
+          createdAt: Timestamp.now(),
+          membershipActive: true,
+          allowProfileEditing,
+        };
+        return Promise.resolve({ member });
       },
     );
 
@@ -59,104 +66,144 @@ describe("POST /:memberId/profile/approve", () => {
       },
     });
 
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
     if (authToken) {
       headers["Authorization"] = `Bearer ${authToken}`;
     }
 
-    const request = new Request(
-      `http://localhost/${memberId}/profile/approve`,
-      {
-        method: "POST",
-        headers: {
-          ...headers,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ allowProfileEditing: true }),
-      },
-    );
+    const request = new Request(`http://localhost/${memberId}/profile/approve`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
 
     return { testApp, request };
   }
 
-  it("should return 401 when no authorization header is provided", async () => {
-    const { testApp, request } = setup({ authToken: null });
+  describe("Authentication", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const { testApp, request } = setup({ authToken: null });
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(401);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBe("Missing Authorization header");
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 403 when non-admin user tries to approve profile work", async () => {
+      const { testApp, request } = setup({ authToken: "non-admin-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Admin privileges required");
+    });
   });
 
-  it("should return 403 when non-admin user tries to approve profile work", async () => {
-    const { testApp, request } = setup({ authToken: "non-admin-token" });
+  describe("Input validation", () => {
+    it("should return 422 when allowProfileEditing is missing", async () => {
+      const { testApp, request } = setup({ body: {} });
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(403);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBe("Admin privileges required");
+      expect(response.status).toBe(422);
+    });
+
+    it("should return 422 when allowProfileEditing is not a boolean", async () => {
+      const { testApp, request } = setup({
+        body: { allowProfileEditing: "yes" },
+      });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
   });
 
-  it("should return success with updated member data", async () => {
-    const { testApp, request } = setup();
+  describe("Success", () => {
+    it("should return success with updated member data", async () => {
+      const { testApp, request } = setup();
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as {
-      success?: boolean;
-      member?: {
-        uid?: string;
-        email?: string;
-        allowProfileEditing?: boolean;
-        isAdmin?: boolean;
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success?: boolean;
+        member?: {
+          uid?: string;
+          email?: string;
+          allowProfileEditing?: boolean;
+          isAdmin?: boolean;
+        };
       };
-    };
-    expect(body.success).toBe(true);
-    expect(body.member?.uid).toBe("test-member-id");
-    expect(body.member?.email).toBe("member@example.com");
-    expect(body.member?.allowProfileEditing).toBe(true);
-    expect(body.member?.isAdmin).toBe(false);
-  });
+      expect(body.success).toBe(true);
+      expect(body.member?.uid).toBe("test-member-id");
+      expect(body.member?.email).toBe("member@example.com");
+      expect(body.member?.allowProfileEditing).toBe(true);
+      expect(body.member?.isAdmin).toBe(false);
+    });
 
-  it("should still return success when isAdmin lookup fails after approval", async () => {
-    const { testApp, request } = setup({ isAdminLookupFails: true });
+    it("should return success when profile editing is disabled", async () => {
+      const { testApp, request } = setup({
+        body: { allowProfileEditing: false },
+      });
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as {
-      success?: boolean;
-      member?: {
-        allowProfileEditing?: boolean;
-        isAdmin?: boolean;
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success?: boolean;
+        member?: {
+          allowProfileEditing?: boolean;
+        };
       };
-    };
-    expect(body.success).toBe(true);
-    expect(body.member?.allowProfileEditing).toBe(true);
-    expect(body.member?.isAdmin).toBe(false);
+      expect(body.success).toBe(true);
+      expect(body.member?.allowProfileEditing).toBe(false);
+    });
+
+    it("should still return success when isAdmin lookup fails after approval", async () => {
+      const { testApp, request } = setup({ isAdminLookupFails: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success?: boolean;
+        member?: {
+          allowProfileEditing?: boolean;
+          isAdmin?: boolean;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.member?.allowProfileEditing).toBe(true);
+      expect(body.member?.isAdmin).toBe(false);
+    });
   });
 
-  it("should return 404 when member not found", async () => {
-    const { testApp, request } = setup({ memberNotFound: true });
+  describe("Error handling", () => {
+    it("should return 404 when member not found", async () => {
+      const { testApp, request } = setup({ memberNotFound: true });
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(404);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toContain("not found");
-  });
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toContain("not found");
+    });
 
-  it("should return 500 for unexpected errors", async () => {
-    const { testApp, request } = setup({ serverError: true });
+    it("should return 500 for unexpected errors", async () => {
+      const { testApp, request } = setup({ serverError: true });
 
-    const response = await handleRequest(testApp, request);
+      const response = await handleRequest(testApp, request);
 
-    expect(response.status).toBe(500);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBeDefined();
-    expect(body.error).not.toContain("Firestore unavailable");
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBeDefined();
+      expect(body.error).not.toContain("Firestore unavailable");
+    });
   });
 });

--- a/functions/src/admin-members-api/routes/approve-profile.test.ts
+++ b/functions/src/admin-members-api/routes/approve-profile.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../shared-api/errors/http-error.js";
 import { handleRequest } from "../../test-utils/handle-request.js";
 import type { MemberDocument } from "../../types/member-document.js";
-import type { ApproveProfileResult } from "../services/approve-profile.js";
+import type { SetProfileEditingPermissionResult } from "../services/approve-profile.js";
 import { createAdminTestPlugin } from "../test-utils/create-admin-test-plugin.js";
 
 describe("POST /:memberId/profile/approve", () => {
@@ -34,7 +34,7 @@ describe("POST /:memberId/profile/approve", () => {
     };
 
     const mockApproveProfile = mock(
-      (): Promise<ApproveProfileResult> => {
+      (): Promise<SetProfileEditingPermissionResult> => {
         if (memberNotFound) {
           return Promise.reject(
             new NotFoundError(`Member with ID ${memberId} not found`),

--- a/functions/src/admin-members-api/routes/approve-profile.ts
+++ b/functions/src/admin-members-api/routes/approve-profile.ts
@@ -7,24 +7,29 @@ import { handleRouteError } from "../../shared-api/utils/route-error-handler.js"
 
 export async function approveProfileLogic({
   memberId,
+  allowProfileEditing,
   adminUid,
   memberAdminService,
   logger,
   set,
 }: {
   memberId: string;
+  allowProfileEditing: boolean;
   adminUid: string;
   memberAdminService: MemberAdminService;
   logger: Logger;
   set: { status?: number | string };
 }): Promise<ApproveProfileApiResponse> {
   try {
-    logger.info("Admin approving member for profile work", {
+    logger.info("Admin updating member profile editing permission", {
       adminUid,
       memberId,
     });
 
-    const result = await memberAdminService.approveProfile({ memberId });
+    const result = await memberAdminService.approveProfile({
+      memberId,
+      allowProfileEditing,
+    });
 
     let isAdmin = false;
     try {
@@ -42,11 +47,11 @@ export async function approveProfileLogic({
   } catch (error: unknown) {
     return handleRouteError({
       error,
-      operation: "approve member for profile work",
+      operation: "update member profile editing permission",
       errorId: ERROR_IDS.API_ADMIN_UPDATE_MEMBER_FAILED,
       logger,
       set,
-      context: { memberId, adminUid },
+      context: { memberId, allowProfileEditing, adminUid },
     }) as ApproveProfileApiResponse;
   }
 }

--- a/functions/src/admin-members-api/routes/link-profile.test.ts
+++ b/functions/src/admin-members-api/routes/link-profile.test.ts
@@ -51,7 +51,7 @@ describe("POST /:memberId/profile/link", () => {
       membershipExpiresAt: Timestamp.now(),
       slug: "unlinked-doula-profile",
       profileCreatedAt: Timestamp.now(),
-      profileApprovedAt: Timestamp.now(),
+      allowProfileEditing: true,
     };
 
     const mockLinkProfile = mock(
@@ -164,7 +164,7 @@ describe("POST /:memberId/profile/link", () => {
           email?: string;
           membershipActive?: boolean;
           slug?: string;
-          profileApprovedAt?: string;
+          allowProfileEditing?: boolean;
           isAdmin?: boolean;
         };
       };
@@ -172,7 +172,7 @@ describe("POST /:memberId/profile/link", () => {
       expect(body.member?.uid).toBe("test-member-id");
       expect(body.member?.email).toBe("member@example.com");
       expect(body.member?.slug).toBe("unlinked-doula-profile");
-      expect(body.member?.profileApprovedAt).toBeDefined();
+      expect(body.member?.allowProfileEditing).toBe(true);
       expect(body.member?.isAdmin).toBe(false);
     });
 

--- a/functions/src/admin-members-api/schemas/member-schemas.ts
+++ b/functions/src/admin-members-api/schemas/member-schemas.ts
@@ -88,12 +88,9 @@ export const MemberResponseSchema = t.Object({
       description: "Profile creation timestamp (ISO 8601)",
     }),
   ),
-  profileApprovedAt: t.Optional(
-    t.String({
-      format: "date-time",
-      description: "Profile approval timestamp (ISO 8601)",
-    }),
-  ),
+  allowProfileEditing: t.Boolean({
+    description: "Whether the member can currently create or edit a profile",
+  }),
   stripeCustomerId: t.Optional(
     t.String({
       description: "Stripe customer ID",
@@ -189,9 +186,7 @@ export function toMemberResponse(
     ...(document.profileCreatedAt !== undefined && {
       profileCreatedAt: timestampToIso(document.profileCreatedAt),
     }),
-    ...(document.profileApprovedAt !== undefined && {
-      profileApprovedAt: timestampToIso(document.profileApprovedAt),
-    }),
+    allowProfileEditing: document.allowProfileEditing ?? false,
     ...(document.stripeCustomerId !== undefined && {
       stripeCustomerId: document.stripeCustomerId,
     }),
@@ -393,6 +388,12 @@ export const UpdateMemberApiResponseSchema = t.Union([
 export type UpdateMemberApiResponse = Static<
   typeof UpdateMemberApiResponseSchema
 >;
+
+export const ApproveProfileBodySchema = t.Object({
+  allowProfileEditing: t.Boolean({
+    description: "Whether the member can currently create or edit a profile",
+  }),
+});
 
 /**
  * POST /api/admin/members/:memberId/profile/approve response - union of success and error.

--- a/functions/src/admin-members-api/services/approve-profile.ts
+++ b/functions/src/admin-members-api/services/approve-profile.ts
@@ -1,4 +1,3 @@
-import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { MEMBERS_COLLECTION } from "../../collections/index.js";
 import { ERROR_IDS } from "../../constants/error-ids.js";
@@ -7,28 +6,29 @@ import { MemberFirestoreService } from "../../shared-api/services/member-firesto
 import type { MemberDocument } from "../../types/member-document.js";
 import { verifyMemberExists } from "./verify-member-exists.js";
 
-export interface ApproveProfileResult {
+export interface SetProfileEditingPermissionResult {
   member: MemberDocument;
 }
 
 /**
- * Approve a member to create or edit a profile.
- * Sets profileApprovedAt to the current server timestamp.
+ * Set whether a member can create or edit a profile.
  *
  * @param options.memberId - The Firestore document ID of the member
+ * @param options.allowProfileEditing - Whether profile editing is allowed
  * @returns The updated member document
  * @throws NotFoundError if member does not exist
  */
 export async function approveProfile(options: {
   memberId: string;
-}): Promise<ApproveProfileResult> {
-  const { memberId } = options;
+  allowProfileEditing: boolean;
+}): Promise<SetProfileEditingPermissionResult> {
+  const { memberId, allowProfileEditing } = options;
 
   try {
     await verifyMemberExists(memberId);
 
     await MemberFirestoreService.updateMember(memberId, {
-      profileApprovedAt: FieldValue.serverTimestamp(),
+      allowProfileEditing,
     });
 
     const updatedMemberDocument = await MemberFirestoreService.getMemberByUid(
@@ -48,7 +48,10 @@ export async function approveProfile(options: {
       uid: updatedMemberDocument.id,
     };
 
-    logger.info("Approved member for profile work", { memberId });
+    logger.info("Updated member profile editing permission", {
+      memberId,
+      allowProfileEditing,
+    });
 
     return {
       member,
@@ -58,12 +61,13 @@ export async function approveProfile(options: {
       throw error;
     }
 
-    logger.error("Failed to approve member for profile work", {
+    logger.error("Failed to update member profile editing permission", {
       errorId: ERROR_IDS.API_ADMIN_UPDATE_MEMBER_FAILED,
       memberId,
+      allowProfileEditing,
       error,
       errorMessage: error instanceof Error ? error.message : "Unknown error",
     });
-    throw new HttpError("Failed to approve member for profile work", 500);
+    throw new HttpError("Failed to update member profile editing permission", 500);
   }
 }

--- a/functions/src/admin-members-api/services/interface.ts
+++ b/functions/src/admin-members-api/services/interface.ts
@@ -125,6 +125,7 @@ export interface MemberAdminService {
    *
    * @param options - Member ID and desired permission state
    * @returns Promise resolving to updated member document
+   * @throws NotFoundError if member does not exist
    */
   approveProfile(options: {
     memberId: string;

--- a/functions/src/admin-members-api/services/interface.ts
+++ b/functions/src/admin-members-api/services/interface.ts
@@ -6,7 +6,7 @@ import type { DeleteDraftProfileResult } from "./delete-draft-profile.js";
 import type { LinkProfileResult } from "./link-profile.js";
 import type { ListUnlinkedProfilesResult } from "./list-unlinked-profiles.js";
 import type { ProfileData } from "../../profiles-api/schemas/profile-schemas.js";
-import type { ApproveProfileResult } from "./approve-profile.js";
+import type { SetProfileEditingPermissionResult } from "./approve-profile.js";
 import type { ReadProfileResult } from "./read-profile.js";
 import type { RefundMembershipResult } from "./refund-membership.js";
 import type { ToggleProfileDraftResult } from "./toggle-profile-draft.js";
@@ -121,6 +121,17 @@ export interface MemberAdminService {
   }): Promise<void>;
 
   /**
+   * Set whether a member can create or edit a profile.
+   *
+   * @param options - Member ID and desired permission state
+   * @returns Promise resolving to updated member document
+   */
+  approveProfile(options: {
+    memberId: string;
+    allowProfileEditing: boolean;
+  }): Promise<SetProfileEditingPermissionResult>;
+
+  /**
    * Check if a user has admin privileges.
    *
    * @param uid - The user's UID
@@ -218,15 +229,6 @@ export interface MemberAdminService {
    * @returns Promise resolving to array of unlinked profiles
    */
   listUnlinkedProfiles(): Promise<ListUnlinkedProfilesResult>;
-
-  /**
-   * Approve a member to create or edit a profile.
-   *
-   * @param options - Object containing memberId
-   * @returns Promise resolving to updated member document
-   * @throws NotFoundError if member does not exist
-   */
-  approveProfile(options: { memberId: string }): Promise<ApproveProfileResult>;
 
   /**
    * Link an unlinked profile to a member account.

--- a/functions/src/admin-members-api/services/link-profile.ts
+++ b/functions/src/admin-members-api/services/link-profile.ts
@@ -1,4 +1,4 @@
-import { FieldValue, getFirestore, Timestamp } from "firebase-admin/firestore";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import {
   IMPORT_COLLECTION,
@@ -84,7 +84,7 @@ export async function linkProfile(options: {
     batch.update(memberReference, {
       slug,
       profileCreatedAt,
-      profileApprovedAt: FieldValue.serverTimestamp(),
+      allowProfileEditing: true,
     });
 
     await batch.commit();

--- a/functions/src/backfill-allow-profile-editing.ts
+++ b/functions/src/backfill-allow-profile-editing.ts
@@ -1,0 +1,24 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { MEMBERS_COLLECTION } from "./collections/index.js";
+
+export async function backfillAllowProfileEditing(): Promise<void> {
+  const firestore = getFirestore();
+  const snapshot = await firestore
+    .collection(MEMBERS_COLLECTION)
+    .where("profileApprovedAt", "!=", null)
+    .get();
+
+  if (snapshot.empty) {
+    return;
+  }
+
+  const batch = firestore.batch();
+
+  for (const document of snapshot.docs) {
+    batch.update(document.ref, {
+      allowProfileEditing: true,
+    });
+  }
+
+  await batch.commit();
+}

--- a/functions/src/backfill-allow-profile-editing.ts
+++ b/functions/src/backfill-allow-profile-editing.ts
@@ -1,24 +1,29 @@
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { MEMBERS_COLLECTION } from "./collections/index.js";
+
+const PROFILE_APPROVAL_CUTOFF = new Timestamp(0, 1);
+const MAX_BATCH_SIZE = 500;
 
 export async function backfillAllowProfileEditing(): Promise<void> {
   const firestore = getFirestore();
   const snapshot = await firestore
     .collection(MEMBERS_COLLECTION)
-    .where("profileApprovedAt", "!=", null)
+    .where("profileApprovedAt", ">", PROFILE_APPROVAL_CUTOFF)
     .get();
 
   if (snapshot.empty) {
     return;
   }
 
-  const batch = firestore.batch();
+  for (let index = 0; index < snapshot.docs.length; index += MAX_BATCH_SIZE) {
+    const batch = firestore.batch();
 
-  for (const document of snapshot.docs) {
-    batch.update(document.ref, {
-      allowProfileEditing: true,
-    });
+    for (const document of snapshot.docs.slice(index, index + MAX_BATCH_SIZE)) {
+      batch.update(document.ref, {
+        allowProfileEditing: true,
+      });
+    }
+
+    await batch.commit();
   }
-
-  await batch.commit();
 }

--- a/functions/src/members-api/routes/members.test.ts
+++ b/functions/src/members-api/routes/members.test.ts
@@ -47,6 +47,7 @@ describe("GET /:memberId (authenticated)", () => {
         createdAt: Timestamp.now(),
         name: "Test Member",
         membershipActive: true,
+        allowProfileEditing: true,
       });
     });
 
@@ -158,9 +159,12 @@ describe("GET /:memberId (authenticated)", () => {
       const response = await handleRequest(testApp, request);
 
       expect(response.status).toBe(200);
-      const body = (await response.json()) as MemberDocument;
+      const body = (await response.json()) as MemberDocument & {
+        allowProfileEditing: boolean;
+      };
       expect(body.uid).toBe("test-member-id");
       expect(body.name).toBe("Test Member");
+      expect(body.allowProfileEditing).toBe(true);
     });
 
     it("should return 404 when member does not exist", async () => {

--- a/functions/src/members-api/schemas/member-schemas.ts
+++ b/functions/src/members-api/schemas/member-schemas.ts
@@ -88,6 +88,9 @@ export const MemberResponseSchema = t.Object({
       description: "Profile creation timestamp (ISO 8601)",
     }),
   ),
+  allowProfileEditing: t.Boolean({
+    description: "Whether the member can currently create or edit a profile",
+  }),
   stripeCustomerId: t.Optional(
     t.String({
       description: "Stripe customer ID",
@@ -195,6 +198,7 @@ export function toMemberResponse(
     ...(document.profileCreatedAt !== undefined && {
       profileCreatedAt: timestampToIso(document.profileCreatedAt),
     }),
+    allowProfileEditing: document.allowProfileEditing ?? false,
     ...(document.stripeCustomerId !== undefined && {
       stripeCustomerId: document.stripeCustomerId,
     }),

--- a/functions/src/profiles-api/routes/create-profile.test.ts
+++ b/functions/src/profiles-api/routes/create-profile.test.ts
@@ -73,7 +73,7 @@ describe("POST /:slug (create profile)", () => {
       if (profileNotApproved) {
         return Promise.reject(
           new ForbiddenError(
-            "Profile work requires admin approval before creating or editing a profile.",
+            "Profile work requires profile editing to be enabled before creating or editing a profile.",
           ),
         );
       }
@@ -106,7 +106,7 @@ describe("POST /:slug (create profile)", () => {
 
     const testApp = createProfilesTestPlugin({
       profileMemberService: {
-        verifyProfileApproved: mockVerifyMembership,
+        verifyProfileEditingAllowed: mockVerifyMembership,
       },
       profileStoreService: {
         createProfile: mockCreateProfile,
@@ -212,7 +212,7 @@ describe("POST /:slug (create profile)", () => {
 
       expect(response.status).toBe(403);
       const body = (await response.json()) as { error?: string };
-      expect(body.error).toContain("admin approval");
+      expect(body.error).toContain("profile editing to be enabled");
     });
 
     it("should return 403 when user has no slug", async () => {

--- a/functions/src/profiles-api/routes/create-profile.ts
+++ b/functions/src/profiles-api/routes/create-profile.ts
@@ -95,7 +95,7 @@ export async function createProfileLogic({
   set: { status?: number | string };
 }): Promise<CreateProfileResponse> {
   try {
-    const member = await profileMemberService.verifyProfileApproved(uid);
+    const member = await profileMemberService.verifyProfileEditingAllowed(uid);
 
     const slug = member.slug;
     if (!slug) {

--- a/functions/src/profiles-api/routes/profile-route-handler-factory.ts
+++ b/functions/src/profiles-api/routes/profile-route-handler-factory.ts
@@ -70,7 +70,7 @@ export function createProfileRouteHandler<TResponse>(
     set: { status?: number | string };
   }): Promise<TResponse> => {
     try {
-      const member = await profileMemberService.verifyProfileApproved(uid);
+      const member = await profileMemberService.verifyProfileEditingAllowed(uid);
 
       const slug = member.slug;
       if (!slug) {

--- a/functions/src/profiles-api/routes/write-profile.test.ts
+++ b/functions/src/profiles-api/routes/write-profile.test.ts
@@ -68,7 +68,7 @@ describe("PUT /:slug (update profile)", () => {
       if (profileNotApproved) {
         return Promise.reject(
           new ForbiddenError(
-            "Profile work requires admin approval before creating or editing a profile.",
+            "Profile work requires profile editing to be enabled before creating or editing a profile.",
           ),
         );
       }
@@ -92,7 +92,7 @@ describe("PUT /:slug (update profile)", () => {
 
     const testApp = createProfilesTestPlugin({
       profileMemberService: {
-        verifyProfileApproved: mockVerifyMembership,
+        verifyProfileEditingAllowed: mockVerifyMembership,
       },
       profileStoreService: {
         writeProfile: mockWriteProfile,
@@ -201,7 +201,7 @@ describe("PUT /:slug (update profile)", () => {
 
       expect(response.status).toBe(403);
       const body = (await response.json()) as { error?: string };
-      expect(body.error).toContain("admin approval");
+      expect(body.error).toContain("profile editing to be enabled");
     });
 
     it("should return 403 when user has no slug (no profile yet)", async () => {

--- a/functions/src/profiles-api/services/member/index.ts
+++ b/functions/src/profiles-api/services/member/index.ts
@@ -64,14 +64,14 @@ async function verifyActiveMembership(uid: string): Promise<MemberDocument> {
 }
 
 /**
- * Verify user has been approved to create or edit a profile.
+ * Verify user has permission to create or edit a profile.
  */
-async function verifyProfileApproved(uid: string): Promise<MemberDocument> {
+async function verifyProfileEditingAllowed(uid: string): Promise<MemberDocument> {
   const member = await verifyActiveMembership(uid);
 
-  if (member.profileApprovedAt === undefined) {
+  if (member.allowProfileEditing !== true) {
     throw new ForbiddenError(
-      "Profile work requires admin approval before creating or editing a profile.",
+      "Profile work requires profile editing to be enabled before creating or editing a profile.",
     );
   }
 
@@ -200,7 +200,7 @@ async function getMemberBySlug(
 export const ProfileMemberService: ProfileMemberServiceInterface = {
   getMemberByUid,
   verifyActiveMembership,
-  verifyProfileApproved,
+  verifyProfileEditingAllowed,
   checkSlugAvailable,
   setSlug,
   setProfileCreatedAt,

--- a/functions/src/profiles-api/services/member/interface.ts
+++ b/functions/src/profiles-api/services/member/interface.ts
@@ -39,14 +39,14 @@ export interface ProfileMemberService {
   verifyActiveMembership(uid: string): Promise<MemberDocument>;
 
   /**
-   * Verify user has been approved to create or edit a profile.
+   * Verify user has permission to create or edit a profile.
    *
    * @param uid - Firebase Auth user ID
    * @returns Promise with member document
    * @throws NotFoundError if member not found
-   * @throws ForbiddenError if profile work is not approved
+   * @throws ForbiddenError if profile work is not allowed
    */
-  verifyProfileApproved(uid: string): Promise<MemberDocument>;
+  verifyProfileEditingAllowed(uid: string): Promise<MemberDocument>;
 
   /**
    * Check if a slug is available (not already in use as a profile document ID).

--- a/functions/src/profiles-api/test-utils/create-profiles-test-plugin.ts
+++ b/functions/src/profiles-api/test-utils/create-profiles-test-plugin.ts
@@ -26,6 +26,7 @@ export const mockMemberDocument: MemberDocument = {
   membershipExpiresAt: Timestamp.now(),
   slug: "test-user",
   profileCreatedAt: Timestamp.now(),
+  allowProfileEditing: true,
 };
 
 /**
@@ -96,7 +97,7 @@ export function createProfilesTestPlugin(overrides?: {
     verifyActiveMembership: mock(() =>
       Promise.resolve({ ...mockMemberDocument }),
     ),
-    verifyProfileApproved: mock(() =>
+    verifyProfileEditingAllowed: mock(() =>
       Promise.resolve({ ...mockMemberDocument }),
     ),
     checkSlugAvailable: mock(() => Promise.resolve({ available: true })),

--- a/functions/src/scripts/backfill-allow-profile-editing.ts
+++ b/functions/src/scripts/backfill-allow-profile-editing.ts
@@ -1,0 +1,116 @@
+/* eslint-disable unicorn/no-process-exit */
+/* eslint-disable unicorn/prefer-top-level-await */
+
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { Socket } from "node:net";
+import { MEMBERS_COLLECTION } from "../collections/index.js";
+
+const USE_EMULATOR = process.env["USE_EMULATOR"] !== "false";
+const PROFILE_APPROVAL_CUTOFF = new Timestamp(0, 1);
+const MAX_BATCH_SIZE = 500;
+
+function isEmulatorReachable(port: number, host = "127.0.0.1"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+
+    const cleanup = () => {
+      socket.removeAllListeners();
+      socket.destroy();
+    };
+
+    socket.setTimeout(500);
+    socket.once("connect", () => {
+      cleanup();
+      resolve(true);
+    });
+    socket.once("timeout", () => {
+      cleanup();
+      resolve(false);
+    });
+    socket.once("error", () => {
+      cleanup();
+      resolve(false);
+    });
+
+    socket.connect(port, host);
+  });
+}
+
+async function configureFirestoreTarget(): Promise<boolean> {
+  if (!USE_EMULATOR) {
+    return true;
+  }
+
+  const emulatorReady = await isEmulatorReachable(8090);
+  if (!emulatorReady) {
+    console.warn(
+      "⚠️ Firestore emulator is not running on 127.0.0.1:8090. Start the emulator to run this backfill locally.",
+    );
+    return false;
+  }
+
+  process.env["FIRESTORE_EMULATOR_HOST"] = "127.0.0.1:8090";
+  process.env["GCLOUD_PROJECT"] = "doula-cooperative";
+  console.log("🔧 Using Firebase Firestore Emulator at 127.0.0.1:8090");
+  return true;
+}
+
+/**
+ * Backfill allowProfileEditing for members who were previously approved via
+ * profileApprovedAt before the explicit boolean permission field existed.
+ *
+ * Timestamp(0, 1) acts as a sentinel for "any real approval timestamp" while
+ * excluding documents where profileApprovedAt was never set.
+ */
+async function backfillAllowProfileEditing(): Promise<void> {
+  const targetReady = await configureFirestoreTarget();
+  if (!targetReady) {
+    return;
+  }
+
+  if (getApps().length === 0) {
+    initializeApp({
+      projectId: "doula-cooperative",
+    });
+  }
+
+  const firestore = getFirestore();
+  const snapshot = await firestore
+    .collection(MEMBERS_COLLECTION)
+    .where("profileApprovedAt", ">", PROFILE_APPROVAL_CUTOFF)
+    .get();
+
+  if (snapshot.empty) {
+    console.log("✅ No members require profile editing backfill.");
+    return;
+  }
+
+  console.log(`Found ${snapshot.docs.length} members to backfill.`);
+
+  let updatedCount = 0;
+  for (let index = 0; index < snapshot.docs.length; index += MAX_BATCH_SIZE) {
+    const batch = firestore.batch();
+
+    for (const document of snapshot.docs.slice(index, index + MAX_BATCH_SIZE)) {
+      batch.update(document.ref, {
+        allowProfileEditing: true,
+      });
+      updatedCount++;
+    }
+
+    await batch.commit();
+    process.stdout.write(".");
+  }
+
+  console.log(`\n✅ Backfilled profile editing permission for ${updatedCount} members.`);
+}
+
+backfillAllowProfileEditing()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error: unknown) => {
+    console.error("❌ Failed to backfill profile editing permission:", error);
+    process.exit(1);
+  });

--- a/functions/src/types/member-document.ts
+++ b/functions/src/types/member-document.ts
@@ -44,8 +44,13 @@ export interface MemberDocument {
    */
   profileCreatedAt?: Timestamp;
   /**
-   * Timestamp when an admin approved the member to create or edit a public doula profile.
-   * Undefined if the member has not been approved for profile work.
+   * Whether an admin currently allows the member to create or edit a public doula profile.
+   * Defaults to false when unset.
+   */
+  allowProfileEditing?: boolean;
+  /**
+   * Legacy timestamp when an admin approved the member for profile work.
+   * Kept only for migration/backfill purposes.
    */
   profileApprovedAt?: Timestamp;
   stripeCustomerId?: string;

--- a/members/e2e/tests/admin-member-detail.spec.ts
+++ b/members/e2e/tests/admin-member-detail.spec.ts
@@ -14,6 +14,7 @@ const mockMember: ApiMemberResponse = {
   createdAt: '2024-01-15T10:30:00.000Z',
   isAdmin: false,
   membershipActive: true,
+  allowProfileEditing: false,
   subscriptionStart: '2024-01-15T10:30:00.000Z',
   membershipExpiresAt: '2025-01-15T10:30:00.000Z',
   slug: 'test-member',

--- a/members/e2e/tests/admin-members.spec.ts
+++ b/members/e2e/tests/admin-members.spec.ts
@@ -18,6 +18,7 @@ const mockMembers: ApiMemberResponse[] = [
     createdAt: '2024-01-15T10:30:00.000Z',
     isAdmin: false,
     membershipActive: true,
+    allowProfileEditing: false,
     subscriptionStart: '2024-01-15T10:30:00.000Z',
     membershipExpiresAt: '2025-01-15T10:30:00.000Z',
   },
@@ -28,6 +29,7 @@ const mockMembers: ApiMemberResponse[] = [
     createdAt: '2024-02-20T14:15:00.000Z',
     isAdmin: false,
     membershipActive: false,
+    allowProfileEditing: false,
     subscriptionStart: '2024-02-20T14:15:00.000Z',
     membershipExpiresAt: '2024-08-20T14:15:00.000Z',
   },
@@ -37,6 +39,7 @@ const mockMembers: ApiMemberResponse[] = [
     createdAt: '2024-03-10T09:00:00.000Z',
     isAdmin: false,
     membershipActive: true,
+    allowProfileEditing: false,
     subscriptionStart: '2024-03-10T09:00:00.000Z',
   },
 ];

--- a/members/e2e/tests/cancel-membership.spec.ts
+++ b/members/e2e/tests/cancel-membership.spec.ts
@@ -19,6 +19,7 @@ const mockActiveStripeMember: ApiMemberResponse = {
   isAdmin: false,
   subscriptionStart: '2024-01-15T00:00:00.000Z',
   membershipActive: true,
+  allowProfileEditing: true,
   stripeCustomerId: 'cus_test123',
   stripeSubscriptionId: 'sub_test456',
   subscriptionStatus: 'active',

--- a/members/e2e/tests/claim-profile.spec.ts
+++ b/members/e2e/tests/claim-profile.spec.ts
@@ -25,6 +25,7 @@ test.describe('Claim Profile Flow', () => {
     isAdmin: false,
     subscriptionStart: '2024-01-01T00:00:00.000Z',
     membershipActive: true,
+    allowProfileEditing: false,
     // No slug - profile not set up yet
   };
 

--- a/members/e2e/tests/create-profile-flow.spec.ts
+++ b/members/e2e/tests/create-profile-flow.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '../fixtures/regular-user-auth.fixture';
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import type { ProfileData } from '../../src/app/types/profile-data';
 import { EditProfilePage } from '../pages/edit-profile.page';
 import type { ApiMemberResponse } from '../../src/app/api-types/members-api.types';
@@ -12,7 +12,13 @@ const mockMemberDocument: ApiMemberResponse = {
   isAdmin: false,
   subscriptionStart: '2024-01-01T00:00:00.000Z',
   membershipActive: true,
+  allowProfileEditing: true,
+};
+
+const mockCreatedMemberDocument: ApiMemberResponse = {
+  ...mockMemberDocument,
   slug: 'test-user',
+  profileCreatedAt: '2024-01-02T00:00:00.000Z',
 };
 
 const mockProfileData: ProfileData = {
@@ -25,20 +31,25 @@ const mockProfileData: ProfileData = {
   draft: true,
 };
 
-function setupApiMocks(page: import('@playwright/test').Page) {
+function createCurrentMemberDocument(): ApiMemberResponse {
+  return { ...mockMemberDocument };
+}
+
+let currentMemberDocument = createCurrentMemberDocument();
+
+function setupApiMocks(page: Page) {
+  currentMemberDocument = createCurrentMemberDocument();
+
   return Promise.all([
-    // Mock member document (no profileCreatedAt so wizard doesn't redirect)
     page.route('**/api/members/*', async (route) => {
       await (route.request().method() === 'GET'
         ? route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify(mockMemberDocument),
+            body: JSON.stringify(currentMemberDocument),
           })
         : route.continue());
     }),
-
-    // Mock slug availability check (slug is available)
     page.route(/\/api\/profiles\/slugs\/check(\?|$)/, async (route) => {
       await route.fulfill({
         status: 200,
@@ -46,57 +57,64 @@ function setupApiMocks(page: import('@playwright/test').Page) {
         body: JSON.stringify({ available: true }),
       });
     }),
-
-    // Mock slug update
     page.route('**/api/profiles/slugs', async (route) => {
-      await (route.request().method() === 'POST'
-        ? route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({ success: true, slug: 'test-user' }),
-          })
-        : route.continue());
-    }),
+      if (route.request().method() === 'POST') {
+        currentMemberDocument = {
+          ...currentMemberDocument,
+          slug: 'test-user',
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, slug: 'test-user' }),
+        });
+        return;
+      }
 
-    // Mock profile creation (POST) and profile fetch (GET)
+      await route.continue();
+    }),
     page.route('**/api/profiles/test-user', async (route) => {
       const method = route.request().method();
       if (method === 'POST') {
+        currentMemberDocument = mockCreatedMemberDocument;
         await route.fulfill({
           status: 201,
           contentType: 'application/json',
           body: JSON.stringify({ success: true, profile: mockProfileData }),
         });
-      } else if (method === 'GET') {
+        return;
+      }
+
+      if (method === 'GET') {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify(mockProfileData),
         });
-      } else {
-        await route.continue();
+        return;
       }
+
+      await route.continue();
     }),
   ]);
 }
 
-async function walkThroughWizard(page: import('@playwright/test').Page) {
-  await page.goto('/profile/create');
+async function walkThroughWizard(page: Page) {
+  await page.goto('/membership');
+  await page.getByRole('button', { name: 'Create Profile' }).click();
 
   // === Step 1: Personal Info ===
-  await page
-    .getByRole('heading', { name: /Personal Information/i, level: 2 })
-    .waitFor({ state: 'visible' });
-  // Name is pre-filled from member document, but we clear and type to trigger slug validator
+  await page.getByRole('heading', { name: /Personal Information/i, level: 2 }).waitFor({
+    state: 'visible',
+  });
   await page.getByLabel(/^Name/i).fill('Test User');
-  // Wait for async slug validator to resolve (shows URL preview)
   await expect(page.getByText(/Your profile URL/i)).toBeVisible({ timeout: 10_000 });
   await page.getByRole('button', { name: 'Next' }).click();
 
   // === Step 2: Tags ===
-  await page
-    .getByRole('heading', { name: /Services & Specialties/i, level: 2 })
-    .waitFor({ state: 'visible' });
+  await page.getByRole('heading', { name: /Services & Specialties/i, level: 2 }).waitFor({
+    state: 'visible',
+  });
   await page.getByLabel('Birth Doula').check();
   await page.getByRole('button', { name: 'Next' }).click();
 
@@ -106,25 +124,24 @@ async function walkThroughWizard(page: import('@playwright/test').Page) {
   await page.getByRole('button', { name: 'Next' }).click();
 
   // === Step 4: Contact ===
-  await page
-    .getByRole('heading', { name: /Contact Information/i, level: 2 })
-    .waitFor({ state: 'visible' });
+  await page.getByRole('heading', { name: /Contact Information/i, level: 2 }).waitFor({
+    state: 'visible',
+  });
   await page.getByRole('button', { name: 'Next' }).click();
 
   // === Step 5: Image (skip) ===
-  await page
-    .getByRole('heading', { name: /Profile Photo/i, level: 2 })
-    .waitFor({ state: 'visible' });
+  await page.getByRole('heading', { name: /Profile Photo/i, level: 2 }).waitFor({
+    state: 'visible',
+  });
   await page.getByRole('button', { name: /Skip for now/i }).click();
 
-  // === Step 6: Preview (triggers profile creation POST on Finish) ===
-  await page
-    .getByRole('heading', { name: /Preview Your Profile/i, level: 2 })
-    .waitFor({ state: 'visible' });
+  // === Step 6: Preview ===
+  await page.getByRole('heading', { name: /Preview Your Profile/i, level: 2 }).waitFor({
+    state: 'visible',
+  });
   await page.getByRole('button', { name: 'Finish' }).click();
 
-  // Wait for navigation to the edit profile page
-  await page.waitForURL('/profile', { timeout: 10_000 });
+  await expect(page).toHaveURL(/\/profile$/);
 }
 
 test.describe('Create Profile → Edit Profile Flow', () => {
@@ -132,11 +149,8 @@ test.describe('Create Profile → Edit Profile Flow', () => {
     authenticatedUserPage,
   }) => {
     await setupApiMocks(authenticatedUserPage);
-
-    // === Walk through the 6-step wizard ===
     await walkThroughWizard(authenticatedUserPage);
 
-    // === Profile form should load with data from the created profile ===
     const editProfilePage = new EditProfilePage(authenticatedUserPage);
     await editProfilePage.waitForProfileForm();
     await expect(editProfilePage.titleInput).toHaveValue('Test User');
@@ -147,11 +161,8 @@ test.describe('Create Profile → Edit Profile Flow', () => {
     authenticatedUserPage,
   }) => {
     await setupApiMocks(authenticatedUserPage);
-
-    // === Walk through the 6-step wizard ===
     await walkThroughWizard(authenticatedUserPage);
 
-    // === Profile form should load immediately with correct data ===
     const editProfilePage = new EditProfilePage(authenticatedUserPage);
     await editProfilePage.waitForProfileForm();
     await expect(editProfilePage.titleInput).toHaveValue('Test User');

--- a/members/e2e/tests/newsletter-preference.spec.ts
+++ b/members/e2e/tests/newsletter-preference.spec.ts
@@ -14,6 +14,7 @@ const mockMemberDocumentBase: ApiMemberResponse = {
   isAdmin: false,
   subscriptionStart: '2024-01-01T00:00:00.000Z',
   membershipActive: true,
+  allowProfileEditing: true,
   slug: 'test-user',
 };
 

--- a/members/e2e/tests/view-profile.spec.ts
+++ b/members/e2e/tests/view-profile.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '../fixtures/regular-user-auth.fixture';
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import type { ProfileData } from '../../src/app/types/profile-data';
 import { EditProfilePage } from '../pages/edit-profile.page';
 import type { ApiMemberResponse } from '../../src/app/api-types/members-api.types';
@@ -37,8 +37,38 @@ const mockMemberDocument: ApiMemberResponse = {
   isAdmin: false,
   subscriptionStart: '2024-01-01T00:00:00.000Z',
   membershipActive: true,
+  allowProfileEditing: true,
   slug: 'test-user',
+  profileCreatedAt: '2024-01-02T00:00:00.000Z',
 };
+
+function setupApiMocks(page: Page, userSlug: string) {
+  return Promise.all([
+    page.route('**/api/members/*', async (route) => {
+      await (route.request().method() === 'GET'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockMemberDocument),
+          })
+        : route.continue());
+    }),
+    page.route(`**/api/profiles/${userSlug}`, async (route) => {
+      await (route.request().method() === 'GET'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockProfileData),
+          })
+        : route.continue());
+    }),
+  ]);
+}
+
+async function goToEditProfile(page: Page) {
+  await page.goto('/membership');
+  await page.getByRole('link', { name: 'Edit Profile' }).click();
+}
 
 test.describe('View Profile', () => {
   /**
@@ -53,30 +83,10 @@ test.describe('View Profile', () => {
   test('user views their profile page', async ({ authenticatedUserPage }) => {
     const userSlug = 'test-user';
 
-    // Mock GET /api/members/:memberId for member document lookup
-    await authenticatedUserPage.route('**/api/members/*', async (route) => {
-      await (route.request().method() === 'GET'
-        ? route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(mockMemberDocument),
-          })
-        : route.continue());
-    });
-
-    // Mock GET /api/profiles/:slug
-    await authenticatedUserPage.route(`**/api/profiles/${userSlug}`, async (route) => {
-      await (route.request().method() === 'GET'
-        ? route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(mockProfileData),
-          })
-        : route.continue());
-    });
+    await setupApiMocks(authenticatedUserPage, userSlug);
 
     const editProfilePage = new EditProfilePage(authenticatedUserPage);
-    await editProfilePage.goto();
+    await goToEditProfile(authenticatedUserPage);
     await editProfilePage.waitForProfileForm();
 
     // === Verify Page Structure ===

--- a/members/src/app/admin/services/admin-members.service.ts
+++ b/members/src/app/admin/services/admin-members.service.ts
@@ -33,6 +33,10 @@ interface ApiMemberSuccessResponse {
 }
 
 type ApiApproveProfileResponse = ApiMemberSuccessResponse | ApiErrorResponse;
+
+interface ApproveProfileRequestBody {
+  allowProfileEditing: boolean;
+}
 type ApiLinkProfileResponse = ApiMemberSuccessResponse | ApiErrorResponse;
 type ApiListUnlinkedProfilesResult = ApiListUnlinkedProfilesResponse | ApiErrorResponse;
 
@@ -130,9 +134,11 @@ export class AdminMembersService {
     );
   }
 
-  async approveProfile(uid: string): Promise<ApiMemberResponse> {
+  async approveProfile(uid: string, allowProfileEditing: boolean): Promise<ApiMemberResponse> {
     const response = await firstValueFrom(
-      this.httpClient.post<ApiApproveProfileResponse>(`/api/admin/members/${uid}/profile/approve`, {}),
+      this.httpClient.post<ApiApproveProfileResponse>(`/api/admin/members/${uid}/profile/approve`, {
+        allowProfileEditing,
+      } satisfies ApproveProfileRequestBody),
     );
 
     return toLinkedMember(response);

--- a/members/src/app/admin/users/active-members-table/active-members-table.spec.ts
+++ b/members/src/app/admin/users/active-members-table/active-members-table.spec.ts
@@ -13,6 +13,7 @@ function createMockMember(overrides: Partial<ApiMemberResponse> = {}): ApiMember
     createdAt: '2024-01-15T00:00:00.000Z',
     isAdmin: false,
     membershipActive: false,
+    allowProfileEditing: false,
     ...overrides,
   };
 }

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.html
@@ -94,13 +94,9 @@
         <dd class="monospace">{{ member.slug }}</dd>
       }
 
-      <dt>Profile Approval:</dt>
+      <dt>Profile Editing:</dt>
       <dd>
-        @if (member.profileApprovedAt) {
-          Approved on {{ member.profileApprovedAt | date: 'MMM d, yyyy h:mm a' }}
-        } @else {
-          Not approved
-        }
+        {{ member.allowProfileEditing ? 'Enabled' : 'Disabled' }}
       </dd>
     </dl>
 
@@ -114,16 +110,18 @@
       }
 
       <div class="action-buttons">
-        @if (!isProfileApproved()) {
-          <button
-            type="button"
-            class="button"
-            (click)="showApproveProfileConfirm()"
-            [disabled]="service.actionInProgress()"
-          >
-            {{ service.actionInProgress() ? 'Processing...' : 'Approve Profile Work' }}
-          </button>
-        }
+        <button
+          type="button"
+          [class]="'button ' + (allowProfileEditing() ? 'button--danger' : '')"
+          (click)="showApproveProfileConfirm()"
+          [disabled]="service.actionInProgress()"
+        >
+          {{
+            service.actionInProgress()
+              ? 'Processing...'
+              : (allowProfileEditing() ? 'Disable Profile Editing' : 'Enable Profile Editing')
+          }}
+        </button>
 
         @if (member.membershipActive) {
           <button
@@ -172,7 +170,7 @@
   @if (!member.slug) {
     <section class="subscription-card">
       <h2>Link Existing Profile</h2>
-      <p>Linking an existing profile will also approve this member to edit that profile.</p>
+      <p>Linking an existing profile will also enable profile editing for this member.</p>
 
       @if (service.unlinkedProfilesResource.isLoading()) {
         <p>Loading unlinked profiles...</p>

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
@@ -204,7 +204,7 @@ export class AdminMemberDetailService {
   }
 
   /**
-   * Delete a draft profile for the current member
+   * Set whether the current member can create or edit a profile.
    */
   async approveProfile(uid: string, allowProfileEditing: boolean): Promise<void> {
     this.actionInProgress.set(true);

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.service.ts
@@ -206,18 +206,22 @@ export class AdminMemberDetailService {
   /**
    * Delete a draft profile for the current member
    */
-  async approveProfile(uid: string): Promise<void> {
+  async approveProfile(uid: string, allowProfileEditing: boolean): Promise<void> {
     this.actionInProgress.set(true);
     this.successMessage.set(undefined);
     this.actionError.set(undefined);
 
     try {
-      await this.adminMembersService.approveProfile(uid);
-      this.successMessage.set('Profile work approved successfully');
+      await this.adminMembersService.approveProfile(uid, allowProfileEditing);
+      this.successMessage.set(
+        allowProfileEditing
+          ? 'Profile editing enabled successfully'
+          : 'Profile editing disabled successfully',
+      );
       this.memberResource.reload();
     } catch (error) {
-      console.error('Error approving profile work:', error);
-      this.actionError.set('Failed to approve profile work.');
+      console.error('Error updating profile editing permission:', error);
+      this.actionError.set('Failed to update profile editing permission.');
     } finally {
       this.actionInProgress.set(false);
     }
@@ -271,7 +275,7 @@ export class AdminMemberDetailService {
 
     try {
       await this.adminMembersService.linkProfile(uid, slug);
-      this.successMessage.set(`Profile "${slug}" linked and approved successfully`);
+      this.successMessage.set(`Profile "${slug}" linked and profile editing enabled successfully`);
       this.memberResource.reload();
     } catch (error) {
       console.error('Error linking profile:', error);

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
@@ -153,7 +153,10 @@ function createMockAdminMembersService({
         }),
     approveProfile: shouldFailApproveProfile
       ? vi.fn().mockRejectedValue(new Error('Failed'))
-      : vi.fn().mockResolvedValue(memberToUse),
+      : vi.fn().mockImplementation(async (_uid: string, allowProfileEditing: boolean) => ({
+          ...memberToUse,
+          allowProfileEditing,
+        })),
     listUnlinkedProfiles:
       overrideListUnlinkedProfiles ??
       (shouldFailUnlinkedProfilesLoad
@@ -567,7 +570,7 @@ describe('AdminUserDetail', () => {
     expect(await screen.findByText('test-slug')).toBeVisible();
   });
 
-  it('should keep profile approval state independent from lazy profile controls', async () => {
+  it('should keep profile editing state independent from lazy profile controls', async () => {
     const member = createMockMember({
       slug: 'test-slug',
       membershipActive: true,
@@ -576,7 +579,7 @@ describe('AdminUserDetail', () => {
 
     await setup({ member });
 
-    expect(await screen.findByText(/Approved on Mar 15, 2024/)).toBeVisible();
+    expect(await screen.findByText('Enabled')).toBeVisible();
     expect(await screen.findByRole('button', { name: 'Load Profile Status' })).toBeVisible();
   });
 
@@ -744,7 +747,7 @@ describe('AdminUserDetail', () => {
     expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
-  it('should show profile approval timestamp for approved linked members before profile load', async () => {
+  it('should show enabled profile editing state for approved linked members before profile load', async () => {
     const member = createMockMember({
       slug: 'test-slug',
       allowProfileEditing: true,
@@ -752,7 +755,7 @@ describe('AdminUserDetail', () => {
 
     await setup({ member });
 
-    expect(await screen.findByText(/Approved on Mar 15, 2024/)).toBeVisible();
+    expect(await screen.findByText('Enabled')).toBeVisible();
   });
 
   it('should still show link section approval helper for unlinked members without approval', async () => {
@@ -833,7 +836,7 @@ describe('AdminUserDetail', () => {
     expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
-  it('should display approved status for linked profile members', async () => {
+  it('should display enabled status for linked profile members', async () => {
     const member = createMockMember({
       slug: 'test-slug',
       allowProfileEditing: true,
@@ -841,7 +844,7 @@ describe('AdminUserDetail', () => {
 
     await setup({ member });
 
-    expect(await screen.findByText(/Approved on Mar 15, 2024/)).toBeVisible();
+    expect(await screen.findByText('Enabled')).toBeVisible();
   });
 
   it('should show no profile approval pending message for approved members', async () => {
@@ -1037,7 +1040,7 @@ describe('AdminUserDetail', () => {
     const { user, mockAdminMembersService } = await setup({ member });
 
     await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Enable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
 
     expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', true);
     expect(await screen.findByText('Profile editing enabled successfully')).toBeVisible();
@@ -1049,7 +1052,7 @@ describe('AdminUserDetail', () => {
     const { user, mockAdminMembersService } = await setup({ member });
 
     await user.click(await screen.findByRole('button', { name: 'Disable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Disable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
 
     expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', false);
     expect(await screen.findByText('Profile editing disabled successfully')).toBeVisible();
@@ -1065,7 +1068,7 @@ describe('AdminUserDetail', () => {
     });
 
     await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Enable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
 
     expect(await screen.findByText('Failed to update profile editing permission.')).toBeVisible();
   });

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
@@ -291,6 +291,7 @@ function createMockMember(overrides: Partial<ApiMemberResponse> = {}): ApiMember
     createdAt: '2024-01-15T10:30:00.000Z',
     isAdmin: false,
     membershipActive: false,
+    allowProfileEditing: false,
     subscriptionStart: '2024-01-01T00:00:00.000Z',
     membershipExpiresAt: '2025-01-01T00:00:00.000Z',
     slug: 'test-slug',
@@ -377,42 +378,62 @@ describe('AdminUserDetail', () => {
     expect(await screen.findByText('Inactive')).toBeVisible();
   });
 
-  it('should display profile approval status when approved', async () => {
+  it('should display profile editing status when enabled', async () => {
     const member = createMockMember({
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
 
-    expect(await screen.findByText(/Approved on Mar 15, 2024/)).toBeVisible();
+    expect(await screen.findByText('Enabled')).toBeVisible();
   });
 
-  it('should display profile approval status when not approved', async () => {
+  it('should display profile editing status when disabled', async () => {
     const member = createMockMember();
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByText('Not approved')).toBeVisible();
+    expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
-  it('should show approve profile action when member is not approved', async () => {
+  it('should show enable profile editing action when permission is disabled', async () => {
     const member = createMockMember();
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByRole('button', { name: 'Approve Profile Work' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Enable Profile Editing' })).toBeVisible();
   });
 
-  it('should hide approve profile action when member is already approved', async () => {
+  it('should show disable profile editing action when permission is enabled', async () => {
     const member = createMockMember({
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
 
-    expect(screen.queryByRole('button', { name: 'Approve Profile Work' })).toBeNull();
+    expect(await screen.findByRole('button', { name: 'Disable Profile Editing' })).toBeVisible();
+  });
+
+  it('should not show enable profile editing action when permission is enabled', async () => {
+    const member = createMockMember({
+      allowProfileEditing: true,
+    });
+
+    await setup({ member });
+
+    expect(screen.queryByRole('button', { name: 'Enable Profile Editing' })).toBeNull();
+  });
+
+  it('should not show disable profile editing action when permission is disabled', async () => {
+    const member = createMockMember({
+      allowProfileEditing: false,
+    });
+
+    await setup({ member });
+
+    expect(screen.queryByRole('button', { name: 'Disable Profile Editing' })).toBeNull();
   });
 
   it('should explain that linking also approves profile editing', async () => {
@@ -428,7 +449,7 @@ describe('AdminUserDetail', () => {
 
     expect(
       await screen.findByText(
-        'Linking an existing profile will also approve this member to edit that profile.',
+        'Linking an existing profile will also enable profile editing for this member.',
       ),
     ).toBeVisible();
   });
@@ -447,7 +468,9 @@ describe('AdminUserDetail', () => {
     await user.click(linkButton);
     await user.click(screen.getByRole('button', { name: 'Link Profile' }));
 
-    expect(await screen.findByText('Profile "matching-doula" linked and approved successfully')).toBeVisible();
+    expect(
+      await screen.findByText('Profile "matching-doula" linked and profile editing enabled successfully'),
+    ).toBeVisible();
   });
 
   it('should keep existing link success behavior visible to admins', async () => {
@@ -464,7 +487,7 @@ describe('AdminUserDetail', () => {
     await user.click(screen.getByRole('button', { name: 'Link Profile' }));
 
     expect(await screen.findByRole('status')).toHaveTextContent(
-      'Profile "matching-doula" linked and approved successfully',
+      'Profile "matching-doula" linked and profile editing enabled successfully',
     );
   });
 
@@ -479,7 +502,7 @@ describe('AdminUserDetail', () => {
       unlinkedProfiles: [createUnlinkedProfile()],
     });
 
-    expect(await screen.findByText('Not approved')).toBeVisible();
+    expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
   it('should still offer linking flow for inactive members without a slug', async () => {
@@ -507,7 +530,7 @@ describe('AdminUserDetail', () => {
       unlinkedProfiles: [createUnlinkedProfile()],
     });
 
-    expect(await screen.findByText('Not approved')).toBeVisible();
+    expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
   it('should keep load profile status available for linked members before loading', async () => {
@@ -548,7 +571,7 @@ describe('AdminUserDetail', () => {
     const member = createMockMember({
       slug: 'test-slug',
       membershipActive: true,
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
@@ -561,12 +584,12 @@ describe('AdminUserDetail', () => {
     const member = createMockMember({
       slug: 'test-slug',
       membershipActive: true,
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
 
-    expect(screen.queryByRole('button', { name: 'Approve Profile Work' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Enable Profile Editing' })).toBeNull();
   });
 
   it('should still allow approval action for inactive linked members without approval', async () => {
@@ -574,11 +597,11 @@ describe('AdminUserDetail', () => {
       slug: 'test-slug',
       membershipActive: false,
     });
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByRole('button', { name: 'Approve Profile Work' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Enable Profile Editing' })).toBeVisible();
   });
 
   it('should keep success banner test aligned with approval-aware link copy', async () => {
@@ -594,7 +617,7 @@ describe('AdminUserDetail', () => {
     await user.click(await screen.findByRole('button', { name: 'Link' }));
     await user.click(screen.getByRole('button', { name: 'Link Profile' }));
 
-    expect(await screen.findByText(/linked and approved successfully/)).toBeVisible();
+    expect(await screen.findByText(/linked and profile editing enabled successfully/)).toBeVisible();
   });
 
   it('should preserve inactive member link helper copy', async () => {
@@ -610,7 +633,7 @@ describe('AdminUserDetail', () => {
 
     expect(
       await screen.findByText(
-        'Linking an existing profile will also approve this member to edit that profile.',
+        'Linking an existing profile will also enable profile editing for this member.',
       ),
     ).toBeVisible();
   });
@@ -633,11 +656,11 @@ describe('AdminUserDetail', () => {
     const member = createMockMember({
       membershipActive: true,
     });
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByRole('button', { name: 'Approve Profile Work' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Enable Profile Editing' })).toBeVisible();
   });
 
   it('should keep load profile status text stable for linked members', async () => {
@@ -714,17 +737,17 @@ describe('AdminUserDetail', () => {
 
   it('should show profile approval as not approved for linked members without approval timestamp', async () => {
     const member = createMockMember({ slug: 'test-slug' });
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByText('Not approved')).toBeVisible();
+    expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
   it('should show profile approval timestamp for approved linked members before profile load', async () => {
     const member = createMockMember({
       slug: 'test-slug',
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
@@ -743,7 +766,7 @@ describe('AdminUserDetail', () => {
 
     expect(
       await screen.findByText(
-        'Linking an existing profile will also approve this member to edit that profile.',
+        'Linking an existing profile will also enable profile editing for this member.',
       ),
     ).toBeVisible();
   });
@@ -791,7 +814,9 @@ describe('AdminUserDetail', () => {
     await user.click(await screen.findByRole('button', { name: 'Link' }));
     await user.click(screen.getByRole('button', { name: 'Link Profile' }));
 
-    expect(await screen.findByText('Profile "matching-doula" linked and approved successfully')).toBeVisible();
+    expect(
+      await screen.findByText('Profile "matching-doula" linked and profile editing enabled successfully'),
+    ).toBeVisible();
   });
 
   it('should display approval pending when member has no profile approval yet', async () => {
@@ -805,13 +830,13 @@ describe('AdminUserDetail', () => {
       unlinkedProfiles: [createUnlinkedProfile()],
     });
 
-    expect(await screen.findByText('Not approved')).toBeVisible();
+    expect(await screen.findByText('Disabled')).toBeVisible();
   });
 
   it('should display approved status for linked profile members', async () => {
     const member = createMockMember({
       slug: 'test-slug',
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
@@ -822,7 +847,7 @@ describe('AdminUserDetail', () => {
   it('should show no profile approval pending message for approved members', async () => {
     const member = createMockMember({
       slug: 'test-slug',
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
@@ -832,21 +857,21 @@ describe('AdminUserDetail', () => {
 
   it('should not show approve button when member already has profile approval', async () => {
     const member = createMockMember({
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member });
 
-    expect(screen.queryByRole('button', { name: 'Approve Profile Work' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Enable Profile Editing' })).toBeNull();
   });
 
   it('should show approve button when member has no profile approval timestamp', async () => {
     const member = createMockMember();
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByRole('button', { name: 'Approve Profile Work' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Enable Profile Editing' })).toBeVisible();
   });
 
   it('should show link profile section for members without slug', async () => {
@@ -892,7 +917,7 @@ describe('AdminUserDetail', () => {
 
     expect(
       await screen.findByText(
-        'Linking an existing profile will also approve this member to edit that profile.',
+        'Linking an existing profile will also enable profile editing for this member.',
       ),
     ).toBeVisible();
   });
@@ -985,52 +1010,64 @@ describe('AdminUserDetail', () => {
     const member = createMockMember({
       membershipActive: false,
     });
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     await setup({ member });
 
-    expect(await screen.findByRole('button', { name: 'Approve Profile Work' })).toBeVisible();
+    expect(await screen.findByRole('button', { name: 'Enable Profile Editing' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Activate Membership' })).toBeVisible();
   });
 
   it('should keep publish and approval actions independent', async () => {
     const member = createMockMember({
       slug: 'test-slug',
-      profileApprovedAt: '2024-03-15T14:30:00.000Z',
+      allowProfileEditing: true,
     });
 
     await setup({ member, profileDraft: true });
 
     expect(await screen.findByRole('button', { name: 'Load Profile Status' })).toBeVisible();
-    expect(screen.queryByRole('button', { name: 'Approve Profile Work' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Enable Profile Editing' })).toBeNull();
   });
 
-  it('should approve profile work after confirmation', async () => {
+  it('should enable profile editing after confirmation', async () => {
     const member = createMockMember();
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     const { user, mockAdminMembersService } = await setup({ member });
 
-    await user.click(await screen.findByRole('button', { name: 'Approve Profile Work' }));
-    await user.click(screen.getByRole('button', { name: 'Approve Profile Approval' }));
+    await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Enable Profile Editing' }));
 
-    expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123');
-    expect(await screen.findByText('Profile work approved successfully')).toBeVisible();
+    expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', true);
+    expect(await screen.findByText('Profile editing enabled successfully')).toBeVisible();
   });
 
-  it('should show error when approving profile work fails', async () => {
+  it('should disable profile editing after confirmation', async () => {
+    const member = createMockMember({ allowProfileEditing: true });
+
+    const { user, mockAdminMembersService } = await setup({ member });
+
+    await user.click(await screen.findByRole('button', { name: 'Disable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Disable Profile Editing' }));
+
+    expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', false);
+    expect(await screen.findByText('Profile editing disabled successfully')).toBeVisible();
+  });
+
+  it('should show error when updating profile editing permission fails', async () => {
     const member = createMockMember();
-    delete member.profileApprovedAt;
+    member.allowProfileEditing = false;
 
     const { user } = await setup({
       member,
       shouldFailApproveProfile: true,
     });
 
-    await user.click(await screen.findByRole('button', { name: 'Approve Profile Work' }));
-    await user.click(screen.getByRole('button', { name: 'Approve Profile Approval' }));
+    await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
+    await user.click(screen.getByRole('button', { name: 'Enable Profile Editing' }));
 
-    expect(await screen.findByText('Failed to approve profile work.')).toBeVisible();
+    expect(await screen.findByText('Failed to update profile editing permission.')).toBeVisible();
   });
 
   it('should display subscription dates', async () => {
@@ -1467,7 +1504,9 @@ describe('AdminUserDetail', () => {
     const confirmButton = screen.getByRole('button', { name: 'Link Profile' });
     await user.click(confirmButton);
 
-    expect(await screen.findByText('Profile "matching-doula" linked and approved successfully')).toBeVisible();
+    expect(
+      await screen.findByText('Profile "matching-doula" linked and profile editing enabled successfully'),
+    ).toBeVisible();
   });
 
   it('should show error banner when linking a profile fails', async () => {

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts
@@ -1,5 +1,5 @@
 import { Router } from '@angular/router';
-import { render, screen, waitFor } from '@testing-library/angular';
+import { render, screen, waitFor, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { ApiMemberResponse } from '../../../api-types/api-member-response';
@@ -1040,10 +1040,11 @@ describe('AdminUserDetail', () => {
     const { user, mockAdminMembersService } = await setup({ member });
 
     await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Enable Profile Editing' }));
 
     expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', true);
-    expect(await screen.findByText('Profile editing enabled successfully')).toBeVisible();
+    expect(await screen.findByRole('status')).toHaveTextContent('Profile editing enabled successfully');
   });
 
   it('should disable profile editing after confirmation', async () => {
@@ -1052,10 +1053,11 @@ describe('AdminUserDetail', () => {
     const { user, mockAdminMembersService } = await setup({ member });
 
     await user.click(await screen.findByRole('button', { name: 'Disable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Disable Profile Editing' }));
 
     expect(mockAdminMembersService.approveProfile).toHaveBeenCalledWith('test-uid-123', false);
-    expect(await screen.findByText('Profile editing disabled successfully')).toBeVisible();
+    expect(await screen.findByRole('status')).toHaveTextContent('Profile editing disabled successfully');
   });
 
   it('should show error when updating profile editing permission fails', async () => {
@@ -1068,9 +1070,10 @@ describe('AdminUserDetail', () => {
     });
 
     await user.click(await screen.findByRole('button', { name: 'Enable Profile Editing' }));
-    await user.click(screen.getByRole('button', { name: 'Cancel' }).nextElementSibling as HTMLButtonElement);
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Enable Profile Editing' }));
 
-    expect(await screen.findByText('Failed to update profile editing permission.')).toBeVisible();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to update profile editing permission.');
   });
 
   it('should display subscription dates', async () => {

--- a/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
+++ b/members/src/app/admin/users/admin-member-detail/admin-member-detail.ts
@@ -29,6 +29,10 @@ type ConfirmAction =
   | 'deleteDraftProfile'
   | 'linkProfile';
 
+interface PendingProfileEditingAction {
+  allowProfileEditing: boolean;
+}
+
 interface DialogConfig {
   title: string;
   message: string;
@@ -82,14 +86,18 @@ export class AdminMemberDetail {
     return profile.draft;
   });
 
-  protected isProfileApproved = computed(() => {
+  protected allowProfileEditing = computed(() => {
     const resource = this.service.memberResource;
     if (!resource.hasValue()) {
       return false;
     }
 
-    return (resource.value() as ApiMemberResponse).profileApprovedAt !== undefined;
+    return (resource.value() as ApiMemberResponse).allowProfileEditing;
   });
+
+  private pendingProfileEditingAction = signal<
+    PendingProfileEditingAction | undefined
+  >(undefined);
 
   protected profileSearchTerm = linkedSignal(() => {
     const member = this.service.memberResource.hasValue()
@@ -198,13 +206,18 @@ export class AdminMemberDetail {
   }
 
   protected showApproveProfileConfirm(): void {
+    const allowProfileEditing = !this.allowProfileEditing();
     this.pendingAction.set('approveProfile');
+    this.pendingProfileEditingAction.set({ allowProfileEditing });
     this.dialogConfig.set({
-      title: 'Confirm Profile Approval',
-      message:
-        'This will allow the member to create a new profile or edit an existing linked profile in the members app.',
-      confirmText: 'Approve Profile Approval',
-      variant: 'primary',
+      title: allowProfileEditing
+        ? 'Confirm Enable Profile Editing'
+        : 'Confirm Disable Profile Editing',
+      message: allowProfileEditing
+        ? 'This will allow the member to create a new profile or edit an existing linked profile in the members app.'
+        : 'This will prevent the member from creating a new profile or editing an existing linked profile in the members app.',
+      confirmText: allowProfileEditing ? 'Enable Profile Editing' : 'Disable Profile Editing',
+      variant: allowProfileEditing ? 'primary' : 'danger',
     });
     this.confirmDialog()?.showModal();
   }
@@ -237,6 +250,7 @@ export class AdminMemberDetail {
     this.confirmDialog()?.close();
     this.pendingAction.set(undefined);
     this.pendingLinkSlug.set(undefined);
+    this.pendingProfileEditingAction.set(undefined);
   }
 
   protected async onConfirmDialog(): Promise<void> {
@@ -265,7 +279,15 @@ export class AdminMemberDetail {
           break;
         }
         case 'approveProfile': {
-          await this.service.approveProfile(this.uid());
+          const profileEditingAction = this.pendingProfileEditingAction();
+          if (profileEditingAction === undefined) {
+            this.service.actionError.set('Failed to update profile editing permission.');
+            break;
+          }
+          await this.service.approveProfile(
+            this.uid(),
+            profileEditingAction.allowProfileEditing,
+          );
           break;
         }
         case 'deleteDraftProfile': {
@@ -286,6 +308,7 @@ export class AdminMemberDetail {
       this.confirmDialog()?.close();
       this.pendingAction.set(undefined);
       this.pendingLinkSlug.set(undefined);
+      this.pendingProfileEditingAction.set(undefined);
     }
   }
 

--- a/members/src/app/api-types/api-member-response.ts
+++ b/members/src/app/api-types/api-member-response.ts
@@ -12,7 +12,7 @@ export interface ApiMemberResponse {
   membershipExpiresAt?: string;
   slug?: string;
   profileCreatedAt?: string;
-  profileApprovedAt?: string;
+  allowProfileEditing: boolean;
   stripeCustomerId?: string;
   stripeSubscriptionId?: string;
   subscriptionStatus?: SubscriptionStatus;

--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { canActivate, redirectLoggedInTo, redirectUnauthorizedTo } from '@angular/fire/auth-guard';
 import { type Routes } from '@angular/router';
 import { redirectNonAdminToMembership } from './guards/admin.guard';
+import { profileEditingGuard } from './guards/profile-editing.guard';
 import { wizardStepGuard } from './create-profile-wizard/guards/wizard-step.guard';
 
 // Guards for different authentication states
@@ -19,6 +20,7 @@ export const routes: Routes = [
   {
     path: 'profile/create',
     ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [profileEditingGuard],
     loadComponent: () =>
       import('./create-profile-wizard/create-profile-wizard').then((m) => m.CreateProfileWizard),
     children: [
@@ -76,12 +78,14 @@ export const routes: Routes = [
     path: 'profile',
     loadComponent: () => import('./edit-profile/edit-profile').then((m) => m.EditProfile),
     ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [profileEditingGuard],
   },
   {
     path: 'profile/image',
     loadComponent: () =>
       import('./edit-profile-image/edit-profile-image').then((m) => m.EditProfileImage),
     ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [profileEditingGuard],
   },
 
   // Admin routes (require authentication and admin claim)

--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -7,6 +7,10 @@ import { wizardStepGuard } from './create-profile-wizard/guards/wizard-step.guar
 // Guards for different authentication states
 const redirectUnauthorizedToSignIn = () => redirectUnauthorizedTo(['sign-in']);
 const redirectToMembership = () => redirectLoggedInTo(['membership']);
+const authThenProfileEditingGuard = [
+  ...canActivate(redirectUnauthorizedToSignIn).canActivate,
+  profileEditingGuard,
+];
 
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'sign-in' },
@@ -19,8 +23,7 @@ export const routes: Routes = [
   },
   {
     path: 'profile/create',
-    ...canActivate(redirectUnauthorizedToSignIn),
-    canActivate: [profileEditingGuard],
+    canActivate: authThenProfileEditingGuard,
     loadComponent: () =>
       import('./create-profile-wizard/create-profile-wizard').then((m) => m.CreateProfileWizard),
     children: [
@@ -77,15 +80,13 @@ export const routes: Routes = [
   {
     path: 'profile',
     loadComponent: () => import('./edit-profile/edit-profile').then((m) => m.EditProfile),
-    ...canActivate(redirectUnauthorizedToSignIn),
-    canActivate: [profileEditingGuard],
+    canActivate: authThenProfileEditingGuard,
   },
   {
     path: 'profile/image',
     loadComponent: () =>
       import('./edit-profile-image/edit-profile-image').then((m) => m.EditProfileImage),
-    ...canActivate(redirectUnauthorizedToSignIn),
-    canActivate: [profileEditingGuard],
+    canActivate: authThenProfileEditingGuard,
   },
 
   // Admin routes (require authentication and admin claim)

--- a/members/src/app/create-profile-wizard/create-profile-wizard.spec.ts
+++ b/members/src/app/create-profile-wizard/create-profile-wizard.spec.ts
@@ -31,6 +31,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
       profileCreatedAt: new Date(),
     };
@@ -52,6 +53,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     };
     mockMembershipService.userDocument.set(member);
@@ -72,6 +74,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     };
     mockMembershipService.userDocument.set(member);
@@ -92,6 +95,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     };
     mockMembershipService.userDocument.set(member);
@@ -112,6 +116,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     };
     mockMembershipService.userDocument.set(member);
@@ -141,6 +146,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     } as Member;
     mockMembershipService.userDocument.set(member);
@@ -166,6 +172,7 @@ describe('CreateProfileWizard', () => {
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
       slug: 'test-user',
     };
     mockMembershipService.userDocument.set(member);
@@ -219,6 +226,7 @@ async function setup({ userDocumentLoading = false }: SetupOptions = {}) {
         createdAt: new Date(0),
         isAdmin: false,
         membershipActive: true,
+        allowProfileEditing: true,
         slug: 'test-user',
       };
 

--- a/members/src/app/create-profile-wizard/steps/personal-info-step/personal-info-step.spec.ts
+++ b/members/src/app/create-profile-wizard/steps/personal-info-step/personal-info-step.spec.ts
@@ -65,6 +65,7 @@ async function setup() {
     createdAt: new Date(0),
     isAdmin: false,
     membershipActive: true,
+    allowProfileEditing: true,
     slug: 'test-user',
   };
 

--- a/members/src/app/edit-profile/edit-profile.spec.ts
+++ b/members/src/app/edit-profile/edit-profile.spec.ts
@@ -356,6 +356,7 @@ async function setup({
       slug: 'jane-doe',
       profileCreatedAt: new Date(0),
       membershipActive: true,
+      allowProfileEditing: true,
     };
   } else {
     mockMemberDocument = {
@@ -364,6 +365,7 @@ async function setup({
       createdAt: new Date(0),
       isAdmin: false,
       membershipActive: true,
+      allowProfileEditing: true,
     };
   }
 

--- a/members/src/app/guards/profile-editing.guard.integration.spec.ts
+++ b/members/src/app/guards/profile-editing.guard.integration.spec.ts
@@ -1,0 +1,114 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { signal } from '@angular/core';
+import { provideRouter, RouterOutlet } from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { MembershipService } from '../services/membership.service';
+import { profileEditingGuard } from './profile-editing.guard';
+
+@Component({
+  selector: 'app-mock-membership-page',
+  template: '<h1>Membership Page</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockMembershipPage {}
+
+@Component({
+  selector: 'app-mock-edit-profile-page',
+  template: '<h1>Edit Profile Page</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockEditProfilePage {}
+
+@Component({
+  selector: 'app-mock-create-profile-page',
+  template: '<h1>Create Profile Page</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockCreateProfilePage {}
+
+@Component({
+  selector: 'app-mock-root',
+  template: '<router-outlet></router-outlet>',
+  imports: [RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockApp {}
+
+const routes = [
+  { path: 'membership', component: MockMembershipPage },
+  {
+    path: 'profile',
+    component: MockEditProfilePage,
+    canActivate: [profileEditingGuard],
+  },
+  {
+    path: 'profile/create',
+    component: MockCreateProfilePage,
+    canActivate: [profileEditingGuard],
+  },
+];
+
+describe('profileEditingGuard - Integration Tests', () => {
+  it('should allow profile route when membership is active and editing is enabled', async () => {
+    const { navigate } = await setup({ membershipActive: true, allowProfileEditing: true });
+
+    await navigate('/profile');
+
+    expect(screen.getByText('Edit Profile Page')).toBeVisible();
+  });
+
+  it('should redirect profile route to membership when editing is disabled', async () => {
+    const { navigate } = await setup({ membershipActive: true, allowProfileEditing: false });
+
+    await navigate('/profile');
+
+    expect(screen.getByText('Membership Page')).toBeVisible();
+  });
+
+  it('should redirect create route to membership when membership is inactive', async () => {
+    const { navigate } = await setup({ membershipActive: false, allowProfileEditing: true });
+
+    await navigate('/profile/create');
+
+    expect(screen.getByText('Membership Page')).toBeVisible();
+  });
+
+  it('should allow create route when membership is active and editing is enabled', async () => {
+    const { navigate } = await setup({ membershipActive: true, allowProfileEditing: true });
+
+    await navigate('/profile/create');
+
+    expect(screen.getByText('Create Profile Page')).toBeVisible();
+  });
+});
+
+interface SetupOptions {
+  membershipActive?: boolean;
+  allowProfileEditing?: boolean;
+}
+
+async function setup({
+  membershipActive = false,
+  allowProfileEditing = false,
+}: SetupOptions = {}) {
+  const mockMembershipService = {
+    userDocument: signal({
+      uid: 'user123',
+      email: 'jane@example.com',
+      createdAt: new Date(),
+      isAdmin: false,
+      membershipActive,
+      allowProfileEditing,
+    }),
+  };
+
+  const { navigate } = await render(MockApp, {
+    providers: [
+      provideRouter(routes),
+      { provide: MembershipService, useValue: mockMembershipService },
+    ],
+  });
+
+  return { navigate };
+}

--- a/members/src/app/guards/profile-editing.guard.integration.spec.ts
+++ b/members/src/app/guards/profile-editing.guard.integration.spec.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, type WritableSignal } from '@angular/core';
 import { provideRouter, RouterOutlet } from '@angular/router';
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
+import type { ResourceStatus } from '@angular/core';
 import { MembershipService } from '../services/membership.service';
 import { profileEditingGuard } from './profile-editing.guard';
 
@@ -28,6 +28,13 @@ class MockEditProfilePage {}
 class MockCreateProfilePage {}
 
 @Component({
+  selector: 'app-mock-edit-profile-image-page',
+  template: '<h1>Edit Profile Image Page</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockEditProfileImagePage {}
+
+@Component({
   selector: 'app-mock-root',
   template: '<router-outlet></router-outlet>',
   imports: [RouterOutlet],
@@ -45,6 +52,11 @@ const routes = [
   {
     path: 'profile/create',
     component: MockCreateProfilePage,
+    canActivate: [profileEditingGuard],
+  },
+  {
+    path: 'profile/image',
+    component: MockEditProfileImagePage,
     canActivate: [profileEditingGuard],
   },
 ];
@@ -81,26 +93,94 @@ describe('profileEditingGuard - Integration Tests', () => {
 
     expect(screen.getByText('Create Profile Page')).toBeVisible();
   });
+
+  it('should wait for member document loading before allowing guarded routes', async () => {
+    const { navigate, resourceStatus } = await setup({
+      membershipActive: true,
+      allowProfileEditing: true,
+      resourceStatus: 'loading',
+    });
+
+    const navigation = navigate('/profile');
+
+    expect(screen.queryByText('Edit Profile Page')).toBeNull();
+    expect(screen.queryByText('Membership Page')).toBeNull();
+
+    resourceStatus.set('resolved');
+    await navigation;
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Profile Page')).toBeVisible();
+    });
+  });
+
+  it('should redirect when member document finishes loading without editing permission', async () => {
+    const { navigate, resourceStatus, memberDocument } = await setup({
+      membershipActive: true,
+      allowProfileEditing: true,
+      resourceStatus: 'loading',
+    });
+
+    const navigation = navigate('/profile');
+    memberDocument.set({
+      uid: 'user123',
+      email: 'jane@example.com',
+      createdAt: new Date(),
+      isAdmin: false,
+      membershipActive: true,
+      allowProfileEditing: false,
+    });
+    resourceStatus.set('resolved');
+    await navigation;
+
+    await waitFor(() => {
+      expect(screen.getByText('Membership Page')).toBeVisible();
+    });
+  });
+
+  it('should redirect guarded routes when member document load errors', async () => {
+    const { navigate } = await setup({ resourceStatus: 'error' });
+
+    await navigate('/profile');
+
+    expect(screen.getByText('Membership Page')).toBeVisible();
+  });
+
+  it('should guard the profile image route', async () => {
+    const { navigate } = await setup({ membershipActive: true, allowProfileEditing: true });
+
+    await navigate('/profile/image');
+
+    expect(screen.getByText('Edit Profile Image Page')).toBeVisible();
+  });
 });
 
 interface SetupOptions {
   membershipActive?: boolean;
   allowProfileEditing?: boolean;
+  resourceStatus?: ResourceStatus;
 }
 
 async function setup({
   membershipActive = false,
   allowProfileEditing = false,
+  resourceStatus = 'resolved',
 }: SetupOptions = {}) {
+  const memberDocument = signal({
+    uid: 'user123',
+    email: 'jane@example.com',
+    createdAt: new Date(),
+    isAdmin: false,
+    membershipActive,
+    allowProfileEditing,
+  });
+  const statusSignal: WritableSignal<ResourceStatus> = signal(resourceStatus);
+
   const mockMembershipService = {
-    userDocument: signal({
-      uid: 'user123',
-      email: 'jane@example.com',
-      createdAt: new Date(),
-      isAdmin: false,
-      membershipActive,
-      allowProfileEditing,
-    }),
+    userDocument: memberDocument,
+    userDocumentResource: {
+      status: statusSignal,
+    },
   };
 
   const { navigate } = await render(MockApp, {
@@ -110,5 +190,5 @@ async function setup({
     ],
   });
 
-  return { navigate };
+  return { navigate, resourceStatus: statusSignal, memberDocument };
 }

--- a/members/src/app/guards/profile-editing.guard.ts
+++ b/members/src/app/guards/profile-editing.guard.ts
@@ -1,15 +1,25 @@
 import { inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { type CanActivateFn, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 import { MembershipService } from '../services/membership.service';
 
 export const profileEditingGuard: CanActivateFn = () => {
   const membershipService = inject(MembershipService);
   const router = inject(Router);
 
-  const member = membershipService.userDocument();
-  if (member?.membershipActive && member.allowProfileEditing) {
-    return true;
-  }
+  return firstValueFrom(
+    toObservable(membershipService.userDocumentResource.status).pipe(
+      filter((status) => !['idle', 'loading', 'reloading'].includes(status)),
+      map(() => {
+        const member = membershipService.userDocument();
+        if (member?.membershipActive && member.allowProfileEditing) {
+          return true;
+        }
 
-  return router.createUrlTree(['/membership']);
+        return router.createUrlTree(['/membership']);
+      }),
+    ),
+  );
 };

--- a/members/src/app/guards/profile-editing.guard.ts
+++ b/members/src/app/guards/profile-editing.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { type CanActivateFn, Router } from '@angular/router';
+import { MembershipService } from '../services/membership.service';
+
+export const profileEditingGuard: CanActivateFn = () => {
+  const membershipService = inject(MembershipService);
+  const router = inject(Router);
+
+  const member = membershipService.userDocument();
+  if (member?.membershipActive && member.allowProfileEditing) {
+    return true;
+  }
+
+  return router.createUrlTree(['/membership']);
+};

--- a/members/src/app/header/header.spec.ts
+++ b/members/src/app/header/header.spec.ts
@@ -45,11 +45,25 @@ describe('Header', () => {
     expect(screen.queryByRole('link', { name: 'Edit Profile' })).not.toBeInTheDocument();
   });
 
+  it('should not show profile button when profile editing is disabled', async () => {
+    await setup({
+      isAuthenticated: true,
+      isEmailVerified: true,
+      isMembershipActive: true,
+      allowProfileEditing: false,
+      hasProfile: true,
+    });
+
+    expect(screen.queryByRole('link', { name: 'Edit Profile' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create Profile' })).not.toBeInTheDocument();
+  });
+
   it('should show edit profile button when user has a profile', async () => {
     await setup({
       isAuthenticated: true,
       isEmailVerified: true,
       isMembershipActive: true,
+      allowProfileEditing: true,
       hasProfile: true,
     });
 
@@ -63,6 +77,7 @@ describe('Header', () => {
       isAuthenticated: true,
       isEmailVerified: true,
       isMembershipActive: true,
+      allowProfileEditing: true,
       hasProfile: false,
     });
 
@@ -76,6 +91,7 @@ interface SetupOptions {
   isAuthenticated?: boolean;
   isEmailVerified?: boolean;
   isMembershipActive?: boolean;
+  allowProfileEditing?: boolean;
   hasProfile?: boolean;
 }
 
@@ -90,6 +106,7 @@ async function setup({
   isAuthenticated = false,
   isEmailVerified = false,
   isMembershipActive = false,
+  allowProfileEditing = true,
   hasProfile = false,
 }: SetupOptions = {}) {
   // eslint-disable-next-line unicorn/no-null
@@ -104,6 +121,7 @@ async function setup({
 
   const mockMembershipService = {
     membershipActive: signal(isMembershipActive),
+    allowProfileEditing: signal(allowProfileEditing),
     userDocument: signal(mockUserDocument),
   };
 

--- a/members/src/app/header/header.ts
+++ b/members/src/app/header/header.ts
@@ -23,7 +23,11 @@ export class Header {
   });
 
   protected readonly canEditProfile = computed(() => {
-    return this.isEmailVerified() && this.membershipService.membershipActive();
+    return (
+      this.isEmailVerified() &&
+      this.membershipService.membershipActive() &&
+      this.membershipService.allowProfileEditing()
+    );
   });
 
   protected readonly hasProfile = computed(() => {

--- a/members/src/app/membership/membership.html
+++ b/members/src/app/membership/membership.html
@@ -8,8 +8,8 @@
           <p>Welcome, {{ name }}!</p>
         }
         <p>
-          You have an active membership and admin approval. Create your public doula profile to
-          appear in our directory and connect with families.
+          You have an active membership and profile editing access. Create your public doula profile
+          to appear in our directory and connect with families.
         </p>
 
         <button
@@ -31,11 +31,11 @@
       </div>
     }
 
-    @if (showProfileApprovalPending()) {
-      <section class="create-profile-banner" aria-labelledby="profile-approval-pending-heading">
-        <h3 id="profile-approval-pending-heading">Profile approval pending</h3>
+    @if (showProfileEditingPending()) {
+      <section class="create-profile-banner" aria-labelledby="profile-editing-pending-heading">
+        <h3 id="profile-editing-pending-heading">Profile editing not enabled</h3>
         <p>
-          Your membership is active, but profile creation is pending admin approval. Once approved,
+          Your membership is active, but profile editing has not been enabled yet. Once enabled,
           you'll be able to create or edit your profile here.
         </p>
       </section>

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -459,7 +459,7 @@ describe('Membership', () => {
           uid: 'user123',
           membershipActive: true,
           name: 'Jane Doe',
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -214,7 +214,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -282,7 +282,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -299,7 +299,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -319,7 +319,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -339,7 +339,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -361,7 +361,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
@@ -387,7 +387,7 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
         updateMemberNameShouldFail: true,
       });
@@ -418,7 +418,7 @@ describe('Membership', () => {
       expect(screen.queryByText('Create Your Doula Profile')).toBeNull();
     });
 
-    it('should not show welcome prompt without profile approval', async () => {
+    it('should not show welcome prompt without profile editing access', async () => {
       await setup({
         isAuthenticated: true,
         hasUserDocument: true,
@@ -433,7 +433,7 @@ describe('Membership', () => {
       expect(screen.queryByText('Welcome to the Rochester Doula Cooperative!')).toBeNull();
     });
 
-    it('should show welcome prompt when profile approval exists and name is missing', async () => {
+    it('should show welcome prompt when profile editing is enabled and name is missing', async () => {
       await setup({
         isAuthenticated: true,
         hasUserDocument: true,
@@ -442,14 +442,14 @@ describe('Membership', () => {
           email: 'jane@example.com',
           uid: 'user123',
           membershipActive: true,
-          profileApprovedAt: new Date(),
+          allowProfileEditing: true,
         },
       });
 
       expect(screen.getByText('Welcome to the Rochester Doula Cooperative!')).toBeVisible();
     });
 
-    it('should show create profile banner when profile approval exists', async () => {
+    it('should show create profile banner when profile editing is enabled', async () => {
       await setup({
         isAuthenticated: true,
         hasUserDocument: true,
@@ -464,10 +464,10 @@ describe('Membership', () => {
       });
 
       expect(screen.getByText('Create Your Doula Profile')).toBeVisible();
-      expect(screen.getByText(/active membership and admin approval/)).toBeVisible();
+      expect(screen.getByText(/active membership and profile editing access/)).toBeVisible();
     });
 
-    it('should show approval pending message when active member is not approved', async () => {
+    it('should show profile editing pending message when active member is not enabled', async () => {
       await setup({
         isAuthenticated: true,
         hasUserDocument: true,
@@ -480,8 +480,8 @@ describe('Membership', () => {
         },
       });
 
-      expect(screen.getByText('Profile approval pending')).toBeVisible();
-      expect(screen.getByText(/profile creation is pending admin approval/)).toBeVisible();
+      expect(screen.getByText('Profile editing not enabled')).toBeVisible();
+      expect(screen.getByText(/profile editing has not been enabled yet/)).toBeVisible();
       expect(screen.queryByText('Create Your Doula Profile')).toBeNull();
     });
   });

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -55,7 +55,7 @@ export class Membership {
     const userDocument = this.userDocument();
     return (
       userDocument?.membershipActive &&
-      userDocument?.profileApprovedAt !== undefined &&
+      userDocument.allowProfileEditing &&
       !userDocument.slug &&
       !!userDocument.name
     );
@@ -67,7 +67,7 @@ export class Membership {
     const userDocument = this.userDocument();
     return (
       userDocument?.membershipActive &&
-      userDocument?.profileApprovedAt !== undefined &&
+      userDocument.allowProfileEditing &&
       !userDocument.slug &&
       !userDocument.name
     );
@@ -84,11 +84,11 @@ export class Membership {
     return userDocument?.name;
   });
 
-  protected showProfileApprovalPending = computed(() => {
+  protected showProfileEditingPending = computed(() => {
     const userDocument = this.userDocument();
     return (
       userDocument?.membershipActive &&
-      userDocument?.profileApprovedAt === undefined &&
+      !userDocument.allowProfileEditing &&
       !userDocument.slug
     );
   });

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -17,7 +17,7 @@ export interface Member {
   membershipExpiresAt?: Date;
   slug?: string;
   profileCreatedAt?: Date;
-  profileApprovedAt?: Date;
+  allowProfileEditing: boolean;
   stripeCustomerId?: string;
   stripeSubscriptionId?: string;
   subscriptionStatus?: SubscriptionStatus;
@@ -72,6 +72,7 @@ export class MembershipService {
 
   // Computed properties for easy access to specific member document fields
   membershipActive = computed(() => this.userDocument()?.membershipActive ?? false);
+  allowProfileEditing = computed(() => this.userDocument()?.allowProfileEditing ?? false);
   hasProfile = computed(() => {
     return !!this.userDocument()?.profileCreatedAt;
   });
@@ -410,9 +411,7 @@ export class MembershipService {
       ...(apiResponse.profileCreatedAt !== undefined && {
         profileCreatedAt: new Date(apiResponse.profileCreatedAt),
       }),
-      ...(apiResponse.profileApprovedAt !== undefined && {
-        profileApprovedAt: new Date(apiResponse.profileApprovedAt),
-      }),
+      allowProfileEditing: apiResponse.allowProfileEditing,
       ...(apiResponse.stripeCustomerId !== undefined && {
         stripeCustomerId: apiResponse.stripeCustomerId,
       }),

--- a/members/src/app/shared/profile-form/profile-form-utilities.spec.ts
+++ b/members/src/app/shared/profile-form/profile-form-utilities.spec.ts
@@ -108,6 +108,7 @@ describe('Profile Form Utilities', () => {
         createdAt: new Date(0),
         isAdmin: false,
         membershipActive: true,
+        allowProfileEditing: false,
         slug: 'test-user',
       };
 
@@ -126,6 +127,7 @@ describe('Profile Form Utilities', () => {
         createdAt: new Date(0),
         isAdmin: false,
         membershipActive: true,
+        allowProfileEditing: false,
       };
 
       initializeCreateProfileForm(form, member);
@@ -146,6 +148,7 @@ describe('Profile Form Utilities', () => {
         createdAt: new Date(0),
         isAdmin: false,
         membershipActive: true,
+        allowProfileEditing: false,
       };
 
       initializeCreateProfileForm(form, member);
@@ -166,6 +169,7 @@ describe('Profile Form Utilities', () => {
         createdAt: new Date(0),
         isAdmin: false,
         membershipActive: false,
+        allowProfileEditing: false,
       };
 
       initializeCreateProfileForm(form, member);


### PR DESCRIPTION
## Summary
- replace the runtime `profileApprovedAt` gate with `allowProfileEditing` across functions and members
- add admin toggle UI, member route protection, and a backfill script for legacy approved members
- update targeted functions and members specs for the new permission model

## Test plan
- [x] `rtk bun test /Users/mgoho/Github/doula-cooperative/functions/src/admin-members-api/routes/approve-profile.test.ts /Users/mgoho/Github/doula-cooperative/functions/src/admin-members-api/routes/link-profile.test.ts /Users/mgoho/Github/doula-cooperative/functions/src/profiles-api/routes/create-profile.test.ts /Users/mgoho/Github/doula-cooperative/functions/src/profiles-api/routes/write-profile.test.ts`
- [ ] `rtk bun test /Users/mgoho/Github/doula-cooperative/members/src/app/admin/users/admin-member-detail/admin-member-detail.spec.ts /Users/mgoho/Github/doula-cooperative/members/src/app/membership/membership.spec.ts /Users/mgoho/Github/doula-cooperative/members/src/app/header/header.spec.ts /Users/mgoho/Github/doula-cooperative/members/src/app/guards/profile-editing.guard.integration.spec.ts` *(currently blocked by an existing Angular router/JIT test-runner issue in this repo)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)