### PR TITLE
feat: add legacy membership draft action

### DIFF
--- a/functions/src/admin-unclaimed-profiles-api/plugins/admin-unclaimed-profiles-plugin.ts
+++ b/functions/src/admin-unclaimed-profiles-api/plugins/admin-unclaimed-profiles-plugin.ts
@@ -7,6 +7,7 @@ import { adminGuard } from "../../shared-api/utils/admin-guard.js";
 import { getAdminUid } from "../../shared-api/utils/get-admin-uid.js";
 import {
   deleteUnclaimedProfileLogic,
+  draftUnclaimedProfileLogic,
   getUnclaimedProfileLogic,
   listUnclaimedProfilesLogic,
   refreshPaymentDatesLogic,
@@ -15,6 +16,7 @@ import {
 import {
   ChangeEmailBodySchema,
   DeleteUnclaimedProfileResponseSchema,
+  DraftUnclaimedProfileResponseSchema,
   EmailParameterSchema,
   ListUnclaimedProfilesQuerySchema,
   ListUnclaimedProfilesResponseSchema,
@@ -132,6 +134,28 @@ export function createAdminUnclaimedProfilesPlugin(services?: PartialServices) {
           params: EmailParameterSchema,
           body: ChangeEmailBodySchema,
           response: UpdateEmailResponseSchema,
+        },
+      )
+      // POST /:email/draft - Set linked public profile to draft without deleting legacy membership
+      .post(
+        "/:email/draft",
+        async ({
+          params,
+          adminToken,
+          unclaimedProfileAdminService,
+          logger,
+          set,
+        }) =>
+          draftUnclaimedProfileLogic({
+            email: params.email,
+            adminUid: getAdminUid(adminToken, logger),
+            unclaimedProfileAdminService,
+            logger,
+            set,
+          }),
+        {
+          params: EmailParameterSchema,
+          response: DraftUnclaimedProfileResponseSchema,
         },
       )
       // DELETE /:email - Delete unclaimed profile

--- a/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
@@ -26,7 +26,7 @@ describe("POST /:email/draft", () => {
       ({ email: requestEmail }: { email: string }): Promise<{
         success: true;
         slug: string;
-        rebuildTriggered: boolean;
+        warning?: string;
       }> => {
         if (profileNotFound || requestEmail === "nonexistent@example.com") {
           return Promise.reject(
@@ -45,7 +45,10 @@ describe("POST /:email/draft", () => {
         return Promise.resolve({
           success: true,
           slug: "test-slug",
-          rebuildTriggered,
+          ...(!rebuildTriggered && {
+            warning:
+              "Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.",
+          }),
         });
       },
     );

--- a/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  NotFoundError,
+  ValidationError,
+} from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import { createAdminTestPlugin } from "../test-utils/create-admin-test-plugin.js";
+
+describe("POST /:email/draft", () => {
+  interface SetupOptions {
+    email?: string;
+    authToken?: string | null;
+    profileNotFound?: boolean;
+    missingSlug?: boolean;
+    rebuildTriggered?: boolean;
+  }
+
+  function setup({
+    email = "test@example.com",
+    authToken = "admin-token",
+    profileNotFound = false,
+    missingSlug = false,
+    rebuildTriggered = true,
+  }: SetupOptions = {}) {
+    const mockDraftUnclaimedProfile = mock(
+      ({ email: requestEmail }: { email: string }): Promise<{
+        success: true;
+        slug: string;
+        rebuildTriggered: boolean;
+      }> => {
+        if (profileNotFound || requestEmail === "nonexistent@example.com") {
+          return Promise.reject(
+            new NotFoundError("Unclaimed profile not found"),
+          );
+        }
+
+        if (missingSlug) {
+          return Promise.reject(
+            new ValidationError(
+              `Unclaimed profile with email ${requestEmail} does not have a profile slug`,
+            ),
+          );
+        }
+
+        return Promise.resolve({
+          success: true,
+          slug: "test-slug",
+          rebuildTriggered,
+        });
+      },
+    );
+
+    const testApp = createAdminTestPlugin({
+      unclaimedProfileAdminService: {
+        draftUnclaimedProfile: mockDraftUnclaimedProfile,
+      },
+    });
+
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(`http://localhost/${email}/draft`, {
+      method: "POST",
+      headers,
+    });
+
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const { testApp, request } = setup({ authToken: null });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Missing Authorization header");
+    });
+
+    it("should return 403 when non-admin user tries to draft", async () => {
+      const { testApp, request } = setup({ authToken: "non-admin-token" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Admin privileges required");
+    });
+  });
+
+  describe("Email parameter validation", () => {
+    it("should reject invalid email format", async () => {
+      const { testApp, request } = setup({ email: "not-an-email" });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Successful drafting", () => {
+    it("should draft unclaimed profile when authenticated as admin", async () => {
+      const { testApp, request } = setup();
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success?: boolean;
+        slug?: string;
+        warning?: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.slug).toBe("test-slug");
+      expect(body.warning).toBeUndefined();
+    });
+
+    it("should return warning when rebuild trigger fails", async () => {
+      const { testApp, request } = setup({ rebuildTriggered: false });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success?: boolean;
+        slug?: string;
+        warning?: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.slug).toBe("test-slug");
+      expect(body.warning).toBe(
+        "Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.",
+      );
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should return 404 when profile not found", async () => {
+      const { testApp, request } = setup({ profileNotFound: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Unclaimed profile not found");
+    });
+
+    it("should return 400 when profile has no slug", async () => {
+      const { testApp, request } = setup({ missingSlug: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe(
+        "Unclaimed profile with email test@example.com does not have a profile slug",
+      );
+    });
+  });
+});

--- a/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.test.ts
@@ -13,6 +13,7 @@ describe("POST /:email/draft", () => {
     profileNotFound?: boolean;
     missingSlug?: boolean;
     rebuildTriggered?: boolean;
+    serviceError?: boolean;
   }
 
   function setup({
@@ -21,6 +22,7 @@ describe("POST /:email/draft", () => {
     profileNotFound = false,
     missingSlug = false,
     rebuildTriggered = true,
+    serviceError = false,
   }: SetupOptions = {}) {
     const mockDraftUnclaimedProfile = mock(
       ({ email: requestEmail }: { email: string }): Promise<{
@@ -28,6 +30,10 @@ describe("POST /:email/draft", () => {
         slug: string;
         warning?: string;
       }> => {
+        if (serviceError) {
+          return Promise.reject(new Error("Unexpected database error"));
+        }
+
         if (profileNotFound || requestEmail === "nonexistent@example.com") {
           return Promise.reject(
             new NotFoundError("Unclaimed profile not found"),
@@ -161,6 +167,16 @@ describe("POST /:email/draft", () => {
       expect(body.error).toBe(
         "Unclaimed profile with email test@example.com does not have a profile slug",
       );
+    });
+
+    it("should return 500 on unexpected service error", async () => {
+      const { testApp, request } = setup({ serviceError: true });
+
+      const response = await handleRequest(testApp, request);
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBeTruthy();
     });
   });
 });

--- a/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.ts
@@ -1,6 +1,7 @@
 import { ERROR_IDS } from "../../constants/error-ids.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import { handleRouteError } from "../../shared-api/utils/route-error-handler.js";
+import type { DraftUnclaimedProfileResponse } from "../schemas/unclaimed-profile-schemas.js";
 import type { UnclaimedProfileAdminService } from "../services/interface.js";
 
 export async function draftUnclaimedProfileLogic({
@@ -15,7 +16,7 @@ export async function draftUnclaimedProfileLogic({
   unclaimedProfileAdminService: UnclaimedProfileAdminService;
   logger: Logger;
   set: { status?: number | string };
-}): Promise<{ success: true; slug: string; warning?: string } | { error: string }> {
+}): Promise<DraftUnclaimedProfileResponse> {
   try {
     logger.info("Admin draft unclaimed profile request", {
       adminUid,
@@ -31,19 +32,10 @@ export async function draftUnclaimedProfileLogic({
       adminUid,
       email,
       slug: result.slug,
-      rebuildTriggered: result.rebuildTriggered,
+      warning: result.warning,
     });
 
-    return {
-      success: true,
-      slug: result.slug,
-      ...(result.rebuildTriggered
-        ? {}
-        : {
-            warning:
-              "Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.",
-          }),
-    };
+    return result;
   } catch (error: unknown) {
     return handleRouteError({
       error,

--- a/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/draft-unclaimed-profile.ts
@@ -1,0 +1,57 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+import { handleRouteError } from "../../shared-api/utils/route-error-handler.js";
+import type { UnclaimedProfileAdminService } from "../services/interface.js";
+
+export async function draftUnclaimedProfileLogic({
+  email,
+  adminUid,
+  unclaimedProfileAdminService,
+  logger,
+  set,
+}: {
+  email: string;
+  adminUid: string;
+  unclaimedProfileAdminService: UnclaimedProfileAdminService;
+  logger: Logger;
+  set: { status?: number | string };
+}): Promise<{ success: true; slug: string; warning?: string } | { error: string }> {
+  try {
+    logger.info("Admin draft unclaimed profile request", {
+      adminUid,
+      email,
+    });
+
+    const result = await unclaimedProfileAdminService.draftUnclaimedProfile({
+      email,
+      logger,
+    });
+
+    logger.info("Unclaimed profile drafted successfully", {
+      adminUid,
+      email,
+      slug: result.slug,
+      rebuildTriggered: result.rebuildTriggered,
+    });
+
+    return {
+      success: true,
+      slug: result.slug,
+      ...(result.rebuildTriggered
+        ? {}
+        : {
+            warning:
+              "Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.",
+          }),
+    };
+  } catch (error: unknown) {
+    return handleRouteError({
+      error,
+      operation: "draft unclaimed profile",
+      errorId: ERROR_IDS.API_ADMIN_DRAFT_UNCLAIMED_PROFILE_FAILED,
+      logger,
+      set,
+      context: { email, adminUid },
+    });
+  }
+}

--- a/functions/src/admin-unclaimed-profiles-api/routes/index.ts
+++ b/functions/src/admin-unclaimed-profiles-api/routes/index.ts
@@ -1,4 +1,5 @@
 export { deleteUnclaimedProfileLogic } from "./delete-unclaimed-profile.js";
+export { draftUnclaimedProfileLogic } from "./draft-unclaimed-profile.js";
 export { getUnclaimedProfileLogic } from "./get-unclaimed-profile.js";
 export { listUnclaimedProfilesLogic } from "./list-unclaimed-profiles.js";
 export { refreshPaymentDatesLogic } from "./refresh-payment-dates.js";

--- a/functions/src/admin-unclaimed-profiles-api/schemas/unclaimed-profile-schemas.ts
+++ b/functions/src/admin-unclaimed-profiles-api/schemas/unclaimed-profile-schemas.ts
@@ -99,6 +99,25 @@ export type DeleteUnclaimedProfileResponse = Static<
   typeof DeleteUnclaimedProfileResponseSchema
 >;
 
+const DraftUnclaimedProfileSuccessSchema = t.Object({
+  success: t.Literal(true),
+  slug: t.String(),
+  warning: t.Optional(t.String()),
+});
+
+export type DraftUnclaimedProfileSuccessResponse = Static<
+  typeof DraftUnclaimedProfileSuccessSchema
+>;
+
+export const DraftUnclaimedProfileResponseSchema = t.Union([
+  DraftUnclaimedProfileSuccessSchema,
+  ErrorResponseSchema,
+]);
+
+export type DraftUnclaimedProfileResponse = Static<
+  typeof DraftUnclaimedProfileResponseSchema
+>;
+
 const RefreshPaymentDatesSuccessSchema = t.Object({
   success: t.Literal(true),
   updatedCount: t.Number(),

--- a/functions/src/admin-unclaimed-profiles-api/schemas/unclaimed-profile-schemas.ts
+++ b/functions/src/admin-unclaimed-profiles-api/schemas/unclaimed-profile-schemas.ts
@@ -101,7 +101,7 @@ export type DeleteUnclaimedProfileResponse = Static<
 
 const DraftUnclaimedProfileSuccessSchema = t.Object({
   success: t.Literal(true),
-  slug: t.String(),
+  slug: t.String({ minLength: 1 }),
   warning: t.Optional(t.String()),
 });
 

--- a/functions/src/admin-unclaimed-profiles-api/services/draft-unclaimed-profile.ts
+++ b/functions/src/admin-unclaimed-profiles-api/services/draft-unclaimed-profile.ts
@@ -1,0 +1,87 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { IMPORT_COLLECTION } from "../../collections/migrated-users-import.js";
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import { draftProfile } from "../../profiles-api/services/profile-store/draft-profile.js";
+import { triggerHugoRebuild } from "../../profiles-api/services/profile-store/trigger-rebuild.js";
+import {
+  HttpError,
+  NotFoundError,
+  ValidationError,
+} from "../../shared-api/errors/http-error.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+
+export async function draftUnclaimedProfile(options: {
+  email: string;
+  logger: Logger;
+}): Promise<{ success: true; slug: string; rebuildTriggered: boolean }> {
+  const { email, logger } = options;
+
+  try {
+    const firestore = getFirestore();
+    const documentReference = firestore.collection(IMPORT_COLLECTION).doc(email);
+    const document = await documentReference.get();
+
+    if (!document.exists) {
+      logger.warn("Unclaimed profile not found", {
+        errorId: ERROR_IDS.API_UNCLAIMED_PROFILE_NOT_FOUND,
+        email,
+      });
+      throw new NotFoundError(`Unclaimed profile with email ${email} not found`);
+    }
+
+    const documentData = document.data();
+    const slug =
+      documentData !== undefined && typeof documentData["slug"] === "string"
+        ? documentData["slug"]
+        : undefined;
+
+    if (slug === undefined || slug.length === 0) {
+      logger.warn("Unclaimed profile is missing slug", {
+        email,
+      });
+      throw new ValidationError(
+        `Unclaimed profile with email ${email} does not have a profile slug`,
+      );
+    }
+
+    await draftProfile({ slug });
+    logger.info("Set unclaimed profile to draft", { email, slug });
+
+    let rebuildTriggered = true;
+
+    try {
+      await triggerHugoRebuild({
+        slug,
+        action: "unclaimed profile drafted",
+      });
+    } catch (rebuildError) {
+      rebuildTriggered = false;
+      logger.error("Failed to trigger Hugo rebuild after drafting unclaimed profile", {
+        email,
+        slug,
+        error: rebuildError,
+        errorMessage:
+          rebuildError instanceof Error ? rebuildError.message : "Unknown error",
+      });
+    }
+
+    return {
+      success: true,
+      slug,
+      rebuildTriggered,
+    };
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    logger.error("Failed to draft unclaimed profile", {
+      errorId: ERROR_IDS.API_FIRESTORE_UPDATE_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      errorStack: error instanceof Error ? error.stack : undefined,
+      email,
+    });
+    throw error;
+  }
+}

--- a/functions/src/admin-unclaimed-profiles-api/services/draft-unclaimed-profile.ts
+++ b/functions/src/admin-unclaimed-profiles-api/services/draft-unclaimed-profile.ts
@@ -9,11 +9,12 @@ import {
   ValidationError,
 } from "../../shared-api/errors/http-error.js";
 import type { Logger } from "../../shared-api/types/logger.js";
+import type { DraftUnclaimedProfileSuccessResponse } from "../schemas/unclaimed-profile-schemas.js";
 
 export async function draftUnclaimedProfile(options: {
   email: string;
   logger: Logger;
-}): Promise<{ success: true; slug: string; rebuildTriggered: boolean }> {
+}): Promise<DraftUnclaimedProfileSuccessResponse> {
   const { email, logger } = options;
 
   try {
@@ -57,6 +58,7 @@ export async function draftUnclaimedProfile(options: {
     } catch (rebuildError) {
       rebuildTriggered = false;
       logger.error("Failed to trigger Hugo rebuild after drafting unclaimed profile", {
+        errorId: ERROR_IDS.API_HUGO_REBUILD_FAILED,
         email,
         slug,
         error: rebuildError,
@@ -68,7 +70,10 @@ export async function draftUnclaimedProfile(options: {
     return {
       success: true,
       slug,
-      rebuildTriggered,
+      ...(!rebuildTriggered && {
+        warning:
+          "Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.",
+      }),
     };
   } catch (error) {
     if (error instanceof HttpError) {
@@ -76,7 +81,7 @@ export async function draftUnclaimedProfile(options: {
     }
 
     logger.error("Failed to draft unclaimed profile", {
-      errorId: ERROR_IDS.API_FIRESTORE_UPDATE_FAILED,
+      errorId: ERROR_IDS.API_ADMIN_DRAFT_UNCLAIMED_PROFILE_FAILED,
       error,
       errorMessage: error instanceof Error ? error.message : "Unknown error",
       errorStack: error instanceof Error ? error.stack : undefined,

--- a/functions/src/admin-unclaimed-profiles-api/services/index.ts
+++ b/functions/src/admin-unclaimed-profiles-api/services/index.ts
@@ -1,4 +1,5 @@
 import { deleteUnclaimedProfile } from "./delete-unclaimed-profile.js";
+import { draftUnclaimedProfile } from "./draft-unclaimed-profile.js";
 import { getUnclaimedProfile } from "./get-unclaimed-profile.js";
 import { listUnclaimedProfiles } from "./list-unclaimed-profiles.js";
 import { refreshPaymentDates } from "./refresh-payment-dates.js";
@@ -13,11 +14,13 @@ export const UnclaimedProfileAdminService = {
   getUnclaimedProfile,
   updateEmail,
   deleteUnclaimedProfile,
+  draftUnclaimedProfile,
   refreshPaymentDates,
 };
 
 // Re-export individual functions for direct imports
 export { deleteUnclaimedProfile } from "./delete-unclaimed-profile.js";
+export { draftUnclaimedProfile } from "./draft-unclaimed-profile.js";
 export { getUnclaimedProfile } from "./get-unclaimed-profile.js";
 export { listUnclaimedProfiles } from "./list-unclaimed-profiles.js";
 export { refreshPaymentDates } from "./refresh-payment-dates.js";

--- a/functions/src/admin-unclaimed-profiles-api/services/interface.ts
+++ b/functions/src/admin-unclaimed-profiles-api/services/interface.ts
@@ -2,6 +2,7 @@ import type { EmailServiceInterface } from "../../shared-api/services/email/inde
 import type { Logger } from "../../shared-api/types/logger.js";
 import type {
   DeleteUnclaimedProfileSuccessResponse,
+  DraftUnclaimedProfileSuccessResponse,
   ListUnclaimedProfilesSuccessResponse,
   RefreshPaymentDatesSuccessResponse,
   UnclaimedProfileSuccessResponse,
@@ -31,6 +32,11 @@ export interface UnclaimedProfileAdminService {
     emailService: EmailServiceInterface;
     logger: Logger;
   }): Promise<DeleteUnclaimedProfileSuccessResponse>;
+
+  draftUnclaimedProfile(options: {
+    email: string;
+    logger: Logger;
+  }): Promise<DraftUnclaimedProfileSuccessResponse & { rebuildTriggered: boolean }>;
 
   refreshPaymentDates(options: {
     logger: Logger;

--- a/functions/src/admin-unclaimed-profiles-api/services/interface.ts
+++ b/functions/src/admin-unclaimed-profiles-api/services/interface.ts
@@ -36,7 +36,7 @@ export interface UnclaimedProfileAdminService {
   draftUnclaimedProfile(options: {
     email: string;
     logger: Logger;
-  }): Promise<DraftUnclaimedProfileSuccessResponse & { rebuildTriggered: boolean }>;
+  }): Promise<DraftUnclaimedProfileSuccessResponse>;
 
   refreshPaymentDates(options: {
     logger: Logger;

--- a/functions/src/admin-unclaimed-profiles-api/test-utils/create-admin-test-plugin.ts
+++ b/functions/src/admin-unclaimed-profiles-api/test-utils/create-admin-test-plugin.ts
@@ -47,8 +47,7 @@ export function createAdminTestPlugin(overrides?: {
       Promise.resolve({
         success: true,
         slug: "test-slug",
-        rebuildTriggered: true,
-      } as DraftUnclaimedProfileSuccessResponse & { rebuildTriggered: boolean }),
+      } as DraftUnclaimedProfileSuccessResponse),
     ),
     refreshPaymentDates: mock(() =>
       Promise.resolve({

--- a/functions/src/admin-unclaimed-profiles-api/test-utils/create-admin-test-plugin.ts
+++ b/functions/src/admin-unclaimed-profiles-api/test-utils/create-admin-test-plugin.ts
@@ -10,6 +10,7 @@ import {
 import { createAdminUnclaimedProfilesPlugin } from "../plugins/admin-unclaimed-profiles-plugin.js";
 import type {
   DeleteUnclaimedProfileSuccessResponse,
+  DraftUnclaimedProfileSuccessResponse,
   ListUnclaimedProfilesSuccessResponse,
   RefreshPaymentDatesSuccessResponse,
   UnclaimedProfileSuccessResponse,
@@ -41,6 +42,13 @@ export function createAdminTestPlugin(overrides?: {
       Promise.resolve({
         success: true,
       } as DeleteUnclaimedProfileSuccessResponse),
+    ),
+    draftUnclaimedProfile: mock(() =>
+      Promise.resolve({
+        success: true,
+        slug: "test-slug",
+        rebuildTriggered: true,
+      } as DraftUnclaimedProfileSuccessResponse & { rebuildTriggered: boolean }),
     ),
     refreshPaymentDates: mock(() =>
       Promise.resolve({

--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -209,6 +209,8 @@ export const ERROR_IDS = {
     "api_admin_delete_unclaimed_profile_notification_failed",
   API_ADMIN_DELETE_UNCLAIMED_PROFILE_DRAFT_FAILED:
     "api_admin_delete_unclaimed_profile_draft_failed",
+  API_ADMIN_DRAFT_UNCLAIMED_PROFILE_FAILED:
+    "api_admin_draft_unclaimed_profile_failed",
   API_UNCLAIMED_PROFILE_NOT_FOUND: "api_unclaimed_profile_not_found",
   API_ADMIN_UPDATE_EMAIL_FAILED: "api_admin_update_email_failed",
   API_ADMIN_REFRESH_PAYMENT_DATES_FAILED:

--- a/functions/src/profiles-api/services/profile-store/draft-profile.ts
+++ b/functions/src/profiles-api/services/profile-store/draft-profile.ts
@@ -2,7 +2,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { PROFILES_COLLECTION } from "../../../collections/index.js";
 import { ERROR_IDS } from "../../../constants/error-ids.js";
-import { HttpError } from "../../../shared-api/errors/http-error.js";
+import { HttpError, NotFoundError } from "../../../shared-api/errors/http-error.js";
 import type { WriteProfileResponse } from "./interface.js";
 
 /**
@@ -22,8 +22,11 @@ export async function draftProfile(options: {
 
     const existing = await documentReference.get();
     if (!existing.exists) {
-      logger.info("Profile not found in Firestore, skipping draft", { slug });
-      return { success: true };
+      logger.warn("Profile not found in Firestore", {
+        errorId: ERROR_IDS.API_PROFILE_NOT_FOUND,
+        slug,
+      });
+      throw new NotFoundError(`Profile with slug ${slug} not found`);
     }
 
     await documentReference.update({

--- a/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
+++ b/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
@@ -16,6 +16,7 @@ export class AdminUnclaimedProfileDetailPage {
 
   // Actions (reused across tests)
   readonly deleteProfileButton: Locator;
+  readonly draftProfileButton: Locator;
   readonly updateEmailButton: Locator;
 
   // Update email form
@@ -27,6 +28,7 @@ export class AdminUnclaimedProfileDetailPage {
   readonly loadingText: Locator;
   readonly errorMessage: Locator;
   readonly successMessage: Locator;
+  readonly warningMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,6 +41,7 @@ export class AdminUnclaimedProfileDetailPage {
     });
 
     this.deleteProfileButton = page.getByRole('button', { name: /Delete Profile/ });
+    this.draftProfileButton = page.getByRole('button', { name: 'Set Profile to Draft' });
     // Update email form
     this.updateEmailButton = page.getByRole('button', { name: 'Update Email' });
     this.updateEmailInput = page.getByLabel('New Email Address');
@@ -49,6 +52,7 @@ export class AdminUnclaimedProfileDetailPage {
     this.loadingText = page.getByText('Loading details...');
     this.errorMessage = page.getByRole('alert');
     this.successMessage = page.getByRole('status');
+    this.warningMessage = page.locator('app-alert-banner.warning');
   }
 
   async goto(email: string): Promise<void> {
@@ -63,5 +67,11 @@ export class AdminUnclaimedProfileDetailPage {
     await this.updateEmailButton.click();
     await this.updateEmailInput.fill(newEmail);
     await this.confirmUpdateButton.click();
+  }
+
+  async confirmDraftProfile(): Promise<void> {
+    await this.draftProfileButton.click();
+    const dialog = this.page.locator('dialog[open]');
+    await dialog.getByRole('button', { name: 'Set to Draft' }).click();
   }
 }

--- a/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
+++ b/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
@@ -52,7 +52,9 @@ export class AdminUnclaimedProfileDetailPage {
     this.loadingText = page.getByText('Loading details...');
     this.errorMessage = page.getByRole('alert');
     this.successMessage = page.getByRole('status');
-    this.warningMessage = page.locator('app-alert-banner.warning');
+    this.warningMessage = page
+      .locator('app-alert-banner')
+      .filter({ hasText: /change may not appear immediately/i });
   }
 
   async goto(email: string): Promise<void> {

--- a/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
+++ b/members/e2e/pages/admin-unclaimed-profile-detail.page.ts
@@ -32,9 +32,9 @@ export class AdminUnclaimedProfileDetailPage {
     this.page = page;
 
     // Page structure
-    this.pageHeading = page.getByRole('heading', { name: 'Unclaimed Profile Details', level: 1 });
+    this.pageHeading = page.getByRole('heading', { name: 'Legacy Membership Details', level: 1 });
     this.sectionHeading = page.getByRole('heading', {
-      name: 'Unclaimed Profile Information',
+      name: 'Legacy Membership Information',
       level: 2,
     });
 

--- a/members/e2e/pages/admin-unclaimed.page.ts
+++ b/members/e2e/pages/admin-unclaimed.page.ts
@@ -43,9 +43,9 @@ export class AdminUnclaimedPage {
     this.page = page;
 
     // Headings - use role-based selectors
-    this.pageHeading = page.getByRole('heading', { name: 'Unclaimed Profiles', level: 1 });
+    this.pageHeading = page.getByRole('heading', { name: 'Legacy Membership', level: 1 });
     this.unclaimedProfilesHeading = page.getByRole('heading', {
-      name: 'Unclaimed Profiles',
+      name: 'Legacy Membership',
       level: 2,
     });
 

--- a/members/e2e/tests/admin-unclaimed-profiles.spec.ts
+++ b/members/e2e/tests/admin-unclaimed-profiles.spec.ts
@@ -563,4 +563,114 @@ test.describe('Admin Unclaimed Profiles', () => {
     await expect(unclaimedProfilePage.updateEmailInput).not.toBeVisible();
     await expect(unclaimedProfilePage.updateEmailButton).toBeVisible();
   });
+
+  test('admin sets profile to draft successfully', async ({ authenticatedAdminPage }) => {
+    const mockProfile = mockUnclaimedProfiles[0]!;
+    let draftRequestMade = false;
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com',
+      async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockProfile),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com/draft',
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          draftRequestMade = true;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true, slug: 'alice-unclaimed' }),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    const unclaimedProfilePage = new AdminUnclaimedProfileDetailPage(authenticatedAdminPage);
+    await unclaimedProfilePage.goto('alice.unclaimed@example.com');
+    await unclaimedProfilePage.waitForProfileDetails();
+
+    // === Open and confirm draft dialog ===
+    await expect(unclaimedProfilePage.draftProfileButton).toBeVisible();
+    await unclaimedProfilePage.confirmDraftProfile();
+
+    // === Verify success state ===
+    await expect(unclaimedProfilePage.successMessage).toBeVisible({ timeout: 5000 });
+    await expect(unclaimedProfilePage.successMessage).toContainText(
+      'Profile alice-unclaimed was set to draft.',
+    );
+    expect(draftRequestMade).toBe(true);
+  });
+
+  test('admin sees rebuild warning after setting profile to draft', async ({
+    authenticatedAdminPage,
+  }) => {
+    const mockProfile = mockUnclaimedProfiles[0]!;
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com',
+      async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockProfile),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com/draft',
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              success: true,
+              slug: 'alice-unclaimed',
+              warning:
+                'Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.',
+            }),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    const unclaimedProfilePage = new AdminUnclaimedProfileDetailPage(authenticatedAdminPage);
+    await unclaimedProfilePage.goto('alice.unclaimed@example.com');
+    await unclaimedProfilePage.waitForProfileDetails();
+
+    // === Open and confirm draft dialog ===
+    await expect(unclaimedProfilePage.draftProfileButton).toBeVisible();
+    await unclaimedProfilePage.confirmDraftProfile();
+
+    // === Verify success and warning states ===
+    await expect(unclaimedProfilePage.successMessage).toBeVisible({ timeout: 5000 });
+    await expect(unclaimedProfilePage.successMessage).toContainText(
+      'Profile alice-unclaimed was set to draft.',
+    );
+    await expect(unclaimedProfilePage.warningMessage).toBeVisible({ timeout: 5000 });
+    await expect(unclaimedProfilePage.warningMessage).toContainText(
+      'Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.',
+    );
+  });
 });

--- a/members/e2e/tests/admin-unclaimed-profiles.spec.ts
+++ b/members/e2e/tests/admin-unclaimed-profiles.spec.ts
@@ -73,7 +73,7 @@ test.describe('Admin Unclaimed Profiles', () => {
 
     // === Page Structure and Stats ===
     await expect(adminUnclaimedPage.pageHeading).toBeVisible();
-    await expect(adminUnclaimedPage.pageHeading).toHaveText('Unclaimed Profiles');
+    await expect(adminUnclaimedPage.pageHeading).toHaveText('Legacy Membership');
 
     // Verify header stats
     const headerStats = authenticatedAdminPage.locator('.header-stats');

--- a/members/e2e/tests/admin-unclaimed-profiles.spec.ts
+++ b/members/e2e/tests/admin-unclaimed-profiles.spec.ts
@@ -673,4 +673,109 @@ test.describe('Admin Unclaimed Profiles', () => {
       'Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.',
     );
   });
+
+  test('admin cancels draft confirmation dialog', async ({ authenticatedAdminPage }) => {
+    const mockProfile = mockUnclaimedProfiles[0]!;
+    let draftRequestMade = false;
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com',
+      async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockProfile),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com/draft',
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          draftRequestMade = true;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true, slug: 'alice-unclaimed' }),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    const unclaimedProfilePage = new AdminUnclaimedProfileDetailPage(authenticatedAdminPage);
+    await unclaimedProfilePage.goto('alice.unclaimed@example.com');
+    await unclaimedProfilePage.waitForProfileDetails();
+
+    // === Open draft confirmation dialog ===
+    await unclaimedProfilePage.draftProfileButton.click();
+    const dialog = authenticatedAdminPage.locator('dialog[open]');
+    await expect(dialog).toBeVisible();
+
+    // === Cancel draft ===
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+
+    // === Verify draft request was not made ===
+    await expect(dialog).not.toBeVisible();
+    expect(draftRequestMade).toBe(false);
+
+    // === Verify still on detail page ===
+    await expect(authenticatedAdminPage).toHaveURL(/\/admin\/unclaimed\/alice\.unclaimed@example\.com/);
+    await expect(unclaimedProfilePage.sectionHeading).toBeVisible();
+  });
+
+  test('handles draft failure with error message', async ({ authenticatedAdminPage }) => {
+    const mockProfile = mockUnclaimedProfiles[0]!;
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com',
+      async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockProfile),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    await authenticatedAdminPage.route(
+      '**/api/admin/unclaimed-profiles/alice.unclaimed@example.com/draft',
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Failed to draft profile' }),
+          });
+          return;
+        }
+        await route.continue();
+      },
+    );
+
+    const unclaimedProfilePage = new AdminUnclaimedProfileDetailPage(authenticatedAdminPage);
+    await unclaimedProfilePage.goto('alice.unclaimed@example.com');
+    await unclaimedProfilePage.waitForProfileDetails();
+
+    // === Open and confirm draft dialog ===
+    await unclaimedProfilePage.confirmDraftProfile();
+
+    // === Verify error state ===
+    await expect(unclaimedProfilePage.errorMessage).toBeVisible({ timeout: 5000 });
+    await expect(unclaimedProfilePage.errorMessage).toContainText('Failed to set profile to draft.');
+
+    // === Verify still on detail page ===
+    await expect(authenticatedAdminPage).toHaveURL(/\/admin\/unclaimed\/alice\.unclaimed@example\.com/);
+    await expect(unclaimedProfilePage.sectionHeading).toBeVisible();
+  });
 });

--- a/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
+++ b/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
@@ -32,8 +32,16 @@ export interface ApiListUnclaimedProfilesResponse {
   total: number;
 }
 
-export interface ApiDraftUnclaimedProfileResponse {
+interface ApiErrorResponse {
+  error: string;
+}
+
+export interface ApiDraftUnclaimedProfileSuccessResponse {
   success: true;
   slug: string;
   warning?: string;
 }
+
+export type ApiDraftUnclaimedProfileResponse =
+  | ApiDraftUnclaimedProfileSuccessResponse
+  | ApiErrorResponse;

--- a/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
+++ b/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
@@ -31,3 +31,9 @@ export interface ApiListUnclaimedProfilesResponse {
   profiles: ApiUnclaimedProfileResponse[];
   total: number;
 }
+
+export interface ApiDraftUnclaimedProfileResponse {
+  success: true;
+  slug: string;
+  warning?: string;
+}

--- a/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
+++ b/members/src/app/admin/api-types/admin-unclaimed-profiles-api.types.ts
@@ -32,10 +32,6 @@ export interface ApiListUnclaimedProfilesResponse {
   total: number;
 }
 
-interface ApiErrorResponse {
-  error: string;
-}
-
 export interface ApiDraftUnclaimedProfileSuccessResponse {
   success: true;
   slug: string;
@@ -44,4 +40,4 @@ export interface ApiDraftUnclaimedProfileSuccessResponse {
 
 export type ApiDraftUnclaimedProfileResponse =
   | ApiDraftUnclaimedProfileSuccessResponse
-  | ApiErrorResponse;
+  | { error: string };

--- a/members/src/app/admin/services/admin-members.service.ts
+++ b/members/src/app/admin/services/admin-members.service.ts
@@ -10,6 +10,7 @@ import type {
 } from '../admin.types';
 import type { ApiMemberResponse } from '../../api-types/api-member-response';
 import type {
+  ApiDraftUnclaimedProfileResponse,
   ApiListUnclaimedProfilesResponse,
   ApiUnclaimedProfileResponse,
 } from '../api-types/admin-unclaimed-profiles-api.types';
@@ -233,6 +234,16 @@ export class AdminMembersService {
       this.httpClient.patch<{ success: boolean }>(`/api/admin/unclaimed-profiles/${email}`, {
         newEmail,
       }),
+    );
+  }
+
+  async draftUnclaimedProfile(email: string): Promise<ApiDraftUnclaimedProfileResponse> {
+    // Authorization header added automatically by authInterceptor
+    return firstValueFrom(
+      this.httpClient.post<ApiDraftUnclaimedProfileResponse>(
+        `/api/admin/unclaimed-profiles/${email}/draft`,
+        {},
+      ),
     );
   }
 

--- a/members/src/app/admin/services/admin-members.service.ts
+++ b/members/src/app/admin/services/admin-members.service.ts
@@ -11,6 +11,7 @@ import type {
 import type { ApiMemberResponse } from '../../api-types/api-member-response';
 import type {
   ApiDraftUnclaimedProfileResponse,
+  ApiDraftUnclaimedProfileSuccessResponse,
   ApiListUnclaimedProfilesResponse,
   ApiUnclaimedProfileResponse,
 } from '../api-types/admin-unclaimed-profiles-api.types';
@@ -237,14 +238,16 @@ export class AdminMembersService {
     );
   }
 
-  async draftUnclaimedProfile(email: string): Promise<ApiDraftUnclaimedProfileResponse> {
+  async draftUnclaimedProfile(email: string): Promise<ApiDraftUnclaimedProfileSuccessResponse> {
     // Authorization header added automatically by authInterceptor
-    return firstValueFrom(
+    const result = await firstValueFrom(
       this.httpClient.post<ApiDraftUnclaimedProfileResponse>(
         `/api/admin/unclaimed-profiles/${email}/draft`,
         {},
       ),
     );
+
+    return assertApiSuccess(result);
   }
 
   async refreshPaymentDates(): Promise<{

--- a/members/src/app/admin/unclaimed/admin-unclaimed.html
+++ b/members/src/app/admin/unclaimed/admin-unclaimed.html
@@ -1,4 +1,4 @@
-<h1>Unclaimed Profiles</h1>
+<h1>Legacy Membership</h1>
 
 <div class="header-stats">
   <span>Total Unclaimed: {{ totalUnclaimed() }}</span>

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
@@ -6,6 +6,10 @@
   <app-alert-banner variant="success">{{ message }}</app-alert-banner>
 }
 
+@if (service.warningMessage(); as message) {
+  <app-alert-banner variant="warning">{{ message }}</app-alert-banner>
+}
+
 @if (service.actionError(); as message) {
   <app-alert-banner variant="error">{{ message }}</app-alert-banner>
 }

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.html
@@ -1,4 +1,4 @@
-<h1>Unclaimed Profile Details</h1>
+<h1>Legacy Membership Details</h1>
 
 @let profileResource = service.unclaimedProfileResource;
 
@@ -16,7 +16,7 @@
   <p class="error" role="alert">{{ errorMessage }}</p>
 } @else if (profileResource.value(); as profile) {
   <section class="user-info-card">
-    <h2>Unclaimed Profile Information</h2>
+    <h2>Legacy Membership Information</h2>
     <app-alert-banner variant="info">
       This profile has not yet been claimed by the member. They will need to create an account with
       this email address to claim it.
@@ -100,9 +100,27 @@
       <dd>
         {{ profile.nextPayment ? (profile.nextPayment | date: 'MMM d, yyyy') : '—' }}
       </dd>
-
     </dl>
   </section>
+
+  @if (profile.slug) {
+    <section class="subscription-card">
+      <h2>Profile Actions</h2>
+      <p>Hide the public doula profile without deleting this legacy membership record.</p>
+      <button
+        type="button"
+        class="button button--secondary"
+        [disabled]="service.draftInProgress()"
+        (click)="showDraftConfirm()"
+      >
+        @if (service.draftInProgress()) {
+          Processing...
+        } @else {
+          Set Profile to Draft
+        }
+      </button>
+    </section>
+  }
 
   <section class="danger-zone">
     <h2>Danger Zone</h2>
@@ -131,6 +149,7 @@
 }
 
 <app-confirm-dialog
+  #deleteConfirmDialog
   title="Confirm Deletion"
   [message]="deleteConfirmMessage()"
   confirmButtonText="Delete Profile"
@@ -138,4 +157,14 @@
   [disabled]="service.deleteInProgress()"
   (confirmed)="onConfirmDelete()"
   (cancelled)="onCancelDelete()"
+/>
+
+<app-confirm-dialog
+  #draftConfirmDialog
+  title="Set Profile to Draft"
+  message="This will hide the public doula profile from the website without deleting this legacy membership record."
+  confirmButtonText="Set to Draft"
+  [disabled]="service.draftInProgress()"
+  (confirmed)="onConfirmDraft()"
+  (cancelled)="onCancelDraft()"
 />

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.service.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.service.ts
@@ -30,6 +30,7 @@ export class AdminUnclaimedProfileDetailService {
   readonly successMessage = signal<string | undefined>(undefined);
   readonly actionError = signal<string | undefined>(undefined);
   readonly deleteInProgress = signal(false);
+  readonly draftInProgress = signal(false);
 
   /**
    * Initialize the service with the email signal from component input
@@ -78,6 +79,27 @@ export class AdminUnclaimedProfileDetailService {
       return undefined;
     } finally {
       this.actionInProgress.set(false);
+    }
+  }
+
+  async draftProfile(email: string): Promise<void> {
+    this.draftInProgress.set(true);
+    this.successMessage.set(undefined);
+    this.actionError.set(undefined);
+
+    try {
+      const result = await this.adminMembersService.draftUnclaimedProfile(email);
+      this.unclaimedState.invalidate();
+      await this.unclaimedProfileResource.reload();
+      this.successMessage.set(
+        result.warning ?? `Profile ${result.slug} was set to draft.`,
+      );
+    } catch (error) {
+      console.error('Error drafting profile:', error);
+      this.actionError.set('Failed to set profile to draft.');
+      throw error;
+    } finally {
+      this.draftInProgress.set(false);
     }
   }
 }

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.service.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.service.ts
@@ -28,6 +28,7 @@ export class AdminUnclaimedProfileDetailService {
   // Action state signals
   readonly actionInProgress = signal(false);
   readonly successMessage = signal<string | undefined>(undefined);
+  readonly warningMessage = signal<string | undefined>(undefined);
   readonly actionError = signal<string | undefined>(undefined);
   readonly deleteInProgress = signal(false);
   readonly draftInProgress = signal(false);
@@ -44,6 +45,7 @@ export class AdminUnclaimedProfileDetailService {
    */
   async deleteProfile(email: string): Promise<void> {
     this.deleteInProgress.set(true);
+    this.warningMessage.set(undefined);
     this.actionError.set(undefined);
 
     try {
@@ -66,6 +68,7 @@ export class AdminUnclaimedProfileDetailService {
   async updateEmail(oldEmail: string, newEmail: string): Promise<string | undefined> {
     this.actionInProgress.set(true);
     this.successMessage.set(undefined);
+    this.warningMessage.set(undefined);
     this.actionError.set(undefined);
 
     try {
@@ -85,15 +88,17 @@ export class AdminUnclaimedProfileDetailService {
   async draftProfile(email: string): Promise<void> {
     this.draftInProgress.set(true);
     this.successMessage.set(undefined);
+    this.warningMessage.set(undefined);
     this.actionError.set(undefined);
 
     try {
       const result = await this.adminMembersService.draftUnclaimedProfile(email);
       this.unclaimedState.invalidate();
       await this.unclaimedProfileResource.reload();
-      this.successMessage.set(
-        result.warning ?? `Profile ${result.slug} was set to draft.`,
-      );
+      this.successMessage.set(`Profile ${result.slug} was set to draft.`);
+      if (result.warning !== undefined) {
+        this.warningMessage.set(result.warning);
+      }
     } catch (error) {
       console.error('Error drafting profile:', error);
       this.actionError.set('Failed to set profile to draft.');

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
@@ -2,7 +2,7 @@ import { computed, inputBinding, signal } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
 import { render, screen } from '@testing-library/angular/zoneless';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { UnclaimedProfile } from '../../admin.types';
 import { AdminUnclaimedProfileDetail } from './admin-unclaimed-profile-detail';
 import { AdminUnclaimedProfileDetailService } from './admin-unclaimed-profile-detail.service';
@@ -17,11 +17,6 @@ describe('AdminUnclaimedProfileDetail', () => {
     });
   });
 
-  // Wait for resource() operations to complete before test cleanup
-  // resource.reload() needs time to settle in CI environment
-  afterEach(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  });
   it('should display loading state initially', async () => {
     await setup({ shouldKeepLoading: true });
 
@@ -61,13 +56,22 @@ describe('AdminUnclaimedProfileDetail', () => {
     expect(screen.queryByRole('button', { name: 'Set Profile to Draft' })).not.toBeInTheDocument();
   });
 
-  it('should call draftProfile when draft is confirmed', async () => {
-    const { user, mockService } = await setup({ slug: 'jane-doula' });
+  it('should show success message when draft is confirmed', async () => {
+    const { user } = await setup({ slug: 'jane-doula' });
 
     await user.click(await screen.findByRole('button', { name: 'Set Profile to Draft' }));
     await user.click(screen.getByRole('button', { name: 'Set to Draft' }));
 
-    expect(mockService.draftProfile).toHaveBeenCalledWith('test@example.com');
+    expect(await screen.findByRole('status')).toHaveTextContent('Profile jane-doula was set to draft.');
+  });
+
+  it('should show error message when draft fails', async () => {
+    const { user } = await setup({ slug: 'jane-doula', shouldFailDraft: true });
+
+    await user.click(await screen.findByRole('button', { name: 'Set Profile to Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Set to Draft' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to set profile to draft.');
   });
 
   it('should display profile link when slug exists', async () => {
@@ -228,6 +232,7 @@ interface SetupOptions {
   nextPayment?: Date | undefined;
   shouldFailLoad?: boolean;
   shouldFailUpdateEmail?: boolean;
+  shouldFailDraft?: boolean;
   shouldKeepLoading?: boolean;
   errorMessage?: string;
 }
@@ -241,6 +246,7 @@ async function setup(rawOptions: SetupOptions = {}) {
     nextPayment,
     shouldFailLoad = false,
     shouldFailUpdateEmail = false,
+    shouldFailDraft = false,
     shouldKeepLoading = false,
     errorMessage = 'Failed to load unclaimed profile details. Please try again.',
   } = rawOptions;
@@ -272,6 +278,7 @@ async function setup(rawOptions: SetupOptions = {}) {
     errorMessage: computed(() => (shouldFailLoad ? errorMessage : undefined)),
     actionInProgress: signal(false),
     successMessage: signal<string | undefined>(undefined),
+    warningMessage: signal<string | undefined>(undefined),
     actionError: signal<string | undefined>(undefined),
     init: vi.fn(),
     updateEmail: vi.fn().mockImplementation(async (_oldEmail: string, newEmail: string) => {
@@ -285,12 +292,18 @@ async function setup(rawOptions: SetupOptions = {}) {
     deleteInProgress: signal(false),
     draftInProgress: signal(false),
     deleteProfile: vi.fn().mockResolvedValue(undefined),
-    draftProfile: vi.fn().mockResolvedValue(undefined),
+    draftProfile: vi.fn().mockImplementation(async () => {
+      if (shouldFailDraft) {
+        mockService.actionError.set('Failed to set profile to draft.');
+        throw new Error('Draft failed');
+      }
+      mockService.successMessage.set(`Profile ${finalProfile.slug ?? 'test-user'} was set to draft.`);
+    }),
   };
 
   const router = { navigate: vi.fn().mockResolvedValue(true) };
 
-  const { fixture } = await render(AdminUnclaimedProfileDetail, {
+  await render(AdminUnclaimedProfileDetail, {
     bindings: [inputBinding('email', () => email)],
     providers: [provideRouter([]), { provide: Router, useValue: router }],
     configureTestBed: (testBed) => {
@@ -305,7 +318,7 @@ async function setup(rawOptions: SetupOptions = {}) {
   // IMPORTANT: Call userEvent.setup() AFTER render() to avoid ApplicationRef destroyed warnings
   const user = userEvent.setup();
 
-  return { user, fixture, mockService, router };
+  return { user, router };
 }
 
 function createMockUnclaimedProfile(overrides: Partial<UnclaimedProfile> = {}): UnclaimedProfile {

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
@@ -1,6 +1,7 @@
 import { computed, inputBinding, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
-import { render, screen } from '@testing-library/angular/zoneless';
+import { render, screen, waitFor } from '@testing-library/angular/zoneless';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { UnclaimedProfile } from '../../admin.types';
@@ -72,6 +73,44 @@ describe('AdminUnclaimedProfileDetail', () => {
     await user.click(screen.getByRole('button', { name: 'Set to Draft' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Failed to set profile to draft.');
+  });
+
+  it('should show warning message when draft succeeds with warning', async () => {
+    const { user } = await setup({
+      slug: 'jane-doula',
+      draftWarning:
+        'Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Set Profile to Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Set to Draft' }));
+
+    expect(
+      await screen.findByText(
+        'Profile was set to draft, but the site rebuild did not trigger. The change may not appear immediately.',
+      ),
+    ).toBeVisible();
+  });
+
+  it('should close draft dialog without drafting when Cancel is clicked', async () => {
+    const { user } = await setup({ slug: 'jane-doula' });
+
+    await user.click(await screen.findByRole('button', { name: 'Set Profile to Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Set to Draft' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set Profile to Draft' })).toBeVisible();
+  });
+
+  it('should show loading state while draft is in progress', async () => {
+    await setup({ slug: 'jane-doula', draftInProgress: true });
+    TestBed.flushEffects();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Processing...' })).toBeDisabled();
+    });
   });
 
   it('should display profile link when slug exists', async () => {
@@ -234,6 +273,8 @@ interface SetupOptions {
   shouldFailUpdateEmail?: boolean;
   shouldFailDraft?: boolean;
   shouldKeepLoading?: boolean;
+  draftWarning?: string;
+  draftInProgress?: boolean;
   errorMessage?: string;
 }
 
@@ -248,6 +289,8 @@ async function setup(rawOptions: SetupOptions = {}) {
     shouldFailUpdateEmail = false,
     shouldFailDraft = false,
     shouldKeepLoading = false,
+    draftWarning,
+    draftInProgress = false,
     errorMessage = 'Failed to load unclaimed profile details. Please try again.',
   } = rawOptions;
 
@@ -290,7 +333,7 @@ async function setup(rawOptions: SetupOptions = {}) {
       return newEmail;
     }),
     deleteInProgress: signal(false),
-    draftInProgress: signal(false),
+    draftInProgress: signal(draftInProgress),
     deleteProfile: vi.fn().mockResolvedValue(undefined),
     draftProfile: vi.fn().mockImplementation(async () => {
       if (shouldFailDraft) {
@@ -298,6 +341,9 @@ async function setup(rawOptions: SetupOptions = {}) {
         throw new Error('Draft failed');
       }
       mockService.successMessage.set(`Profile ${finalProfile.slug ?? 'test-user'} was set to draft.`);
+      if (draftWarning !== undefined) {
+        mockService.warningMessage.set(draftWarning);
+      }
     }),
   };
 

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.spec.ts
@@ -2,12 +2,21 @@ import { computed, inputBinding, signal } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
 import { render, screen } from '@testing-library/angular/zoneless';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { UnclaimedProfile } from '../../admin.types';
 import { AdminUnclaimedProfileDetail } from './admin-unclaimed-profile-detail';
 import { AdminUnclaimedProfileDetailService } from './admin-unclaimed-profile-detail.service';
 
 describe('AdminUnclaimedProfileDetail', () => {
+  beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+      this.open = true;
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+      this.open = false;
+    });
+  });
+
   // Wait for resource() operations to complete before test cleanup
   // resource.reload() needs time to settle in CI environment
   afterEach(async () => {
@@ -32,6 +41,33 @@ describe('AdminUnclaimedProfileDetail', () => {
     // Assert
     expect(await screen.findByText('Jane Doula')).toBeVisible();
     expect(screen.getByText('jane@example.com')).toBeVisible();
+  });
+
+  it('should display Legacy Membership Details heading', async () => {
+    await setup();
+
+    expect(await screen.findByRole('heading', { name: 'Legacy Membership Details' })).toBeVisible();
+  });
+
+  it('should show Set Profile to Draft button when slug exists', async () => {
+    await setup({ slug: 'jane-doula' });
+
+    expect(await screen.findByRole('button', { name: 'Set Profile to Draft' })).toBeVisible();
+  });
+
+  it('should not show Set Profile to Draft button when no slug exists', async () => {
+    await setup({ slug: undefined });
+
+    expect(screen.queryByRole('button', { name: 'Set Profile to Draft' })).not.toBeInTheDocument();
+  });
+
+  it('should call draftProfile when draft is confirmed', async () => {
+    const { user, mockService } = await setup({ slug: 'jane-doula' });
+
+    await user.click(await screen.findByRole('button', { name: 'Set Profile to Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Set to Draft' }));
+
+    expect(mockService.draftProfile).toHaveBeenCalledWith('test@example.com');
   });
 
   it('should display profile link when slug exists', async () => {
@@ -158,17 +194,12 @@ describe('AdminUnclaimedProfileDetail', () => {
 
   it('should navigate to new email route after successful update email', async () => {
     // Arrange
-    const { fixture, router, mockService } = await setup();
-    mockService.updateEmail.mockResolvedValue('updated@example.com');
-
-    const instance = fixture.componentInstance as unknown as {
-      updateEmailValue: { set(value: string): void };
-      updateEmail(): Promise<void>;
-    };
-    instance.updateEmailValue.set('updated@example.com');
+    const { user, router } = await setup();
 
     // Act
-    await instance.updateEmail();
+    await user.click(await screen.findByRole('button', { name: 'Update Email' }));
+    await user.type(screen.getByLabelText('New Email Address'), 'updated@example.com');
+    await user.click(screen.getByRole('button', { name: 'Confirm Update' }));
 
     // Assert
     expect(router.navigate).toHaveBeenCalledWith(['/admin/unclaimed', 'updated@example.com']);
@@ -176,19 +207,16 @@ describe('AdminUnclaimedProfileDetail', () => {
 
   it('should not navigate when update email fails', async () => {
     // Arrange
-    const { fixture, router } = await setup({ shouldFailUpdateEmail: true });
-
-    const instance = fixture.componentInstance as unknown as {
-      updateEmailValue: { set(value: string): void };
-      updateEmail(): Promise<void>;
-    };
-    instance.updateEmailValue.set('updated@example.com');
+    const { user, router } = await setup({ shouldFailUpdateEmail: true });
 
     // Act
-    await instance.updateEmail();
+    await user.click(await screen.findByRole('button', { name: 'Update Email' }));
+    await user.type(screen.getByLabelText('New Email Address'), 'updated@example.com');
+    await user.click(screen.getByRole('button', { name: 'Confirm Update' }));
 
     // Assert
     expect(router.navigate).not.toHaveBeenCalled();
+    expect(screen.getByText('Failed to update email.')).toBeVisible();
   });
 });
 
@@ -255,7 +283,9 @@ async function setup(rawOptions: SetupOptions = {}) {
       return newEmail;
     }),
     deleteInProgress: signal(false),
+    draftInProgress: signal(false),
     deleteProfile: vi.fn().mockResolvedValue(undefined),
+    draftProfile: vi.fn().mockResolvedValue(undefined),
   };
 
   const router = { navigate: vi.fn().mockResolvedValue(true) };

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
@@ -27,7 +27,8 @@ export class AdminUnclaimedProfileDetail {
 
   email = input.required<string>();
 
-  protected confirmDialog = viewChild(ConfirmDialog);
+  protected deleteConfirmDialog = viewChild<ConfirmDialog>('deleteConfirmDialog');
+  protected draftConfirmDialog = viewChild<ConfirmDialog>('draftConfirmDialog');
 
   protected deleteConfirmMessage = computed(() => {
     const resource = this.service.unclaimedProfileResource;
@@ -45,22 +46,38 @@ export class AdminUnclaimedProfileDetail {
   }
 
   protected showDeleteConfirm(): void {
-    this.confirmDialog()?.showModal();
+    this.deleteConfirmDialog()?.showModal();
+  }
+
+  protected showDraftConfirm(): void {
+    this.draftConfirmDialog()?.showModal();
   }
 
   protected async onConfirmDelete(): Promise<void> {
     try {
       await this.service.deleteProfile(this.email());
-      this.confirmDialog()?.close();
+      this.deleteConfirmDialog()?.close();
       await this.router.navigateByUrl('/admin/unclaimed');
     } catch {
       // Error already handled in service (sets actionError signal)
-      this.confirmDialog()?.close();
+      this.deleteConfirmDialog()?.close();
+    }
+  }
+
+  protected async onConfirmDraft(): Promise<void> {
+    try {
+      await this.service.draftProfile(this.email());
+    } finally {
+      this.draftConfirmDialog()?.close();
     }
   }
 
   protected onCancelDelete(): void {
-    this.confirmDialog()?.close();
+    this.deleteConfirmDialog()?.close();
+  }
+
+  protected onCancelDraft(): void {
+    this.draftConfirmDialog()?.close();
   }
 
   protected async updateEmail(): Promise<void> {

--- a/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
+++ b/members/src/app/admin/users/admin-unclaimed-profile-detail/admin-unclaimed-profile-detail.ts
@@ -67,6 +67,8 @@ export class AdminUnclaimedProfileDetail {
   protected async onConfirmDraft(): Promise<void> {
     try {
       await this.service.draftProfile(this.email());
+    } catch {
+      // Error already handled in service (sets actionError signal)
     } finally {
       this.draftConfirmDialog()?.close();
     }


### PR DESCRIPTION
## Summary
- add an admin endpoint and UI action to set linked legacy membership profiles to draft without deleting the legacy membership record
- rename the admin unclaimed profiles experience to Legacy Membership across members UI and E2E coverage
- add backend route coverage and update members tests/e2e selectors for the renamed flow

## Test plan
- [x] cd members && bun run lint
- [x] cd members && bun run test
- [x] cd members && bun run build
- [x] cd members && bun run e2e
- [x] cd functions && npm run lint
- [x] cd functions && bun test src/
- [x] cd functions && npm run build
- [x] cd functions && npm run typecheck:tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)