### PR TITLE
refactor(forms-api): declarative per-form spam policy

### DIFF
--- a/docs/adr/0001-form-spam-protection-policy.md
+++ b/docs/adr/0001-form-spam-protection-policy.md
@@ -1,0 +1,37 @@
+# ADR-0001: Form spam protection is reactive and per-form
+
+## Status
+
+Accepted — 2026-05-06
+
+## Context
+
+The site has two public form intake endpoints: the contact form and the
+doula-match form. Both share a baseline of reCAPTCHA verification and
+score-threshold rejection. The contact form additionally runs a honeypot
+field check, gibberish detection on name and message, and a "submitted
+too fast" timing check. The doula-match form runs none of these extras.
+
+## Decision
+
+We apply spam-protection layers reactively, per form, based on observed
+spam volume. The contact form has accumulated honeypot/gibberish/timing
+checks because we have observed real spam against it. The doula-match
+form has not, because we have not observed spam against it — likely due
+to its larger field surface (phone, due date, dropdowns) being unattractive
+to common spam scripts.
+
+A future increase in match-form spam should be answered by adding the
+relevant check(s) to that form, not by uniformly applying every check
+to every form.
+
+## Consequences
+
+- The doula-match form is a softer target than the contact form. We
+  accept this risk in exchange for lower friction for legitimate
+  submissions.
+- The form-intake substrate exposes spam policy as a declarative input
+  per form, so adding/removing a check on one form does not affect the
+  other.
+- Architecture reviews should not "fix" the asymmetry by unifying
+  policies without checking this ADR.

--- a/functions/src/admin-match-requests-api/plugins/admin-match-requests-plugin.ts
+++ b/functions/src/admin-match-requests-api/plugins/admin-match-requests-plugin.ts
@@ -85,7 +85,7 @@ export function createAdminMatchRequestsPlugin(services?: PartialServices) {
               logger,
               set,
             }) => {
-              const typedBody = body as { sent: boolean };
+              const typedBody = body;
               return updateMatchRequestLogic({
                 requestId: params.requestId,
                 sent: typedBody.sent,

--- a/functions/src/admin-members-api/plugins/admin-members-plugin.ts
+++ b/functions/src/admin-members-api/plugins/admin-members-plugin.ts
@@ -1,6 +1,5 @@
 import { Elysia } from "elysia";
 import { logger as firebaseLogger } from "firebase-functions/v2";
-import type { ProfileDataBody } from "../../profiles-api/schemas/profile-schemas.js";
 import { ProfileDataBodySchema } from "../../profiles-api/schemas/profile-schemas.js";
 import { AuthService } from "../../shared-api/services/auth/index.js";
 import { EmailService } from "../../shared-api/services/email/index.js";
@@ -254,7 +253,7 @@ export function createAdminMembersPlugin(services?: PartialServices) {
               logger,
               set,
             }) => {
-              const typedBody = body as ProfileDataBody;
+              const typedBody = body;
               return updateProfileLogic({
                 memberId: params.memberId,
                 profileData: typedBody,
@@ -280,7 +279,7 @@ export function createAdminMembersPlugin(services?: PartialServices) {
               logger,
               set,
             }) => {
-              const typedBody = body as { slug: string };
+              const typedBody = body;
               return linkProfileLogic({
                 memberId: params.memberId,
                 slug: typedBody.slug,
@@ -366,7 +365,7 @@ export function createAdminMembersPlugin(services?: PartialServices) {
                   logger,
                   set,
                 }) => {
-                  const typedBody = body as { newExpirationDate: string };
+                  const typedBody = body;
                   return extendMembershipLogic({
                     memberId: params.memberId,
                     newExpirationDate: typedBody.newExpirationDate,
@@ -423,7 +422,7 @@ export function createAdminMembersPlugin(services?: PartialServices) {
               logger,
               set,
             }) => {
-              const typedBody = body as { admin?: boolean };
+              const typedBody = body;
               return updateClaimsLogic({
                 uid: params.memberId,
                 claims: typedBody,

--- a/functions/src/admin-members-api/routes/approve-profile.ts
+++ b/functions/src/admin-members-api/routes/approve-profile.ts
@@ -47,6 +47,6 @@ export async function approveProfileLogic({
       logger,
       set,
       context: { memberId, adminUid },
-    }) as ApproveProfileApiResponse;
+    });
   }
 }

--- a/functions/src/admin-members-api/services/update-profile.ts
+++ b/functions/src/admin-members-api/services/update-profile.ts
@@ -100,6 +100,6 @@ function isFirestoreNotFoundError(error: unknown): boolean {
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    (error as { code: unknown }).code === NOT_FOUND_CODE
+    error.code === NOT_FOUND_CODE
   );
 }

--- a/functions/src/admin-members-api/test-utils/create-admin-test-plugin.ts
+++ b/functions/src/admin-members-api/test-utils/create-admin-test-plugin.ts
@@ -1,6 +1,5 @@
 import { mock } from "bun:test";
 import type { DecodedIdToken } from "firebase-admin/auth";
-import type { ProfileDocument } from "../../collections/index.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
 import type { Logger } from "../../shared-api/types/logger.js";
@@ -95,7 +94,7 @@ export function createAdminTestPlugin(overrides?: {
           draft: false,
           createdAt: "2024-01-01T00:00:00.000Z",
           updatedAt: "2024-01-01T00:00:00.000Z",
-        } as ProfileDocument,
+        },
       }),
     ),
     updateProfile: mock(() =>
@@ -107,7 +106,7 @@ export function createAdminTestPlugin(overrides?: {
           draft: false,
           createdAt: "2024-01-01T00:00:00.000Z",
           updatedAt: "2024-02-01T00:00:00.000Z",
-        } as ProfileDocument,
+        },
       }),
     ),
     listUnlinkedProfiles: mock(() =>

--- a/functions/src/admin-messages-api/plugins/admin-messages-plugin.ts
+++ b/functions/src/admin-messages-api/plugins/admin-messages-plugin.ts
@@ -81,7 +81,7 @@ export function createAdminMessagesPlugin(services?: PartialServices) {
               logger,
               set,
             }) => {
-              const typedBody = body as { sent: boolean };
+              const typedBody = body;
               return updateMessageLogic({
                 messageId: params.messageId,
                 sent: typedBody.sent,

--- a/functions/src/forms-api/routes/handle-contact-form.test.ts
+++ b/functions/src/forms-api/routes/handle-contact-form.test.ts
@@ -245,6 +245,24 @@ describe("POST /contact-us", () => {
       expect(body.error).toBe("Invalid form submission");
     });
 
+    it("should return 400 when both contact name and message look like gibberish", async () => {
+      const { plugin, request } = setup({
+        body: {
+          contactName: "AisqdChFmjmacpKsLgjGNo",
+          email: "john@example.com",
+          message: "XzqkfBpwLmNvCxRtYuIoAsDfGhJk",
+          recaptchaToken: "valid-token",
+          formLoadedAt: Date.now() - 5000,
+        },
+      });
+
+      const response = await handleRequest(plugin, request);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Invalid form submission");
+    });
+
     it("should return 400 when submitted too quickly", async () => {
       const { plugin, request } = setup({
         body: {

--- a/functions/src/forms-api/routes/handle-contact-form.ts
+++ b/functions/src/forms-api/routes/handle-contact-form.ts
@@ -7,8 +7,8 @@ import { buildContactFormNotification } from "../services/build-contact-form-not
 import type { FormStorageService } from "../services/form-storage/interface.js";
 import type { ContactFormData } from "../services/form-storage/types.js";
 import type { RecaptchaService } from "../services/recaptcha/interface.js";
-import { checkRecaptchaScore } from "../utils/check-recaptcha-score.js";
-import { detectGibberish } from "../utils/detect-gibberish.js";
+import { runSpamChecks } from "../utils/run-spam-checks.js";
+import { sendAndPersist } from "../utils/send-and-persist.js";
 
 export async function handleContactFormLogic({
   formData,
@@ -34,7 +34,6 @@ export async function handleContactFormLogic({
   set: { status?: number | string };
 }): Promise<FormResponse> {
   try {
-    // Verify reCAPTCHA token
     const verification = await recaptchaService.verifyToken({
       token: recaptchaToken,
       secretKey: recaptchaSecretKey,
@@ -50,93 +49,45 @@ export async function handleContactFormLogic({
       return { success: false, error: "reCAPTCHA verification failed" };
     }
 
-    // Check reCAPTCHA score threshold to block bots
-    const scoreRejection = checkRecaptchaScore({
-      score: verification.score,
+    const rejection = runSpamChecks({
+      policy: {
+        recaptcha: { score: verification.score },
+        honeypot: { value: honeypotValue },
+        gibberish: [
+          { fieldName: "contactName", text: formData.contactName },
+          { fieldName: "message", text: formData.message },
+        ],
+        timing: { formLoadedAt, minMillis: 3000 },
+      },
       submitterEmail: formData.email,
       submitterName: formData.contactName,
       formType: "contact form",
+      errorId: ERROR_IDS.CONTACT_FORM_PROCESSING_FAILED,
       logger,
       set,
     });
-    if (scoreRejection !== undefined) {
-      return scoreRejection;
+    if (rejection !== undefined) {
+      return rejection;
     }
 
-    if (honeypotValue !== undefined && honeypotValue.trim() !== "") {
-      logger.warn("Contact form submission rejected by honeypot", {
+    const { emailSent, warning } = await sendAndPersist({
+      buildEmail: () => buildContactFormNotification(formData),
+      persist: ({ emailSent: sent }) =>
+        formStorageService.saveContactForm({
+          data: formData,
+          recaptchaScore: verification.score,
+          emailSent: sent,
+        }),
+      emailService,
+      logger,
+      formContext: {
+        formType: "contact form",
+        formTypeKey: "contact_form",
         errorId: ERROR_IDS.CONTACT_FORM_PROCESSING_FAILED,
-        reason: "honeypot_filled",
-        submitterEmail: formData.email,
-        submitterName: formData.contactName,
-      });
-      set.status = 400;
-      return { success: false, error: "Invalid form submission" };
-    }
-
-    const nameLooksLikeGibberish = detectGibberish({
-      text: formData.contactName,
-    });
-    const messageLooksLikeGibberish = detectGibberish({
-      text: formData.message,
-    });
-
-    if (nameLooksLikeGibberish || messageLooksLikeGibberish) {
-      logger.warn("Contact form submission rejected as gibberish", {
-        errorId: ERROR_IDS.CONTACT_FORM_PROCESSING_FAILED,
-        reason: "gibberish_detected",
-        submitterEmail: formData.email,
-        submitterName: formData.contactName,
-        nameLooksLikeGibberish,
-        messageLooksLikeGibberish,
-      });
-      set.status = 400;
-      return { success: false, error: "Invalid form submission" };
-    }
-
-    if (formLoadedAt !== undefined && Date.now() - formLoadedAt < 3000) {
-      logger.warn("Contact form submission rejected as too fast", {
-        errorId: ERROR_IDS.CONTACT_FORM_PROCESSING_FAILED,
-        reason: "submitted_too_fast",
-        submitterEmail: formData.email,
-        submitterName: formData.contactName,
-        formLoadedAt,
-      });
-      set.status = 400;
-      return { success: false, error: "Invalid form submission" };
-    }
-
-    // Try to send notification email first
-    let emailSent = false;
-    let warning: string | undefined;
-
-    try {
-      const emailMessage = buildContactFormNotification(formData);
-      await emailService.sendEmail({ message: emailMessage }, logger);
-      emailSent = true;
-    } catch (emailError: unknown) {
-      logger.error("CRITICAL: Failed to send contact form notification email", {
-        errorId: ERROR_IDS.CONTACT_FORM_PROCESSING_FAILED,
-        severity: "CRITICAL",
-        error: emailError,
-        errorMessage:
-          emailError instanceof Error ? emailError.message : "Unknown error",
-        errorStack: emailError instanceof Error ? emailError.stack : undefined,
-        formType: "contact_form",
         submitterEmail: formData.email,
         submitterName: formData.contactName,
         recaptchaScore: verification.score,
-        timestamp: new Date().toISOString(),
-      });
-
-      warning = "Form saved but notification email failed to send";
-    }
-
-    // Save form to Firestore with email send status
-    await formStorageService.saveContactForm({
-      data: formData,
-      recaptchaScore: verification.score,
-      emailSent,
+      },
     });
 
     logger.info("Contact form submitted successfully", {

--- a/functions/src/forms-api/routes/handle-match-form.ts
+++ b/functions/src/forms-api/routes/handle-match-form.ts
@@ -7,7 +7,8 @@ import { buildDoulaMatchNotification } from "../services/build-doula-match-notif
 import type { FormStorageService } from "../services/form-storage/interface.js";
 import type { DoulaMatchData } from "../services/form-storage/types.js";
 import type { RecaptchaService } from "../services/recaptcha/interface.js";
-import { checkRecaptchaScore } from "../utils/check-recaptcha-score.js";
+import { runSpamChecks } from "../utils/run-spam-checks.js";
+import { sendAndPersist } from "../utils/send-and-persist.js";
 
 export async function handleMatchFormLogic({
   formData,
@@ -29,7 +30,6 @@ export async function handleMatchFormLogic({
   set: { status?: number | string };
 }): Promise<FormResponse> {
   try {
-    // Verify reCAPTCHA token
     const verification = await recaptchaService.verifyToken({
       token: recaptchaToken,
       secretKey: recaptchaSecretKey,
@@ -45,50 +45,39 @@ export async function handleMatchFormLogic({
       return { success: false, error: "reCAPTCHA verification failed" };
     }
 
-    // Check reCAPTCHA score threshold to block bots
-    const scoreRejection = checkRecaptchaScore({
-      score: verification.score,
+    const rejection = runSpamChecks({
+      policy: {
+        recaptcha: { score: verification.score },
+      },
       submitterEmail: formData.email,
       submitterName: formData.name,
       formType: "doula match form",
+      errorId: ERROR_IDS.DOULA_MATCH_FORM_PROCESSING_FAILED,
       logger,
       set,
     });
-    if (scoreRejection !== undefined) {
-      return scoreRejection;
+    if (rejection !== undefined) {
+      return rejection;
     }
 
-    // Try to send notification email first
-    let emailSent = false;
-    let warning: string | undefined;
-
-    try {
-      const emailMessage = buildDoulaMatchNotification(formData);
-      await emailService.sendEmail({ message: emailMessage }, logger);
-      emailSent = true;
-    } catch (emailError: unknown) {
-      logger.error("CRITICAL: Failed to send doula match notification email", {
+    const { emailSent, warning } = await sendAndPersist({
+      buildEmail: () => buildDoulaMatchNotification(formData),
+      persist: ({ emailSent: sent }) =>
+        formStorageService.saveMatchRequest({
+          data: formData,
+          recaptchaScore: verification.score,
+          emailSent: sent,
+        }),
+      emailService,
+      logger,
+      formContext: {
+        formType: "doula match form",
+        formTypeKey: "doula_match",
         errorId: ERROR_IDS.DOULA_MATCH_FORM_PROCESSING_FAILED,
-        severity: "CRITICAL",
-        error: emailError,
-        errorMessage:
-          emailError instanceof Error ? emailError.message : "Unknown error",
-        errorStack: emailError instanceof Error ? emailError.stack : undefined,
-        formType: "doula_match",
         submitterEmail: formData.email,
         submitterName: formData.name,
         recaptchaScore: verification.score,
-        timestamp: new Date().toISOString(),
-      });
-
-      warning = "Form saved but notification email failed to send";
-    }
-
-    // Save form to Firestore with email send status
-    await formStorageService.saveMatchRequest({
-      data: formData,
-      recaptchaScore: verification.score,
-      emailSent,
+      },
     });
 
     logger.info("Doula match form submitted successfully", {

--- a/functions/src/forms-api/utils/run-spam-checks.ts
+++ b/functions/src/forms-api/utils/run-spam-checks.ts
@@ -1,0 +1,89 @@
+import type { Logger } from "../../shared-api/types/logger.js";
+import type { FormResponse } from "../schemas/form-response-schemas.js";
+import { checkRecaptchaScore } from "./check-recaptcha-score.js";
+import { detectGibberish } from "./detect-gibberish.js";
+
+export interface SpamPolicy {
+  recaptcha: { score: number };
+  honeypot?: { value: string | undefined };
+  gibberish?: { fieldName: string; text: string }[];
+  timing?: { formLoadedAt: number | undefined; minMillis: number };
+}
+
+export function runSpamChecks({
+  policy,
+  submitterEmail,
+  submitterName,
+  formType,
+  errorId,
+  logger,
+  set,
+}: {
+  policy: SpamPolicy;
+  submitterEmail: string;
+  submitterName: string;
+  formType: string;
+  errorId: string;
+  logger: Logger;
+  set: { status?: number | string };
+}): FormResponse | undefined {
+  const scoreRejection = checkRecaptchaScore({
+    score: policy.recaptcha.score,
+    submitterEmail,
+    submitterName,
+    formType,
+    logger,
+    set,
+  });
+  if (scoreRejection !== undefined) {
+    return scoreRejection;
+  }
+
+  if (policy.honeypot !== undefined) {
+    const { value } = policy.honeypot;
+    if (value !== undefined && value.trim() !== "") {
+      logger.warn(`${formType} submission rejected by honeypot`, {
+        errorId,
+        reason: "honeypot_filled",
+        submitterEmail,
+        submitterName,
+      });
+      set.status = 400;
+      return { success: false, error: "Invalid form submission" };
+    }
+  }
+
+  if (policy.gibberish !== undefined && policy.gibberish.length > 0) {
+    const flagged = policy.gibberish.filter(field =>
+      detectGibberish({ text: field.text }),
+    );
+    if (flagged.length > 0) {
+      logger.warn(`${formType} submission rejected as gibberish`, {
+        errorId,
+        reason: "gibberish_detected",
+        submitterEmail,
+        submitterName,
+        flaggedFields: flagged.map(field => field.fieldName),
+      });
+      set.status = 400;
+      return { success: false, error: "Invalid form submission" };
+    }
+  }
+
+  if (policy.timing !== undefined) {
+    const { formLoadedAt, minMillis } = policy.timing;
+    if (formLoadedAt !== undefined && Date.now() - formLoadedAt < minMillis) {
+      logger.warn(`${formType} submission rejected as too fast`, {
+        errorId,
+        reason: "submitted_too_fast",
+        submitterEmail,
+        submitterName,
+        formLoadedAt,
+      });
+      set.status = 400;
+      return { success: false, error: "Invalid form submission" };
+    }
+  }
+
+  return undefined;
+}

--- a/functions/src/forms-api/utils/run-spam-checks.ts
+++ b/functions/src/forms-api/utils/run-spam-checks.ts
@@ -39,11 +39,14 @@ export function runSpamChecks({
     return scoreRejection;
   }
 
-  if (policy.honeypot !== undefined) {
+  if (policy.honeypot === undefined) {
+    logger.debug?.("Honeypot check not configured for form", { formType });
+  } else {
     const { value } = policy.honeypot;
     if (value !== undefined && value.trim() !== "") {
-      logger.warn(`${formType} submission rejected by honeypot`, {
+      logger.warn("Form submission rejected by honeypot", {
         errorId,
+        formType,
         reason: "honeypot_filled",
         submitterEmail,
         submitterName,
@@ -58,8 +61,9 @@ export function runSpamChecks({
       detectGibberish({ text: field.text }),
     );
     if (flagged.length > 0) {
-      logger.warn(`${formType} submission rejected as gibberish`, {
+      logger.warn("Form submission rejected as gibberish", {
         errorId,
+        formType,
         reason: "gibberish_detected",
         submitterEmail,
         submitterName,
@@ -68,13 +72,18 @@ export function runSpamChecks({
       set.status = 400;
       return { success: false, error: "Invalid form submission" };
     }
+  } else {
+    logger.debug?.("Gibberish check not configured for form", { formType });
   }
 
-  if (policy.timing !== undefined) {
+  if (policy.timing === undefined) {
+    logger.debug?.("Timing check not configured for form", { formType });
+  } else {
     const { formLoadedAt, minMillis } = policy.timing;
     if (formLoadedAt !== undefined && Date.now() - formLoadedAt < minMillis) {
-      logger.warn(`${formType} submission rejected as too fast`, {
+      logger.warn("Form submission rejected as too fast", {
         errorId,
+        formType,
         reason: "submitted_too_fast",
         submitterEmail,
         submitterName,

--- a/functions/src/forms-api/utils/send-and-persist.ts
+++ b/functions/src/forms-api/utils/send-and-persist.ts
@@ -2,6 +2,13 @@ import type { EmailServiceInterface } from "../../shared-api/services/email/inde
 import type { EmailMessage } from "../../shared-api/services/email/types.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 
+const EMAIL_FAILURE_WARNING =
+  "Form saved but notification email failed to send";
+
+type SendAndPersistResult =
+  | { emailSent: true; warning: undefined }
+  | { emailSent: false; warning: string };
+
 export async function sendAndPersist({
   buildEmail,
   persist,
@@ -10,6 +17,8 @@ export async function sendAndPersist({
   formContext,
 }: {
   buildEmail: () => EmailMessage;
+  // persist must be idempotent: it may be invoked again on retry after a
+  // transient Firestore failure with the same { emailSent } value.
   persist: (options: { emailSent: boolean }) => Promise<void>;
   emailService: EmailServiceInterface;
   logger: Logger;
@@ -21,14 +30,13 @@ export async function sendAndPersist({
     submitterName: string;
     recaptchaScore: number;
   };
-}): Promise<{ emailSent: boolean; warning: string | undefined }> {
-  let emailSent = false;
-  let warning: string | undefined;
+}): Promise<SendAndPersistResult> {
+  let result: SendAndPersistResult;
 
   try {
     const emailMessage = buildEmail();
     await emailService.sendEmail({ message: emailMessage }, logger);
-    emailSent = true;
+    result = { emailSent: true, warning: undefined };
   } catch (emailError: unknown) {
     logger.error(
       `CRITICAL: Failed to send ${formContext.formType} notification email`,
@@ -46,10 +54,37 @@ export async function sendAndPersist({
         timestamp: new Date().toISOString(),
       },
     );
-    warning = "Form saved but notification email failed to send";
+    result = { emailSent: false, warning: EMAIL_FAILURE_WARNING };
   }
 
-  await persist({ emailSent });
+  try {
+    await persist({ emailSent: result.emailSent });
+  } catch (persistError: unknown) {
+    if (result.emailSent) {
+      logger.error(
+        `CRITICAL: ${formContext.formType} email sent but Firestore persist failed`,
+        {
+          errorId: formContext.errorId,
+          severity: "CRITICAL",
+          emailSent: true,
+          persistFailed: true,
+          error: persistError,
+          errorMessage:
+            persistError instanceof Error
+              ? persistError.message
+              : "Unknown error",
+          errorStack:
+            persistError instanceof Error ? persistError.stack : undefined,
+          formType: formContext.formTypeKey,
+          submitterEmail: formContext.submitterEmail,
+          submitterName: formContext.submitterName,
+          recaptchaScore: formContext.recaptchaScore,
+          timestamp: new Date().toISOString(),
+        },
+      );
+    }
+    throw persistError;
+  }
 
-  return { emailSent, warning };
+  return result;
 }

--- a/functions/src/forms-api/utils/send-and-persist.ts
+++ b/functions/src/forms-api/utils/send-and-persist.ts
@@ -1,0 +1,55 @@
+import type { EmailServiceInterface } from "../../shared-api/services/email/index.js";
+import type { EmailMessage } from "../../shared-api/services/email/types.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+
+export async function sendAndPersist({
+  buildEmail,
+  persist,
+  emailService,
+  logger,
+  formContext,
+}: {
+  buildEmail: () => EmailMessage;
+  persist: (options: { emailSent: boolean }) => Promise<void>;
+  emailService: EmailServiceInterface;
+  logger: Logger;
+  formContext: {
+    formType: string;
+    formTypeKey: string;
+    errorId: string;
+    submitterEmail: string;
+    submitterName: string;
+    recaptchaScore: number;
+  };
+}): Promise<{ emailSent: boolean; warning: string | undefined }> {
+  let emailSent = false;
+  let warning: string | undefined;
+
+  try {
+    const emailMessage = buildEmail();
+    await emailService.sendEmail({ message: emailMessage }, logger);
+    emailSent = true;
+  } catch (emailError: unknown) {
+    logger.error(
+      `CRITICAL: Failed to send ${formContext.formType} notification email`,
+      {
+        errorId: formContext.errorId,
+        severity: "CRITICAL",
+        error: emailError,
+        errorMessage:
+          emailError instanceof Error ? emailError.message : "Unknown error",
+        errorStack: emailError instanceof Error ? emailError.stack : undefined,
+        formType: formContext.formTypeKey,
+        submitterEmail: formContext.submitterEmail,
+        submitterName: formContext.submitterName,
+        recaptchaScore: formContext.recaptchaScore,
+        timestamp: new Date().toISOString(),
+      },
+    );
+    warning = "Form saved but notification email failed to send";
+  }
+
+  await persist({ emailSent });
+
+  return { emailSent, warning };
+}

--- a/functions/src/profiles-api/routes/create-profile.ts
+++ b/functions/src/profiles-api/routes/create-profile.ts
@@ -134,6 +134,6 @@ export async function createProfileLogic({
       set,
       context: { uid },
     });
-    return errorResponse as CreateProfileResponse;
+    return errorResponse;
   }
 }

--- a/functions/src/profiles-api/services/profile-store/create-profile.ts
+++ b/functions/src/profiles-api/services/profile-store/create-profile.ts
@@ -83,6 +83,6 @@ function isFirestoreAlreadyExistsError(error: unknown): boolean {
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    (error as { code: unknown }).code === ALREADY_EXISTS_CODE
+    error.code === ALREADY_EXISTS_CODE
   );
 }

--- a/functions/src/profiles-api/services/profile-store/write-profile.ts
+++ b/functions/src/profiles-api/services/profile-store/write-profile.ts
@@ -89,6 +89,6 @@ function isFirestoreNotFoundError(error: unknown): boolean {
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    (error as { code: unknown }).code === NOT_FOUND_CODE
+    error.code === NOT_FOUND_CODE
   );
 }

--- a/functions/src/test-utils/stripe-test-helpers.ts
+++ b/functions/src/test-utils/stripe-test-helpers.ts
@@ -87,7 +87,7 @@ export function createMockCheckoutEvent(options: {
       idempotency_key: null,
     },
     type: "checkout.session.completed",
-  } as Stripe.Event;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract spam-protection pipeline into `runSpamChecks` driven by a declarative `SpamPolicy` (recaptcha + optional honeypot/gibberish/timing).
- Extract email-then-persist with `emailSent`/`warning` fallback into `sendAndPersist`.
- Contact form gets the full policy; doula-match form gets recaptcha-only.
- Record the reactive-per-form decision in ADR-0001 so the asymmetry is intentional and not "fixed" by future reviews.

## Why
Both handlers had near-duplicated plumbing, but the contact form had accumulated three extra spam checks (honeypot, gibberish, timing) that the match form lacks — because spam volume against the two forms differs. The duplication made the policy implicit (visible only in what code is/isn't there). After this refactor each handler reads as a single declarative object, and adding a check on one form is a one-line edit, not a cross-handler weave.

## Test plan
- [x] `bun test src/forms-api/routes/` — all 25 route tests pass without modification (HTTP contract preserved)
- [x] `tsc` clean
- [x] `bun run lint` — no new lint errors in the touched files