### PR TITLE
feat(members): member-facing referral portal

### DIFF
--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -354,6 +354,13 @@ export const ERROR_IDS = {
   API_ADMIN_LIST_UNLINKED_PROFILES_FAILED:
     "api_admin_list_unlinked_profiles_failed",
   API_ADMIN_LINK_PROFILE_FAILED: "api_admin_link_profile_failed",
+
+  // Member referrals errors
+  API_MEMBER_LIST_REFERRALS_FAILED: "api_member_list_referrals_failed",
+  API_MEMBER_GET_REFERRAL_FAILED: "api_member_get_referral_failed",
+  API_MEMBER_REFERRAL_NOT_FOUND: "api_member_referral_not_found",
+  API_MEMBER_REFERRALS_ELIGIBILITY_FAILED:
+    "api_member_referrals_eligibility_failed",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/members-api/plugins/members-plugin.ts
+++ b/functions/src/members-api/plugins/members-plugin.ts
@@ -22,6 +22,8 @@ import {
   VerifyEmailResponseSchema,
 } from "../schemas/member-schemas.js";
 import {
+  ListReferralsRouteResponseSchema,
+  ReferralDetailRouteResponseSchema,
   ReferralRequestIdParameterSchema,
 } from "../schemas/referral-schemas.js";
 import { MemberService } from "../services/member/member-service.js";
@@ -239,6 +241,7 @@ export function createMembersPlugin(services?: PartialServices) {
           }),
         {
           params: MemberIdParameterSchema,
+          response: ListReferralsRouteResponseSchema,
         },
       )
       // GET /:memberId/referrals/:requestId - Get referral detail (active Stripe member or admin) - Served at /api/members/:memberId/referrals/:requestId
@@ -269,6 +272,7 @@ export function createMembersPlugin(services?: PartialServices) {
             memberId: MemberIdParameterSchema.properties.memberId,
             requestId: ReferralRequestIdParameterSchema.properties.requestId,
           }),
+          response: ReferralDetailRouteResponseSchema,
         },
       )
   );

--- a/functions/src/members-api/plugins/members-plugin.ts
+++ b/functions/src/members-api/plugins/members-plugin.ts
@@ -1,9 +1,11 @@
-import { Elysia } from "elysia";
+import { Elysia, t } from "elysia";
 import { logger as firebaseLogger } from "firebase-functions/v2";
 import { AuthService } from "../../shared-api/services/auth/index.js";
 import { EmailService } from "../../shared-api/services/email/index.js";
 import { MemberFirestoreService } from "../../shared-api/services/member-firestore/index.js";
 import { cancelMembershipLogic } from "../routes/cancel-membership.js";
+import { getReferralLogic } from "../routes/get-referral.js";
+import { listReferralsLogic } from "../routes/list-referrals.js";
 import { getMemberLogic } from "../routes/members.js";
 import { syncEmailLogic } from "../routes/sync-email.js";
 import { updateMemberNameLogic } from "../routes/update-member-name.js";
@@ -19,8 +21,12 @@ import {
   UpdateNewsletterPreferenceResponseSchema,
   VerifyEmailResponseSchema,
 } from "../schemas/member-schemas.js";
+import {
+  ReferralRequestIdParameterSchema,
+} from "../schemas/referral-schemas.js";
 import { MemberService } from "../services/member/member-service.js";
 import { NewsletterService } from "../services/newsletter/newsletter-service.js";
+import { ReferralsServiceImpl } from "../services/referrals/referrals-service.js";
 import { VerifyEmailServiceImpl } from "../services/verify-email/verify-email-service.js";
 import { SERVICE_KEYS, type PartialServices } from "../types/services.js";
 
@@ -59,6 +65,10 @@ export function createMembersPlugin(services?: PartialServices) {
       .decorate(
         SERVICE_KEYS.MEMBER_FIRESTORE_SERVICE,
         services?.memberFirestoreService ?? MemberFirestoreService,
+      )
+      .decorate(
+        SERVICE_KEYS.REFERRALS_SERVICE,
+        services?.referralsService ?? ReferralsServiceImpl,
       )
       // GET /:memberId - Get member by ID (owner or admin) - Served at /api/members/:memberId
       .get(
@@ -203,6 +213,62 @@ export function createMembersPlugin(services?: PartialServices) {
         {
           params: MemberIdParameterSchema,
           response: CancelMembershipResponseSchema,
+        },
+      )
+      // GET /:memberId/referrals - List referrals (active Stripe member or admin) - Served at /api/members/:memberId/referrals
+      .get(
+        "/:memberId/referrals",
+        async ({
+          params,
+          memberService,
+          referralsService,
+          authService,
+          logger,
+          request,
+          set,
+        }) =>
+          listReferralsLogic({
+            memberId: params.memberId,
+            memberService,
+            referralsService,
+            authService,
+            logger,
+            authorizationHeader:
+              request.headers.get("authorization") ?? undefined,
+            set,
+          }),
+        {
+          params: MemberIdParameterSchema,
+        },
+      )
+      // GET /:memberId/referrals/:requestId - Get referral detail (active Stripe member or admin) - Served at /api/members/:memberId/referrals/:requestId
+      .get(
+        "/:memberId/referrals/:requestId",
+        async ({
+          params,
+          memberService,
+          referralsService,
+          authService,
+          logger,
+          request,
+          set,
+        }) =>
+          getReferralLogic({
+            memberId: params.memberId,
+            requestId: params.requestId,
+            memberService,
+            referralsService,
+            authService,
+            logger,
+            authorizationHeader:
+              request.headers.get("authorization") ?? undefined,
+            set,
+          }),
+        {
+          params: t.Object({
+            memberId: MemberIdParameterSchema.properties.memberId,
+            requestId: ReferralRequestIdParameterSchema.properties.requestId,
+          }),
         },
       )
   );

--- a/functions/src/members-api/routes/get-referral.test.ts
+++ b/functions/src/members-api/routes/get-referral.test.ts
@@ -49,6 +49,7 @@ function makeReferralItem(id = REQUEST_ID): ReferralItem {
       insurance: ["medicaid"],
       submitted: Timestamp.now(),
       sent: false,
+      recaptchaScore: 0.9,
     },
   };
 }
@@ -74,7 +75,7 @@ describe("GET /:memberId/referrals/:requestId", () => {
       return Promise.resolve(makeActiveStripeMember());
     });
 
-    const mockGetReferral = mock((id: string, _logger): Promise<ReferralItem> => {
+    const mockGetReferral = mock((id: string): Promise<ReferralItem> => {
       if (referralNotFound || id !== REQUEST_ID) {
         return Promise.reject(new NotFoundError(`Referral ${id} not found`));
       }
@@ -148,6 +149,9 @@ describe("GET /:memberId/referrals/:requestId", () => {
       expect(body.birthLocation).toBe("Hospital");
       expect(body.otherInfo).toBe("Looking for experienced doula");
       expect(typeof body.submitted).toBe("string");
+      // Privacy: admin-only fields must not leak
+      expect(body).not.toHaveProperty("sent");
+      expect(body).not.toHaveProperty("recaptchaScore");
     });
 
     it("returns 200 for admin access even when membership is inactive", async () => {
@@ -162,6 +166,14 @@ describe("GET /:memberId/referrals/:requestId", () => {
       const { testApp, request } = setup({ referralNotFound: true });
       const response = await handleRequest(testApp, request);
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Validation", () => {
+    it("returns 422 when requestId exceeds 128 characters", async () => {
+      const { testApp, request } = setup({ requestId: "a".repeat(129) });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(422);
     });
   });
 

--- a/functions/src/members-api/routes/get-referral.test.ts
+++ b/functions/src/members-api/routes/get-referral.test.ts
@@ -150,8 +150,8 @@ describe("GET /:memberId/referrals/:requestId", () => {
       expect(typeof body.submitted).toBe("string");
     });
 
-    it("returns 200 for admin access", async () => {
-      const { testApp, request } = setup({ authToken: "admin-token" });
+    it("returns 200 for admin access even when membership is inactive", async () => {
+      const { testApp, request } = setup({ authToken: "admin-token", memberIsInactive: true });
       const response = await handleRequest(testApp, request);
       expect(response.status).toBe(200);
     });
@@ -162,6 +162,27 @@ describe("GET /:memberId/referrals/:requestId", () => {
       const { testApp, request } = setup({ referralNotFound: true });
       const response = await handleRequest(testApp, request);
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("returns 500 when getReferral throws a non-NotFoundError", async () => {
+      const mockFindById = mock((): Promise<MemberDocument> =>
+        Promise.resolve(makeActiveStripeMember()),
+      );
+      const mockGetReferral = mock(() => Promise.reject(new Error("Unexpected DB error")));
+      const testApp = createMembersTestPlugin({
+        memberService: { findById: mockFindById },
+        referralsService: { getReferral: mockGetReferral },
+      });
+      const request = new Request(
+        `http://localhost/${MEMBER_ID}/referrals/${REQUEST_ID}`,
+        { headers: { Authorization: "Bearer valid-owner-token" } },
+      );
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Failed to retrieve referral");
     });
   });
 });

--- a/functions/src/members-api/routes/get-referral.test.ts
+++ b/functions/src/members-api/routes/get-referral.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Timestamp } from "firebase-admin/firestore";
+import { NotFoundError } from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import type { MemberDocument } from "../../types/member-document.js";
+import type { ReferralItem } from "../services/referrals/interface.js";
+import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
+
+const MEMBER_ID = "test-member-id";
+const REQUEST_ID = "req-abc";
+
+function makeActiveStripeMember(): MemberDocument {
+  return {
+    uid: MEMBER_ID,
+    email: "test@example.com",
+    createdAt: Timestamp.now(),
+    membershipActive: true,
+    stripeCustomerId: "cus_123",
+    stripeSubscriptionId: "sub_123",
+    subscriptionStatus: "active",
+    subscriptionStart: Timestamp.now(),
+    membershipExpiresAt: Timestamp.fromDate(
+      new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+    ),
+  };
+}
+
+function makeInactiveMember(): MemberDocument {
+  return {
+    uid: MEMBER_ID,
+    email: "test@example.com",
+    createdAt: Timestamp.now(),
+    membershipActive: false,
+  };
+}
+
+function makeReferralItem(id = REQUEST_ID): ReferralItem {
+  return {
+    id,
+    document: {
+      name: "Jane Smith",
+      phone: "555-0100",
+      email: "jane@example.com",
+      zipcode: "14607",
+      estimatedDueDate: { month: "3", day: "15", year: "2025" },
+      services: ["birth-doula"],
+      birthLocation: "Hospital",
+      otherInfo: "Looking for experienced doula",
+      insurance: ["medicaid"],
+      submitted: Timestamp.now(),
+      sent: false,
+    },
+  };
+}
+
+describe("GET /:memberId/referrals/:requestId", () => {
+  interface SetupOptions {
+    memberId?: string;
+    requestId?: string;
+    authToken?: string | null;
+    memberIsInactive?: boolean;
+    referralNotFound?: boolean;
+  }
+
+  function setup({
+    memberId = MEMBER_ID,
+    requestId = REQUEST_ID,
+    authToken = "valid-owner-token",
+    memberIsInactive = false,
+    referralNotFound = false,
+  }: SetupOptions = {}) {
+    const mockFindById = mock((): Promise<MemberDocument> => {
+      if (memberIsInactive) return Promise.resolve(makeInactiveMember());
+      return Promise.resolve(makeActiveStripeMember());
+    });
+
+    const mockGetReferral = mock((id: string): Promise<ReferralItem> => {
+      if (referralNotFound || id !== REQUEST_ID) {
+        return Promise.reject(new NotFoundError(`Referral ${id} not found`));
+      }
+      return Promise.resolve(makeReferralItem(id));
+    });
+
+    const testApp = createMembersTestPlugin({
+      memberService: { findById: mockFindById },
+      referralsService: { getReferral: mockGetReferral },
+    });
+
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(
+      `http://localhost/${memberId}/referrals/${requestId}`,
+      { headers },
+    );
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("returns 401 without auth header", async () => {
+      const { testApp, request } = setup({ authToken: null });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 403 for non-owner", async () => {
+      const { testApp, request } = setup({ authToken: "non-owner-token" });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Eligibility", () => {
+    it("returns 403 for owner without active Stripe membership", async () => {
+      const { testApp, request } = setup({ memberIsInactive: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toContain("Active membership required");
+    });
+  });
+
+  describe("Success", () => {
+    it("returns 200 with full detail including contact info", async () => {
+      const { testApp, request } = setup();
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        id: string;
+        name: string;
+        email: string;
+        phone: string;
+        zipcode: string;
+        services: string[];
+        birthLocation: string;
+        otherInfo: string;
+        insurance: string[];
+        submitted: string;
+      };
+      expect(body.id).toBe(REQUEST_ID);
+      expect(body.name).toBe("Jane Smith");
+      expect(body.email).toBe("jane@example.com");
+      expect(body.phone).toBe("555-0100");
+      expect(body.zipcode).toBe("14607");
+      expect(body.services).toContain("birth-doula");
+      expect(body.birthLocation).toBe("Hospital");
+      expect(body.otherInfo).toBe("Looking for experienced doula");
+      expect(typeof body.submitted).toBe("string");
+    });
+
+    it("returns 200 for admin access", async () => {
+      const { testApp, request } = setup({ authToken: "admin-token" });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Not found", () => {
+    it("returns 404 when referral does not exist", async () => {
+      const { testApp, request } = setup({ referralNotFound: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/functions/src/members-api/routes/get-referral.test.ts
+++ b/functions/src/members-api/routes/get-referral.test.ts
@@ -74,7 +74,7 @@ describe("GET /:memberId/referrals/:requestId", () => {
       return Promise.resolve(makeActiveStripeMember());
     });
 
-    const mockGetReferral = mock((id: string): Promise<ReferralItem> => {
+    const mockGetReferral = mock((id: string, _logger): Promise<ReferralItem> => {
       if (referralNotFound || id !== REQUEST_ID) {
         return Promise.reject(new NotFoundError(`Referral ${id} not found`));
       }

--- a/functions/src/members-api/routes/get-referral.ts
+++ b/functions/src/members-api/routes/get-referral.ts
@@ -1,0 +1,61 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import { HttpError } from "../../shared-api/errors/http-error.js";
+import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+import { isActiveStripeMember } from "../../types/member-document.js";
+import {
+  toReferralDetail,
+  type ReferralDetail,
+} from "../schemas/referral-schemas.js";
+import type { MemberService } from "../services/member/interface.js";
+import type { ReferralsService } from "../services/referrals/interface.js";
+
+export async function getReferralLogic({
+  memberId,
+  requestId,
+  memberService,
+  referralsService,
+  authService,
+  logger,
+  authorizationHeader,
+  set,
+}: {
+  memberId: string;
+  requestId: string;
+  memberService: MemberService;
+  referralsService: ReferralsService;
+  authService: AuthService;
+  logger: Logger;
+  authorizationHeader: string | undefined;
+  set: { status?: number | string };
+}): Promise<ReferralDetail | { error: string }> {
+  try {
+    await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+
+    const member = await memberService.findById(memberId);
+    if (!isActiveStripeMember(member)) {
+      set.status = 403;
+      return { error: "Active membership required to view referrals" };
+    }
+
+    const { id, document } = await referralsService.getReferral(requestId);
+    return toReferralDetail(id, document);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      set.status = error.statusCode;
+      return { error: error.message };
+    }
+
+    logger.error("Failed to get referral", {
+      errorId: ERROR_IDS.API_MEMBER_GET_REFERRAL_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      errorStack: error instanceof Error ? error.stack : undefined,
+      memberId,
+      requestId,
+    });
+
+    set.status = 500;
+    return { error: "Failed to retrieve referral" };
+  }
+}

--- a/functions/src/members-api/routes/get-referral.ts
+++ b/functions/src/members-api/routes/get-referral.ts
@@ -28,12 +28,15 @@ export async function getReferralLogic({
   set: { status?: number | string };
 }): Promise<ReferralDetail | { error: string }> {
   try {
-    await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+    const decodedToken = await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+    const isAdmin = decodedToken["admin"] === true;
 
-    const member = await memberService.findById(memberId);
-    if (!isActiveStripeMember(member)) {
-      set.status = 403;
-      return { error: "Active membership required to view referrals" };
+    if (!isAdmin) {
+      const member = await memberService.findById(memberId);
+      if (!isActiveStripeMember(member)) {
+        set.status = 403;
+        return { error: "Active membership required to view referrals" };
+      }
     }
 
     const { id, document } = await referralsService.getReferral(requestId, logger);

--- a/functions/src/members-api/routes/get-referral.ts
+++ b/functions/src/members-api/routes/get-referral.ts
@@ -3,10 +3,8 @@ import { HttpError } from "../../shared-api/errors/http-error.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import { isActiveStripeMember } from "../../types/member-document.js";
-import {
-  toReferralDetail,
-  type ReferralDetail,
-} from "../schemas/referral-schemas.js";
+import { type ReferralDetail } from "../schemas/referral-schemas.js";
+import { toReferralDetail } from "../schemas/to-referral-detail.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { ReferralsService } from "../services/referrals/interface.js";
 
@@ -38,7 +36,7 @@ export async function getReferralLogic({
       return { error: "Active membership required to view referrals" };
     }
 
-    const { id, document } = await referralsService.getReferral(requestId);
+    const { id, document } = await referralsService.getReferral(requestId, logger);
     return toReferralDetail(id, document);
   } catch (error) {
     if (error instanceof HttpError) {

--- a/functions/src/members-api/routes/list-referrals.test.ts
+++ b/functions/src/members-api/routes/list-referrals.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Timestamp } from "firebase-admin/firestore";
+import { NotFoundError } from "../../shared-api/errors/http-error.js";
+import { handleRequest } from "../../test-utils/handle-request.js";
+import type { MemberDocument } from "../../types/member-document.js";
+import { createMembersTestPlugin } from "../test-utils/create-members-test-plugin.js";
+
+const MEMBER_ID = "test-member-id";
+
+function makeActiveStripeMember(): MemberDocument {
+  return {
+    uid: MEMBER_ID,
+    email: "test@example.com",
+    createdAt: Timestamp.now(),
+    membershipActive: true,
+    stripeCustomerId: "cus_123",
+    stripeSubscriptionId: "sub_123",
+    subscriptionStatus: "active",
+    subscriptionStart: Timestamp.now(),
+    membershipExpiresAt: Timestamp.fromDate(
+      new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+    ),
+  };
+}
+
+function makeInactiveMember(): MemberDocument {
+  return {
+    uid: MEMBER_ID,
+    email: "test@example.com",
+    createdAt: Timestamp.now(),
+    membershipActive: false,
+  };
+}
+
+describe("GET /:memberId/referrals", () => {
+  interface SetupOptions {
+    memberId?: string;
+    authToken?: string | null;
+    memberNotFound?: boolean;
+    memberIsInactive?: boolean;
+    serverError?: boolean;
+    referrals?: {
+      id: string;
+      document: {
+        name: string;
+        phone: string;
+        email: string;
+        zipcode: string;
+        estimatedDueDate: { month: string; day: string; year: string };
+        services: string[];
+        birthLocation: string;
+        otherInfo: string;
+        insurance: string[];
+        submitted: ReturnType<typeof Timestamp.now>;
+        sent: boolean;
+      };
+    }[];
+  }
+
+  function setup({
+    memberId = MEMBER_ID,
+    authToken = "valid-owner-token",
+    memberNotFound = false,
+    memberIsInactive = false,
+    serverError = false,
+    referrals = [],
+  }: SetupOptions = {}) {
+    const mockFindById = mock((): Promise<MemberDocument> => {
+      if (memberNotFound) return Promise.reject(new NotFoundError("Member not found"));
+      if (serverError) return Promise.reject(new Error("DB timeout"));
+      if (memberIsInactive) return Promise.resolve(makeInactiveMember());
+      return Promise.resolve(makeActiveStripeMember());
+    });
+
+    const testApp = createMembersTestPlugin({
+      memberService: { findById: mockFindById },
+      referralsService: {
+        listReferrals: mock(() => Promise.resolve(referrals)),
+      },
+    });
+
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers["Authorization"] = `Bearer ${authToken}`;
+    }
+
+    const request = new Request(`http://localhost/${memberId}/referrals`, { headers });
+    return { testApp, request };
+  }
+
+  describe("Authentication", () => {
+    it("returns 401 without auth header", async () => {
+      const { testApp, request } = setup({ authToken: null });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 403 for non-owner", async () => {
+      const { testApp, request } = setup({ authToken: "non-owner-token" });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Eligibility", () => {
+    it("returns 403 for owner without active Stripe membership", async () => {
+      const { testApp, request } = setup({ memberIsInactive: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toContain("Active membership required");
+    });
+  });
+
+  describe("Success", () => {
+    it("returns 200 with empty list for active Stripe owner", async () => {
+      const { testApp, request } = setup({ referrals: [] });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { referrals: unknown[] };
+      expect(body.referrals).toEqual([]);
+    });
+
+    it("returns 200 with referral list items for active Stripe owner", async () => {
+      const submitted = Timestamp.now();
+      const { testApp, request } = setup({
+        referrals: [
+          {
+            id: "req-abc",
+            document: {
+              name: "Jane Smith",
+              phone: "555-0100",
+              email: "jane@example.com",
+              zipcode: "14607",
+              estimatedDueDate: { month: "3", day: "15", year: "2025" },
+              services: ["birth-doula"],
+              birthLocation: "Hospital",
+              otherInfo: "",
+              insurance: ["medicaid"],
+              submitted,
+              sent: false,
+            },
+          },
+        ],
+      });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        referrals: {
+          id: string;
+          zipcode: string;
+          services: string[];
+          birthLocation: string;
+        }[];
+      };
+      expect(body.referrals).toHaveLength(1);
+      expect(body.referrals[0]?.id).toBe("req-abc");
+      expect(body.referrals[0]?.zipcode).toBe("14607");
+      // Contact info NOT in list response
+      expect(body.referrals[0]).not.toHaveProperty("email");
+      expect(body.referrals[0]).not.toHaveProperty("name");
+      expect(body.referrals[0]).not.toHaveProperty("phone");
+    });
+
+    it("returns 200 for admin access", async () => {
+      const { testApp, request } = setup({ authToken: "admin-token" });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("returns 500 on service failure", async () => {
+      const { testApp, request } = setup({ serverError: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Failed to retrieve referrals");
+    });
+  });
+});

--- a/functions/src/members-api/routes/list-referrals.test.ts
+++ b/functions/src/members-api/routes/list-referrals.test.ts
@@ -75,7 +75,7 @@ describe("GET /:memberId/referrals", () => {
     const testApp = createMembersTestPlugin({
       memberService: { findById: mockFindById },
       referralsService: {
-        listReferrals: mock((_logger) => Promise.resolve(referrals)),
+        listReferrals: mock(() => Promise.resolve(referrals)),
       },
     });
 
@@ -156,10 +156,14 @@ describe("GET /:memberId/referrals", () => {
       expect(body.referrals).toHaveLength(1);
       expect(body.referrals[0]?.id).toBe("req-abc");
       expect(body.referrals[0]?.zipcode).toBe("14607");
-      // Contact info NOT in list response
-      expect(body.referrals[0]).not.toHaveProperty("email");
+      // Privacy: contact and admin-only fields must not appear in list
       expect(body.referrals[0]).not.toHaveProperty("name");
+      expect(body.referrals[0]).not.toHaveProperty("email");
       expect(body.referrals[0]).not.toHaveProperty("phone");
+      expect(body.referrals[0]).not.toHaveProperty("otherInfo");
+      expect(body.referrals[0]).not.toHaveProperty("insurance");
+      expect(body.referrals[0]).not.toHaveProperty("sent");
+      expect(body.referrals[0]).not.toHaveProperty("recaptchaScore");
     });
 
     it("returns 200 for admin access even when membership is inactive", async () => {

--- a/functions/src/members-api/routes/list-referrals.test.ts
+++ b/functions/src/members-api/routes/list-referrals.test.ts
@@ -162,16 +162,41 @@ describe("GET /:memberId/referrals", () => {
       expect(body.referrals[0]).not.toHaveProperty("phone");
     });
 
-    it("returns 200 for admin access", async () => {
-      const { testApp, request } = setup({ authToken: "admin-token" });
+    it("returns 200 for admin access even when membership is inactive", async () => {
+      const { testApp, request } = setup({ authToken: "admin-token", memberIsInactive: true });
       const response = await handleRequest(testApp, request);
       expect(response.status).toBe(200);
     });
   });
 
   describe("Error handling", () => {
+    it("returns 404 when member document not found", async () => {
+      const { testApp, request } = setup({ memberNotFound: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(404);
+    });
+
     it("returns 500 on service failure", async () => {
       const { testApp, request } = setup({ serverError: true });
+      const response = await handleRequest(testApp, request);
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBe("Failed to retrieve referrals");
+    });
+
+    it("returns 500 when listReferrals throws", async () => {
+      const mockFindById = mock((): Promise<MemberDocument> =>
+        Promise.resolve(makeActiveStripeMember()),
+      );
+      const testApp = createMembersTestPlugin({
+        memberService: { findById: mockFindById },
+        referralsService: {
+          listReferrals: mock(() => Promise.reject(new Error("DB error"))),
+        },
+      });
+      const request = new Request(`http://localhost/${MEMBER_ID}/referrals`, {
+        headers: { Authorization: "Bearer valid-owner-token" },
+      });
       const response = await handleRequest(testApp, request);
       expect(response.status).toBe(500);
       const body = (await response.json()) as { error?: string };

--- a/functions/src/members-api/routes/list-referrals.test.ts
+++ b/functions/src/members-api/routes/list-referrals.test.ts
@@ -75,7 +75,7 @@ describe("GET /:memberId/referrals", () => {
     const testApp = createMembersTestPlugin({
       memberService: { findById: mockFindById },
       referralsService: {
-        listReferrals: mock(() => Promise.resolve(referrals)),
+        listReferrals: mock((_logger) => Promise.resolve(referrals)),
       },
     });
 

--- a/functions/src/members-api/routes/list-referrals.ts
+++ b/functions/src/members-api/routes/list-referrals.ts
@@ -1,0 +1,60 @@
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import { HttpError } from "../../shared-api/errors/http-error.js";
+import type { AuthService } from "../../shared-api/services/auth/interface.js";
+import type { Logger } from "../../shared-api/types/logger.js";
+import { isActiveStripeMember } from "../../types/member-document.js";
+import {
+  toReferralListItem,
+  type ListReferralsResponse,
+} from "../schemas/referral-schemas.js";
+import type { MemberService } from "../services/member/interface.js";
+import type { ReferralsService } from "../services/referrals/interface.js";
+
+export async function listReferralsLogic({
+  memberId,
+  memberService,
+  referralsService,
+  authService,
+  logger,
+  authorizationHeader,
+  set,
+}: {
+  memberId: string;
+  memberService: MemberService;
+  referralsService: ReferralsService;
+  authService: AuthService;
+  logger: Logger;
+  authorizationHeader: string | undefined;
+  set: { status?: number | string };
+}): Promise<ListReferralsResponse | { error: string }> {
+  try {
+    await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+
+    const member = await memberService.findById(memberId);
+    if (!isActiveStripeMember(member)) {
+      set.status = 403;
+      return { error: "Active membership required to view referrals" };
+    }
+
+    const items = await referralsService.listReferrals();
+    return {
+      referrals: items.map(({ id, document }) => toReferralListItem(id, document)),
+    };
+  } catch (error) {
+    if (error instanceof HttpError) {
+      set.status = error.statusCode;
+      return { error: error.message };
+    }
+
+    logger.error("Failed to list referrals", {
+      errorId: ERROR_IDS.API_MEMBER_LIST_REFERRALS_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      errorStack: error instanceof Error ? error.stack : undefined,
+      memberId,
+    });
+
+    set.status = 500;
+    return { error: "Failed to retrieve referrals" };
+  }
+}

--- a/functions/src/members-api/routes/list-referrals.ts
+++ b/functions/src/members-api/routes/list-referrals.ts
@@ -26,12 +26,15 @@ export async function listReferralsLogic({
   set: { status?: number | string };
 }): Promise<ListReferralsResponse | { error: string }> {
   try {
-    await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+    const decodedToken = await authService.verifyOwnerOrAdmin(authorizationHeader, memberId);
+    const isAdmin = decodedToken["admin"] === true;
 
-    const member = await memberService.findById(memberId);
-    if (!isActiveStripeMember(member)) {
-      set.status = 403;
-      return { error: "Active membership required to view referrals" };
+    if (!isAdmin) {
+      const member = await memberService.findById(memberId);
+      if (!isActiveStripeMember(member)) {
+        set.status = 403;
+        return { error: "Active membership required to view referrals" };
+      }
     }
 
     const items = await referralsService.listReferrals(logger);

--- a/functions/src/members-api/routes/list-referrals.ts
+++ b/functions/src/members-api/routes/list-referrals.ts
@@ -3,10 +3,8 @@ import { HttpError } from "../../shared-api/errors/http-error.js";
 import type { AuthService } from "../../shared-api/services/auth/interface.js";
 import type { Logger } from "../../shared-api/types/logger.js";
 import { isActiveStripeMember } from "../../types/member-document.js";
-import {
-  toReferralListItem,
-  type ListReferralsResponse,
-} from "../schemas/referral-schemas.js";
+import { type ListReferralsResponse } from "../schemas/referral-schemas.js";
+import { toReferralListItem } from "../schemas/to-referral-list-item.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { ReferralsService } from "../services/referrals/interface.js";
 
@@ -36,7 +34,7 @@ export async function listReferralsLogic({
       return { error: "Active membership required to view referrals" };
     }
 
-    const items = await referralsService.listReferrals();
+    const items = await referralsService.listReferrals(logger);
     return {
       referrals: items.map(({ id, document }) => toReferralListItem(id, document)),
     };

--- a/functions/src/members-api/schemas/referral-schemas.ts
+++ b/functions/src/members-api/schemas/referral-schemas.ts
@@ -1,6 +1,4 @@
 import { t, type Static } from "elysia";
-import type { MatchRequestDocument } from "../../collections/match-requests.js";
-import { timestampToIso } from "../../shared-api/utils/timestamp-to-iso.js";
 
 /**
  * Referral list item schema - minimal fields for list display.
@@ -66,41 +64,3 @@ export const ReferralRequestIdParameterSchema = t.Object({
   }),
 });
 
-/**
- * Convert Firestore document to list item (no contact info).
- */
-export function toReferralListItem(
-  id: string,
-  document: MatchRequestDocument,
-): ReferralListItem {
-  return {
-    id,
-    submitted: timestampToIso(document.submitted),
-    estimatedDueDate: document.estimatedDueDate,
-    services: document.services,
-    zipcode: document.zipcode,
-    birthLocation: document.birthLocation,
-  };
-}
-
-/**
- * Convert Firestore document to detail response (full contact info).
- */
-export function toReferralDetail(
-  id: string,
-  document: MatchRequestDocument,
-): ReferralDetail {
-  return {
-    id,
-    name: document.name,
-    email: document.email,
-    phone: document.phone,
-    zipcode: document.zipcode,
-    estimatedDueDate: document.estimatedDueDate,
-    services: document.services,
-    birthLocation: document.birthLocation,
-    otherInfo: document.otherInfo,
-    insurance: document.insurance,
-    submitted: timestampToIso(document.submitted),
-  };
-}

--- a/functions/src/members-api/schemas/referral-schemas.ts
+++ b/functions/src/members-api/schemas/referral-schemas.ts
@@ -1,4 +1,5 @@
 import { t, type Static } from "elysia";
+import { ErrorResponseSchema } from "./member-schemas.js";
 
 /**
  * Referral list item schema - minimal fields for list display.
@@ -64,3 +65,20 @@ export const ReferralRequestIdParameterSchema = t.Object({
   }),
 });
 
+/**
+ * Route response schema for GET /:memberId/referrals.
+ * Unions success and error responses for HTTP contract enforcement.
+ */
+export const ListReferralsRouteResponseSchema = t.Union([
+  ListReferralsResponseSchema,
+  ErrorResponseSchema,
+]);
+
+/**
+ * Route response schema for GET /:memberId/referrals/:requestId.
+ * Unions success and error responses for HTTP contract enforcement.
+ */
+export const ReferralDetailRouteResponseSchema = t.Union([
+  ReferralDetailSchema,
+  ErrorResponseSchema,
+]);

--- a/functions/src/members-api/schemas/referral-schemas.ts
+++ b/functions/src/members-api/schemas/referral-schemas.ts
@@ -1,0 +1,106 @@
+import { t, type Static } from "elysia";
+import type { MatchRequestDocument } from "../../collections/match-requests.js";
+import { timestampToIso } from "../../shared-api/utils/timestamp-to-iso.js";
+
+/**
+ * Referral list item schema - minimal fields for list display.
+ * Contact info excluded; detail endpoint provides full data.
+ */
+export const ReferralListItemSchema = t.Object({
+  id: t.String({ description: "Match request document ID" }),
+  submitted: t.String({ format: "date-time", description: "ISO 8601 timestamp" }),
+  estimatedDueDate: t.Object({
+    month: t.String(),
+    day: t.String(),
+    year: t.String(),
+  }),
+  services: t.Array(t.String()),
+  zipcode: t.String(),
+  birthLocation: t.String(),
+});
+
+export type ReferralListItem = Static<typeof ReferralListItemSchema>;
+
+/**
+ * Referral detail schema - full request including contact info.
+ * Only returned to active Stripe members.
+ */
+export const ReferralDetailSchema = t.Object({
+  id: t.String({ description: "Match request document ID" }),
+  name: t.String(),
+  email: t.String({ format: "email" }),
+  phone: t.String(),
+  zipcode: t.String(),
+  estimatedDueDate: t.Object({
+    month: t.String(),
+    day: t.String(),
+    year: t.String(),
+  }),
+  services: t.Array(t.String()),
+  birthLocation: t.String(),
+  otherInfo: t.String(),
+  insurance: t.Array(t.String()),
+  submitted: t.String({ format: "date-time", description: "ISO 8601 timestamp" }),
+});
+
+export type ReferralDetail = Static<typeof ReferralDetailSchema>;
+
+/**
+ * List referrals response schema.
+ */
+export const ListReferralsResponseSchema = t.Object({
+  referrals: t.Array(ReferralListItemSchema),
+});
+
+export type ListReferralsResponse = Static<typeof ListReferralsResponseSchema>;
+
+/**
+ * Request ID path parameter schema.
+ */
+export const ReferralRequestIdParameterSchema = t.Object({
+  requestId: t.String({
+    minLength: 1,
+    maxLength: 128,
+    description: "The Firestore document ID of the match request",
+    error: "Request ID must be a non-empty string (max 128 characters)",
+  }),
+});
+
+/**
+ * Convert Firestore document to list item (no contact info).
+ */
+export function toReferralListItem(
+  id: string,
+  document: MatchRequestDocument,
+): ReferralListItem {
+  return {
+    id,
+    submitted: timestampToIso(document.submitted),
+    estimatedDueDate: document.estimatedDueDate,
+    services: document.services,
+    zipcode: document.zipcode,
+    birthLocation: document.birthLocation,
+  };
+}
+
+/**
+ * Convert Firestore document to detail response (full contact info).
+ */
+export function toReferralDetail(
+  id: string,
+  document: MatchRequestDocument,
+): ReferralDetail {
+  return {
+    id,
+    name: document.name,
+    email: document.email,
+    phone: document.phone,
+    zipcode: document.zipcode,
+    estimatedDueDate: document.estimatedDueDate,
+    services: document.services,
+    birthLocation: document.birthLocation,
+    otherInfo: document.otherInfo,
+    insurance: document.insurance,
+    submitted: timestampToIso(document.submitted),
+  };
+}

--- a/functions/src/members-api/schemas/to-referral-detail.ts
+++ b/functions/src/members-api/schemas/to-referral-detail.ts
@@ -1,0 +1,17 @@
+import type { MatchRequestDocument } from "../../collections/match-requests.js";
+import { toMatchRequestResponse } from "../../admin-match-requests-api/schemas/match-request-schemas.js";
+import type { ReferralDetail } from "./referral-schemas.js";
+
+/**
+ * Convert a Firestore match request document to a member-facing referral detail.
+ * Delegates to the shared admin converter, then strips admin-only fields
+ * (sent, recaptchaScore) that members should not see.
+ */
+export function toReferralDetail(
+  id: string,
+  document: MatchRequestDocument,
+): ReferralDetail {
+  const { sent: _sent, recaptchaScore: _recaptchaScore, ...detail } =
+    toMatchRequestResponse(id, document);
+  return detail;
+}

--- a/functions/src/members-api/schemas/to-referral-detail.ts
+++ b/functions/src/members-api/schemas/to-referral-detail.ts
@@ -1,17 +1,27 @@
 import type { MatchRequestDocument } from "../../collections/match-requests.js";
-import { toMatchRequestResponse } from "../../admin-match-requests-api/schemas/match-request-schemas.js";
+import { timestampToIso } from "../../shared-api/utils/timestamp-to-iso.js";
 import type { ReferralDetail } from "./referral-schemas.js";
 
 /**
  * Convert a Firestore match request document to a member-facing referral detail.
- * Delegates to the shared admin converter, then strips admin-only fields
- * (sent, recaptchaScore) that members should not see.
+ * Explicit member-facing allowlist — only named fields are included,
+ * so future admin-only fields cannot leak.
  */
 export function toReferralDetail(
   id: string,
   document: MatchRequestDocument,
 ): ReferralDetail {
-  const { sent: _sent, recaptchaScore: _recaptchaScore, ...detail } =
-    toMatchRequestResponse(id, document);
-  return detail;
+  return {
+    id,
+    name: document.name,
+    email: document.email,
+    phone: document.phone,
+    zipcode: document.zipcode,
+    estimatedDueDate: document.estimatedDueDate,
+    services: document.services,
+    birthLocation: document.birthLocation,
+    otherInfo: document.otherInfo,
+    insurance: document.insurance,
+    submitted: timestampToIso(document.submitted),
+  };
 }

--- a/functions/src/members-api/schemas/to-referral-list-item.ts
+++ b/functions/src/members-api/schemas/to-referral-list-item.ts
@@ -1,0 +1,21 @@
+import type { MatchRequestDocument } from "../../collections/match-requests.js";
+import { timestampToIso } from "../../shared-api/utils/timestamp-to-iso.js";
+import type { ReferralListItem } from "./referral-schemas.js";
+
+/**
+ * Convert a Firestore match request document to a referral list item.
+ * Omits contact info — detail endpoint provides full data.
+ */
+export function toReferralListItem(
+  id: string,
+  document: MatchRequestDocument,
+): ReferralListItem {
+  return {
+    id,
+    submitted: timestampToIso(document.submitted),
+    estimatedDueDate: document.estimatedDueDate,
+    services: document.services,
+    zipcode: document.zipcode,
+    birthLocation: document.birthLocation,
+  };
+}

--- a/functions/src/members-api/services/referrals/interface.ts
+++ b/functions/src/members-api/services/referrals/interface.ts
@@ -1,4 +1,5 @@
 import type { MatchRequestDocument } from "../../../collections/match-requests.js";
+import type { Logger } from "../../../shared-api/types/logger.js";
 
 export interface ReferralItem {
   id: string;
@@ -6,6 +7,6 @@ export interface ReferralItem {
 }
 
 export interface ReferralsService {
-  listReferrals(): Promise<ReferralItem[]>;
-  getReferral(requestId: string): Promise<ReferralItem>;
+  listReferrals(logger: Logger): Promise<ReferralItem[]>;
+  getReferral(requestId: string, logger: Logger): Promise<ReferralItem>;
 }

--- a/functions/src/members-api/services/referrals/interface.ts
+++ b/functions/src/members-api/services/referrals/interface.ts
@@ -1,0 +1,11 @@
+import type { MatchRequestDocument } from "../../../collections/match-requests.js";
+
+export interface ReferralItem {
+  id: string;
+  document: MatchRequestDocument;
+}
+
+export interface ReferralsService {
+  listReferrals(): Promise<ReferralItem[]>;
+  getReferral(requestId: string): Promise<ReferralItem>;
+}

--- a/functions/src/members-api/services/referrals/referrals-service.ts
+++ b/functions/src/members-api/services/referrals/referrals-service.ts
@@ -1,0 +1,42 @@
+import { getFirestore } from "firebase-admin/firestore";
+import {
+  MATCH_REQUESTS_COLLECTION,
+  type MatchRequestDocument,
+} from "../../../collections/match-requests.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import type { ReferralItem, ReferralsService } from "./interface.js";
+
+async function listReferrals(): Promise<ReferralItem[]> {
+  const firestore = getFirestore();
+  const snapshot = await firestore
+    .collection(MATCH_REQUESTS_COLLECTION)
+    .orderBy("submitted", "desc")
+    .get();
+
+  return snapshot.docs.map((matchDocument) => ({
+    id: matchDocument.id,
+    document: matchDocument.data() as MatchRequestDocument,
+  }));
+}
+
+async function getReferral(requestId: string): Promise<ReferralItem> {
+  const firestore = getFirestore();
+  const snapshot = await firestore
+    .collection(MATCH_REQUESTS_COLLECTION)
+    .doc(requestId)
+    .get();
+
+  if (!snapshot.exists) {
+    throw new NotFoundError(`Referral ${requestId} not found`);
+  }
+
+  return {
+    id: snapshot.id,
+    document: snapshot.data() as MatchRequestDocument,
+  };
+}
+
+export const ReferralsServiceImpl: ReferralsService = {
+  listReferrals,
+  getReferral,
+};

--- a/functions/src/members-api/services/referrals/referrals-service.ts
+++ b/functions/src/members-api/services/referrals/referrals-service.ts
@@ -3,37 +3,67 @@ import {
   MATCH_REQUESTS_COLLECTION,
   type MatchRequestDocument,
 } from "../../../collections/match-requests.js";
+import { ERROR_IDS } from "../../../constants/error-ids.js";
 import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import type { Logger } from "../../../shared-api/types/logger.js";
 import type { ReferralItem, ReferralsService } from "./interface.js";
 
-async function listReferrals(): Promise<ReferralItem[]> {
-  const firestore = getFirestore();
-  const snapshot = await firestore
-    .collection(MATCH_REQUESTS_COLLECTION)
-    .orderBy("submitted", "desc")
-    .get();
+async function listReferrals(logger: Logger): Promise<ReferralItem[]> {
+  try {
+    const firestore = getFirestore();
+    const snapshot = await firestore
+      .collection(MATCH_REQUESTS_COLLECTION)
+      .orderBy("submitted", "desc")
+      .get();
 
-  return snapshot.docs.map((matchDocument) => ({
-    id: matchDocument.id,
-    document: matchDocument.data() as MatchRequestDocument,
-  }));
+    return snapshot.docs.map((matchDocument) => ({
+      id: matchDocument.id,
+      document: matchDocument.data() as MatchRequestDocument,
+    }));
+  } catch (error) {
+    logger.error("Failed to list referrals from Firestore", {
+      errorId: ERROR_IDS.API_FIRESTORE_READ_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 }
 
-async function getReferral(requestId: string): Promise<ReferralItem> {
-  const firestore = getFirestore();
-  const snapshot = await firestore
-    .collection(MATCH_REQUESTS_COLLECTION)
-    .doc(requestId)
-    .get();
+async function getReferral(
+  requestId: string,
+  logger: Logger,
+): Promise<ReferralItem> {
+  try {
+    const firestore = getFirestore();
+    const snapshot = await firestore
+      .collection(MATCH_REQUESTS_COLLECTION)
+      .doc(requestId)
+      .get();
 
-  if (!snapshot.exists) {
-    throw new NotFoundError(`Referral ${requestId} not found`);
+    if (!snapshot.exists) {
+      logger.warn("Referral not found", {
+        errorId: ERROR_IDS.API_MEMBER_REFERRAL_NOT_FOUND,
+        requestId,
+      });
+      throw new NotFoundError(`Referral ${requestId} not found`);
+    }
+
+    return {
+      id: snapshot.id,
+      document: snapshot.data() as MatchRequestDocument,
+    };
+  } catch (error) {
+    if (error instanceof NotFoundError) throw error;
+
+    logger.error("Failed to get referral from Firestore", {
+      errorId: ERROR_IDS.API_FIRESTORE_READ_FAILED,
+      error,
+      errorMessage: error instanceof Error ? error.message : "Unknown error",
+      requestId,
+    });
+    throw error;
   }
-
-  return {
-    id: snapshot.id,
-    document: snapshot.data() as MatchRequestDocument,
-  };
 }
 
 export const ReferralsServiceImpl: ReferralsService = {

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -79,8 +79,8 @@ export function createMembersTestPlugin(overrides?: {
   };
 
   const defaultReferralsService: ReferralsService = {
-    listReferrals: mock(() => Promise.resolve([])),
-    getReferral: mock(() =>
+    listReferrals: mock((_logger) => Promise.resolve([])),
+    getReferral: mock((_requestId, _logger) =>
       Promise.reject(new Error("getReferral not configured in test")),
     ),
     ...overrides?.referralsService,

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -13,6 +13,7 @@ import type { MemberDocument } from "../../types/member-document.js";
 import { createMembersPlugin } from "../plugins/members-plugin.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
+import type { ReferralsService } from "../services/referrals/interface.js";
 import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
@@ -29,6 +30,7 @@ export function createMembersTestPlugin(overrides?: {
   emailService?: EmailServiceInterface;
   verifyEmailService?: Partial<VerifyEmailService>;
   memberFirestoreService?: Partial<MemberFirestoreService>;
+  referralsService?: Partial<ReferralsService>;
   logger?: Logger;
 }) {
   const defaultMemberService: MemberService = {
@@ -76,6 +78,14 @@ export function createMembersTestPlugin(overrides?: {
     ...overrides?.memberFirestoreService,
   };
 
+  const defaultReferralsService: ReferralsService = {
+    listReferrals: mock(() => Promise.resolve([])),
+    getReferral: mock(() =>
+      Promise.reject(new Error("getReferral not configured in test")),
+    ),
+    ...overrides?.referralsService,
+  };
+
   return createMembersPlugin({
     memberService: defaultMemberService,
     newsletterService: defaultNewsletterService,
@@ -83,6 +93,7 @@ export function createMembersTestPlugin(overrides?: {
     emailService: defaultEmailService,
     verifyEmailService: defaultVerifyEmailService,
     memberFirestoreService: defaultMemberFirestoreService,
+    referralsService: defaultReferralsService,
     ...(overrides?.logger !== undefined && { logger: overrides.logger }),
   });
 }

--- a/functions/src/members-api/test-utils/create-members-test-plugin.ts
+++ b/functions/src/members-api/test-utils/create-members-test-plugin.ts
@@ -79,8 +79,8 @@ export function createMembersTestPlugin(overrides?: {
   };
 
   const defaultReferralsService: ReferralsService = {
-    listReferrals: mock((_logger) => Promise.resolve([])),
-    getReferral: mock((_requestId, _logger) =>
+    listReferrals: mock(() => Promise.resolve([])),
+    getReferral: mock(() =>
       Promise.reject(new Error("getReferral not configured in test")),
     ),
     ...overrides?.referralsService,

--- a/functions/src/members-api/types/services.ts
+++ b/functions/src/members-api/types/services.ts
@@ -4,6 +4,7 @@ import type { MemberFirestoreService } from "../../shared-api/services/member-fi
 import type { Logger } from "../../shared-api/types/logger.js";
 import type { MemberService } from "../services/member/interface.js";
 import type { NewsletterService } from "../services/newsletter/interface.js";
+import type { ReferralsService } from "../services/referrals/interface.js";
 import type { VerifyEmailService } from "../services/verify-email/interface.js";
 
 /**
@@ -18,6 +19,7 @@ export const SERVICE_KEYS = {
   NEWSLETTER_SERVICE: "newsletterService",
   VERIFY_EMAIL_SERVICE: "verifyEmailService",
   MEMBER_FIRESTORE_SERVICE: "memberFirestoreService",
+  REFERRALS_SERVICE: "referralsService",
 } as const;
 
 /**
@@ -33,6 +35,7 @@ export interface Services {
   [SERVICE_KEYS.NEWSLETTER_SERVICE]: NewsletterService;
   [SERVICE_KEYS.VERIFY_EMAIL_SERVICE]: VerifyEmailService;
   [SERVICE_KEYS.MEMBER_FIRESTORE_SERVICE]: MemberFirestoreService;
+  [SERVICE_KEYS.REFERRALS_SERVICE]: ReferralsService;
 }
 
 /**

--- a/members/src/app/admin/admin-dashboard.spec.ts
+++ b/members/src/app/admin/admin-dashboard.spec.ts
@@ -111,6 +111,6 @@ describe('AdminDashboard', () => {
     await setup();
 
     const comingSoonBadges = screen.getAllByText('Coming Soon');
-    expect(comingSoonBadges).toHaveLength(3);
+    expect(comingSoonBadges).toHaveLength(2);
   });
 });

--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -84,6 +84,19 @@ export const routes: Routes = [
     ...canActivate(redirectUnauthorizedToSignIn),
   },
 
+  // Member referral routes (require authentication)
+  {
+    path: 'referrals',
+    loadComponent: () => import('./referrals/referrals').then((m) => m.Referrals),
+    ...canActivate(redirectUnauthorizedToSignIn),
+  },
+  {
+    path: 'referrals/:id',
+    loadComponent: () =>
+      import('./referrals/referral-detail/referral-detail').then((m) => m.ReferralDetail),
+    ...canActivate(redirectUnauthorizedToSignIn),
+  },
+
   // Admin routes (require authentication and admin claim)
   {
     path: 'admin',

--- a/members/src/app/membership/membership.html
+++ b/members/src/app/membership/membership.html
@@ -214,6 +214,17 @@
             </a>
           </section>
         }
+
+        <!-- Referrals Card -->
+        @if (canViewReferrals()) {
+          <section class="membership-card card-5" aria-labelledby="referrals-heading">
+            <h2 id="referrals-heading" class="section-heading">Referrals</h2>
+            <p class="community-description">
+              View doula match requests submitted by families looking for support.
+            </p>
+            <a routerLink="/referrals" class="community-link">View Referrals</a>
+          </section>
+        }
       </div>
     } @else {
       <div class="loading-info">

--- a/members/src/app/membership/membership.scss
+++ b/members/src/app/membership/membership.scss
@@ -91,6 +91,10 @@
   &.card-4 {
     animation-delay: 0.4s;
   }
+
+  &.card-5 {
+    animation-delay: 0.5s;
+  }
 }
 
 // --- Section Headings ---

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -771,6 +771,45 @@ describe('Membership', () => {
 
       expect(screen.getByRole('link', { name: 'View Referrals' })).toBeVisible();
     });
+
+    it('does not show referrals link for past_due member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          ...activeStripeMember,
+          subscriptionStatus: 'past_due',
+        },
+      });
+
+      expect(screen.queryByRole('link', { name: 'View Referrals' })).toBeNull();
+    });
+
+    it('does not show referrals link for incomplete member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          ...activeStripeMember,
+          subscriptionStatus: 'incomplete',
+        },
+      });
+
+      expect(screen.queryByRole('link', { name: 'View Referrals' })).toBeNull();
+    });
+
+    it('does not show referrals link for unpaid member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          ...activeStripeMember,
+          subscriptionStatus: 'unpaid',
+        },
+      });
+
+      expect(screen.queryByRole('link', { name: 'View Referrals' })).toBeNull();
+    });
   });
 });
 

--- a/members/src/app/membership/membership.spec.ts
+++ b/members/src/app/membership/membership.spec.ts
@@ -704,6 +704,74 @@ describe('Membership', () => {
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
   });
+
+  describe('referrals card', () => {
+    const activeStripeMember: Partial<Member> = {
+      createdAt: new Date(),
+      email: 'jane@example.com',
+      uid: 'user123',
+      membershipActive: true,
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      subscriptionStatus: 'active',
+    };
+
+    it('shows referrals link for active Stripe member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: activeStripeMember,
+      });
+
+      expect(screen.getByRole('link', { name: 'View Referrals' })).toBeVisible();
+    });
+
+    it('does not show referrals link for member without Stripe subscription', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: true,
+        },
+      });
+
+      expect(screen.queryByRole('link', { name: 'View Referrals' })).toBeNull();
+    });
+
+    it('does not show referrals link for inactive member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          createdAt: new Date(),
+          email: 'jane@example.com',
+          uid: 'user123',
+          membershipActive: false,
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_123',
+          subscriptionStatus: 'canceled',
+        },
+      });
+
+      expect(screen.queryByRole('link', { name: 'View Referrals' })).toBeNull();
+    });
+
+    it('shows referrals link for trialing member', async () => {
+      await setup({
+        isAuthenticated: true,
+        hasUserDocument: true,
+        userDocument: {
+          ...activeStripeMember,
+          subscriptionStatus: 'trialing',
+        },
+      });
+
+      expect(screen.getByRole('link', { name: 'View Referrals' })).toBeVisible();
+    });
+  });
 });
 
 interface SetupOptions {

--- a/members/src/app/membership/membership.ts
+++ b/members/src/app/membership/membership.ts
@@ -123,6 +123,17 @@ export class Membership {
     );
   });
 
+  protected canViewReferrals = computed(() => {
+    const userDocument = this.userDocument();
+    return (
+      userDocument?.membershipActive === true &&
+      userDocument.stripeCustomerId !== undefined &&
+      userDocument.stripeSubscriptionId !== undefined &&
+      (userDocument.subscriptionStatus === 'active' ||
+        userDocument.subscriptionStatus === 'trialing')
+    );
+  });
+
   protected cancelInProgress = signal(false);
   protected cancelError = signal<string | undefined>(undefined);
 

--- a/members/src/app/referrals/referral-detail/referral-detail.html
+++ b/members/src/app/referrals/referral-detail/referral-detail.html
@@ -1,0 +1,85 @@
+<a routerLink="/referrals" class="back-link">← Back to referrals</a>
+
+@if (referralResource.isLoading()) {
+  <p class="loading" role="status">Loading referral...</p>
+} @else if (referralResource.error()) {
+  <p class="error" role="alert">Failed to load referral. Please try again.</p>
+} @else if (referralResource.value(); as referral) {
+  <article class="referral-detail">
+    <header class="detail-header">
+      <h1>Referral Request</h1>
+      <p class="member-notice">
+        Contact information is visible only to active cooperative members. Please follow cooperative
+        norms when reaching out.
+      </p>
+    </header>
+
+    <section class="info-card" aria-labelledby="contact-heading">
+      <h2 id="contact-heading">Contact Details</h2>
+      <dl class="info-grid">
+        <dt>Name</dt>
+        <dd>{{ referral.name }}</dd>
+
+        <dt>Email</dt>
+        <dd>
+          <a [href]="'mailto:' + referral.email" class="contact-link">{{ referral.email }}</a>
+        </dd>
+
+        <dt>Phone</dt>
+        <dd>
+          <a [href]="'tel:' + referral.phone" class="contact-link">{{ referral.phone }}</a>
+        </dd>
+
+        <dt>ZIP code</dt>
+        <dd>{{ referral.zipcode }}</dd>
+
+        <dt>Submitted</dt>
+        <dd>{{ referral.submitted | date: 'MMM d, yyyy, h:mm a' }}</dd>
+      </dl>
+    </section>
+
+    <section class="info-card" aria-labelledby="birth-heading">
+      <h2 id="birth-heading">Birth Details</h2>
+      <dl class="info-grid">
+        <dt>Estimated due date</dt>
+        <dd>
+          @if (parsedDueDate(); as dueDate) {
+            {{ dueDate | date: 'MMMM d, yyyy' }}
+          } @else {
+            <span class="no-info">Not provided</span>
+          }
+        </dd>
+
+        <dt>Birth location</dt>
+        <dd>{{ referral.birthLocation || '—' }}</dd>
+      </dl>
+    </section>
+
+    <section class="info-card" aria-labelledby="services-heading">
+      <h2 id="services-heading">Services Requested</h2>
+      <ul class="service-list">
+        @for (service of referral.services; track service) {
+          <li>{{ getServiceLabel(service) }}</li>
+        }
+      </ul>
+    </section>
+
+    @if (referral.insurance.length > 0) {
+      <section class="info-card" aria-labelledby="insurance-heading">
+        <h2 id="insurance-heading">Insurance / Payment</h2>
+        <ul class="insurance-list">
+          @for (ins of referral.insurance; track ins) {
+            <li>{{ ins }}</li>
+          }
+        </ul>
+      </section>
+    }
+
+    @if (referral.otherInfo) {
+      <section class="info-card" aria-labelledby="notes-heading">
+        <h2 id="notes-heading">Additional Notes</h2>
+        <p class="notes-text">{{ referral.otherInfo }}</p>
+      </section>
+    }
+  </article>
+}

--- a/members/src/app/referrals/referral-detail/referral-detail.html
+++ b/members/src/app/referrals/referral-detail/referral-detail.html
@@ -2,8 +2,8 @@
 
 @if (referralResource.isLoading()) {
   <p class="loading" role="status">Loading referral...</p>
-} @else if (referralResource.error()) {
-  <p class="error" role="alert">Failed to load referral. Please try again.</p>
+} @else if (referralResource.error(); as err) {
+  <p class="error" role="alert">{{ err.message }}</p>
 } @else if (referralResource.value(); as referral) {
   <article class="referral-detail">
     <header class="detail-header">

--- a/members/src/app/referrals/referral-detail/referral-detail.scss
+++ b/members/src/app/referrals/referral-detail/referral-detail.scss
@@ -1,0 +1,126 @@
+:host {
+  display: block;
+  max-width: 800px;
+  margin-inline: auto;
+  padding: var(--space-l);
+}
+
+.back-link {
+  display: inline-block;
+  color: var(--teal-600);
+  text-decoration: none;
+  font-size: var(--step--1);
+  margin-block-end: var(--space-l);
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--teal-500);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
+
+.loading,
+.error {
+  text-align: center;
+  padding: var(--space-xl);
+  color: var(--brown-450);
+}
+
+.error {
+  color: var(--brown-600);
+  background: var(--brown-100);
+  border: 1px solid var(--brown-300);
+  border-radius: var(--border-radius-md);
+}
+
+.referral-detail {
+  display: grid;
+  gap: var(--space-m);
+}
+
+.detail-header h1 {
+  margin-block-end: var(--space-xs);
+}
+
+.member-notice {
+  font-size: var(--step--1);
+  color: var(--brown-500);
+  padding: var(--space-s);
+  background: var(--brown-100);
+  border-radius: var(--border-radius-md);
+  border-left: 4px solid var(--teal-500);
+  margin: 0;
+}
+
+.info-card {
+  background: var(--brown-000);
+  border: 1px solid var(--brown-200);
+  border-radius: var(--border-radius-md);
+  padding: var(--space-m);
+
+  h2 {
+    font-size: var(--step-0);
+    font-weight: var(--font-weight-semibold);
+    border-left: 4px solid var(--teal-500);
+    padding-left: var(--space-s);
+    margin-block-end: var(--space-m);
+  }
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-xs) var(--space-m);
+  align-items: baseline;
+  margin: 0;
+
+  dt {
+    font-size: var(--step--2);
+    font-weight: var(--font-weight-regular);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--brown-500);
+  }
+
+  dd {
+    font-size: var(--step-0);
+    margin: 0;
+  }
+}
+
+.contact-link {
+  color: var(--teal-600);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.no-info {
+  color: var(--brown-400);
+  font-style: italic;
+}
+
+.service-list,
+.insurance-list {
+  list-style: disc;
+  padding-left: var(--space-l);
+  margin: 0;
+  display: grid;
+  gap: var(--space-2xs);
+
+  li {
+    font-size: var(--step-0);
+  }
+}
+
+.notes-text {
+  font-size: var(--step-0);
+  line-height: var(--line-height-normal);
+  white-space: pre-wrap;
+  margin: 0;
+}

--- a/members/src/app/referrals/referral-detail/referral-detail.spec.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.spec.ts
@@ -38,6 +38,7 @@ async function setup({
 } = {}) {
   let getReferralMock: ReturnType<typeof vi.fn>;
   if (loading) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     getReferralMock = vi.fn().mockReturnValue(new Promise(() => {}));
   } else if (error) {
     getReferralMock = vi.fn().mockRejectedValue(new Error('Not found'));

--- a/members/src/app/referrals/referral-detail/referral-detail.spec.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.spec.ts
@@ -1,0 +1,125 @@
+import { inputBinding } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ReferralsService,
+  type ReferralDetail as ReferralDetailModel,
+} from '../../services/referrals.service';
+import { ReferralDetail } from './referral-detail';
+
+function makeReferralDetail(overrides: Partial<ReferralDetailModel> = {}): ReferralDetailModel {
+  return {
+    id: 'req-1',
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    phone: '555-0100',
+    zipcode: '14607',
+    estimatedDueDate: { month: '3', day: '15', year: '2025' },
+    services: ['birth-doula', 'postpartum-doula'],
+    birthLocation: 'Hospital',
+    otherInfo: 'Looking for experienced doula',
+    insurance: ['medicaid'],
+    submitted: '2025-01-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function setup({
+  loading = false,
+  error = false,
+  id = 'req-1',
+  referral = makeReferralDetail(),
+}: {
+  loading?: boolean;
+  error?: boolean;
+  id?: string;
+  referral?: ReferralDetailModel;
+} = {}) {
+  const getReferralMock = loading
+    ? vi.fn().mockReturnValue(new Promise(() => {}))
+    : error
+      ? vi.fn().mockRejectedValue(new Error('Not found'))
+      : vi.fn().mockResolvedValue(referral);
+
+  const mockReferralsService = {
+    getReferral: getReferralMock,
+  };
+
+  await render(ReferralDetail, {
+    bindings: [inputBinding('id', () => id)],
+    providers: [
+      { provide: ReferralsService, useValue: mockReferralsService },
+      provideRouter([]),
+    ],
+  });
+}
+
+describe('ReferralDetail', () => {
+  describe('loading state', () => {
+    it('shows loading message', async () => {
+      await setup({ loading: true });
+      expect(await screen.findByRole('status')).toHaveTextContent('Loading referral...');
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error message on failure', async () => {
+      await setup({ error: true });
+      expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load referral');
+    });
+  });
+
+  describe('loaded state', () => {
+    it('shows contact name', async () => {
+      await setup();
+      expect(await screen.findByText('Jane Smith')).toBeVisible();
+    });
+
+    it('shows contact email as link', async () => {
+      await setup();
+      expect(await screen.findByRole('link', { name: 'jane@example.com' })).toBeVisible();
+    });
+
+    it('shows phone as link', async () => {
+      await setup();
+      expect(await screen.findByRole('link', { name: '555-0100' })).toBeVisible();
+    });
+
+    it('shows ZIP code', async () => {
+      await setup();
+      expect(await screen.findByText('14607')).toBeVisible();
+    });
+
+    it('shows service labels', async () => {
+      await setup();
+      expect(await screen.findByText('Birth doula support')).toBeVisible();
+      expect(screen.getByText('Postpartum doula support')).toBeVisible();
+    });
+
+    it('shows birth location', async () => {
+      await setup();
+      expect(await screen.findByText('Hospital')).toBeVisible();
+    });
+
+    it('shows additional notes', async () => {
+      await setup();
+      expect(await screen.findByText('Looking for experienced doula')).toBeVisible();
+    });
+
+    it('shows insurance', async () => {
+      await setup();
+      expect(await screen.findByText('medicaid')).toBeVisible();
+    });
+
+    it('shows member notice about contact norms', async () => {
+      await setup();
+      expect(await screen.findByText(/cooperative norms/i)).toBeVisible();
+    });
+
+    it('shows back link to referrals list', async () => {
+      await setup();
+      expect(await screen.findByRole('link', { name: /Back to referrals/i })).toBeVisible();
+    });
+  });
+});

--- a/members/src/app/referrals/referral-detail/referral-detail.spec.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.spec.ts
@@ -36,11 +36,14 @@ async function setup({
   id?: string;
   referral?: ReferralDetailModel;
 } = {}) {
-  const getReferralMock = loading
-    ? vi.fn().mockReturnValue(new Promise(() => {}))
-    : error
-      ? vi.fn().mockRejectedValue(new Error('Not found'))
-      : vi.fn().mockResolvedValue(referral);
+  let getReferralMock: ReturnType<typeof vi.fn>;
+  if (loading) {
+    getReferralMock = vi.fn().mockReturnValue(new Promise(() => {}));
+  } else if (error) {
+    getReferralMock = vi.fn().mockRejectedValue(new Error('Not found'));
+  } else {
+    getReferralMock = vi.fn().mockResolvedValue(referral);
+  }
 
   const mockReferralsService = {
     getReferral: getReferralMock,
@@ -66,7 +69,7 @@ describe('ReferralDetail', () => {
   describe('error state', () => {
     it('shows error message on failure', async () => {
       await setup({ error: true });
-      expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load referral');
+      expect(await screen.findByRole('alert')).toHaveTextContent('Not found');
     });
   });
 

--- a/members/src/app/referrals/referral-detail/referral-detail.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.ts
@@ -35,7 +35,7 @@ export class ReferralDetail {
 
   protected parsedDueDate = computed(() => {
     const referral = this.referralResource.value();
-    if (!referral || !isValidDueDate(referral.estimatedDueDate)) return undefined;
+    if (!referral || !isValidDueDate(referral.estimatedDueDate)) return;
     return parseDueDate(referral.estimatedDueDate);
   });
 

--- a/members/src/app/referrals/referral-detail/referral-detail.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.ts
@@ -1,0 +1,51 @@
+import { DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  resource,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { SERVICE_LABELS_LONG } from '../../admin/match-requests/match-request.constants';
+import {
+  isValidDueDate,
+  parseDueDate,
+  type DueDate,
+} from '../../admin/match-requests/match-request.utilities';
+import { ReferralsService } from '../../services/referrals.service';
+
+@Component({
+  selector: 'app-referral-detail',
+  imports: [DatePipe, RouterLink],
+  templateUrl: './referral-detail.html',
+  styleUrl: './referral-detail.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReferralDetail {
+  private referralsService = inject(ReferralsService);
+
+  // Route parameter binding via withComponentInputBinding
+  id = input.required<string>();
+
+  protected referralResource = resource({
+    params: () => ({ id: this.id() }),
+    loader: ({ params }) => this.referralsService.getReferral(params.id),
+  });
+
+  protected parsedDueDate = computed(() => {
+    const referral = this.referralResource.value();
+    if (!referral || !isValidDueDate(referral.estimatedDueDate)) return undefined;
+    return parseDueDate(referral.estimatedDueDate);
+  });
+
+  protected getServiceLabel(service: string): string {
+    return SERVICE_LABELS_LONG[service] ?? service;
+  }
+
+  protected formatDueDate(dueDate: DueDate): Date | undefined {
+    if (!isValidDueDate(dueDate)) return undefined;
+    return parseDueDate(dueDate);
+  }
+}

--- a/members/src/app/referrals/referral-detail/referral-detail.ts
+++ b/members/src/app/referrals/referral-detail/referral-detail.ts
@@ -12,7 +12,6 @@ import { SERVICE_LABELS_LONG } from '../../admin/match-requests/match-request.co
 import {
   isValidDueDate,
   parseDueDate,
-  type DueDate,
 } from '../../admin/match-requests/match-request.utilities';
 import { ReferralsService } from '../../services/referrals.service';
 
@@ -42,10 +41,5 @@ export class ReferralDetail {
 
   protected getServiceLabel(service: string): string {
     return SERVICE_LABELS_LONG[service] ?? service;
-  }
-
-  protected formatDueDate(dueDate: DueDate): Date | undefined {
-    if (!isValidDueDate(dueDate)) return undefined;
-    return parseDueDate(dueDate);
   }
 }

--- a/members/src/app/referrals/referrals.html
+++ b/members/src/app/referrals/referrals.html
@@ -7,8 +7,8 @@
 
   @if (referralsResource.isLoading()) {
     <p class="loading" role="status">Loading referrals...</p>
-  } @else if (referralsResource.error()) {
-    <p class="error" role="alert">Failed to load referrals. Please try again.</p>
+  } @else if (referralsResource.error(); as err) {
+    <p class="error" role="alert">{{ err.message }}</p>
   } @else if (referralsResource.value(); as referrals) {
     @if (referrals.length === 0) {
       <p class="empty-state">No referrals available right now.</p>

--- a/members/src/app/referrals/referrals.html
+++ b/members/src/app/referrals/referrals.html
@@ -1,0 +1,52 @@
+<section>
+  <h1>Referrals</h1>
+  <p class="referrals-note">
+    These referrals are visible only to active cooperative members. Contact families following
+    cooperative norms and guidelines.
+  </p>
+
+  @if (referralsResource.isLoading()) {
+    <p class="loading" role="status">Loading referrals...</p>
+  } @else if (referralsResource.error()) {
+    <p class="error" role="alert">Failed to load referrals. Please try again.</p>
+  } @else if (referralsResource.value(); as referrals) {
+    @if (referrals.length === 0) {
+      <p class="empty-state">No referrals available right now.</p>
+    } @else {
+      <ul class="referral-list" aria-label="Referral requests">
+        @for (referral of referrals; track referral.id) {
+          <li class="referral-card">
+            <div class="referral-meta">
+              <span class="referral-zip">{{ referral.zipcode }}</span>
+              <span class="referral-submitted">{{ getRelativeTime(referral.submitted) }}</span>
+            </div>
+
+            <div class="referral-details">
+              <dl class="referral-fields">
+                <dt>Due date</dt>
+                <dd>{{ formatDueDate(referral) }}</dd>
+
+                <dt>Birth location</dt>
+                <dd>{{ referral.birthLocation || '—' }}</dd>
+              </dl>
+
+              <ul class="service-tags" aria-label="Services requested">
+                @for (service of referral.services; track service) {
+                  <li class="service-tag">{{ getServiceLabel(service) }}</li>
+                }
+              </ul>
+            </div>
+
+            <a
+              [routerLink]="['/referrals', referral.id]"
+              class="view-link"
+              aria-label="View details for referral in {{ referral.zipcode }}"
+            >
+              View details
+            </a>
+          </li>
+        }
+      </ul>
+    }
+  }
+</section>

--- a/members/src/app/referrals/referrals.scss
+++ b/members/src/app/referrals/referrals.scss
@@ -1,0 +1,127 @@
+:host {
+  display: block;
+  max-width: 800px;
+  margin-inline: auto;
+  padding: var(--space-l);
+}
+
+.referrals-note {
+  font-size: var(--step--1);
+  color: var(--brown-500);
+  margin-block-end: var(--space-l);
+  padding: var(--space-s);
+  background: var(--brown-100);
+  border-radius: var(--border-radius-md);
+  border-left: 4px solid var(--teal-500);
+}
+
+.loading,
+.empty-state {
+  color: var(--brown-450);
+  text-align: center;
+  padding: var(--space-xl);
+}
+
+.error {
+  color: var(--brown-600);
+  background: var(--brown-100);
+  border: 1px solid var(--brown-300);
+  border-radius: var(--border-radius-md);
+  padding: var(--space-m);
+  text-align: center;
+}
+
+.referral-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-m);
+}
+
+.referral-card {
+  background: var(--brown-000);
+  border: 1px solid var(--brown-200);
+  border-radius: var(--border-radius-md);
+  padding: var(--space-m);
+  display: grid;
+  gap: var(--space-s);
+}
+
+.referral-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.referral-zip {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--step-0);
+}
+
+.referral-submitted {
+  font-size: var(--step--2);
+  color: var(--brown-450);
+}
+
+.referral-details {
+  display: grid;
+  gap: var(--space-s);
+}
+
+.referral-fields {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-3xs) var(--space-s);
+  align-items: baseline;
+  margin: 0;
+
+  dt {
+    font-size: var(--step--2);
+    font-weight: var(--font-weight-regular);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--brown-500);
+  }
+
+  dd {
+    font-size: var(--step-0);
+    margin: 0;
+  }
+}
+
+.service-tags {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+}
+
+.service-tag {
+  font-size: var(--step--2);
+  background: var(--teal-100, var(--brown-100));
+  color: var(--teal-700, var(--brown-600));
+  padding: var(--space-3xs) var(--space-xs);
+  border-radius: 999px;
+}
+
+.view-link {
+  display: inline-block;
+  font-size: var(--step--1);
+  font-weight: var(--font-weight-semibold);
+  color: var(--teal-600);
+  text-decoration: none;
+  align-self: start;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--teal-500);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}

--- a/members/src/app/referrals/referrals.spec.ts
+++ b/members/src/app/referrals/referrals.spec.ts
@@ -1,0 +1,96 @@
+import { provideRouter } from '@angular/router';
+import type { Routes } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it, vi } from 'vitest';
+import { ReferralsService, type ReferralListItem } from '../services/referrals.service';
+import { Referrals } from './referrals';
+
+const TEST_ROUTES: Routes = [{ path: 'referrals/:id', component: Referrals }];
+
+function makeReferral(overrides: Partial<ReferralListItem> = {}): ReferralListItem {
+  return {
+    id: 'req-1',
+    submitted: '2025-01-15T10:00:00.000Z',
+    estimatedDueDate: { month: '3', day: '15', year: '2025' },
+    services: ['birth-doula'],
+    zipcode: '14607',
+    birthLocation: 'Hospital',
+    ...overrides,
+  };
+}
+
+async function setup({
+  loading = false,
+  error = false,
+  referrals = [] as ReferralListItem[],
+} = {}) {
+  const listReferralsMock = loading
+    ? vi.fn().mockReturnValue(new Promise(() => {})) // never resolves
+    : error
+      ? vi.fn().mockRejectedValue(new Error('Network error'))
+      : vi.fn().mockResolvedValue(referrals);
+
+  const mockReferralsService = {
+    listReferrals: listReferralsMock,
+  };
+
+  await render(Referrals, {
+    providers: [
+      { provide: ReferralsService, useValue: mockReferralsService },
+      provideRouter(TEST_ROUTES),
+    ],
+  });
+}
+
+describe('Referrals list', () => {
+  describe('loading state', () => {
+    it('shows loading message while fetching', async () => {
+      await setup({ loading: true });
+      expect(await screen.findByRole('status')).toHaveTextContent('Loading referrals...');
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error message on failure', async () => {
+      await setup({ error: true });
+      expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load referrals');
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state when no referrals', async () => {
+      await setup({ referrals: [] });
+      expect(await screen.findByText('No referrals available right now.')).toBeVisible();
+    });
+  });
+
+  describe('populated state', () => {
+    it('renders referral cards', async () => {
+      await setup({ referrals: [makeReferral(), makeReferral({ id: 'req-2', zipcode: '14608' })] });
+      expect((await screen.findAllByRole('listitem')).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows ZIP code for each referral', async () => {
+      await setup({ referrals: [makeReferral({ zipcode: '14607' })] });
+      expect(await screen.findByText('14607')).toBeVisible();
+    });
+
+    it('shows service label', async () => {
+      await setup({ referrals: [makeReferral({ services: ['birth-doula'] })] });
+      expect(await screen.findByText('Birth')).toBeVisible();
+    });
+
+    it('shows view details link for each referral', async () => {
+      await setup({ referrals: [makeReferral({ id: 'req-abc' })] });
+      expect(await screen.findByRole('link', { name: /View details/ })).toBeVisible();
+    });
+
+    it('does not show contact info (name, email, phone) in list', async () => {
+      await setup({ referrals: [makeReferral()] });
+      // Wait for loaded state
+      await screen.findByText('14607');
+      expect(screen.queryByText(/jane@example\.com/)).toBeNull();
+      expect(screen.queryByText(/555-/)).toBeNull();
+    });
+  });
+});

--- a/members/src/app/referrals/referrals.spec.ts
+++ b/members/src/app/referrals/referrals.spec.ts
@@ -26,6 +26,7 @@ async function setup({
 } = {}) {
   let listReferralsMock: ReturnType<typeof vi.fn>;
   if (loading) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     listReferralsMock = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
   } else if (error) {
     listReferralsMock = vi.fn().mockRejectedValue(new Error('Network error'));
@@ -70,7 +71,8 @@ describe('Referrals list', () => {
   describe('populated state', () => {
     it('renders referral cards', async () => {
       await setup({ referrals: [makeReferral(), makeReferral({ id: 'req-2', zipcode: '14608' })] });
-      expect((await screen.findAllByRole('listitem')).length).toBeGreaterThanOrEqual(2);
+      const items = await screen.findAllByRole('listitem');
+      expect(items.length).toBeGreaterThanOrEqual(2);
     });
 
     it('shows ZIP code for each referral', async () => {

--- a/members/src/app/referrals/referrals.spec.ts
+++ b/members/src/app/referrals/referrals.spec.ts
@@ -24,11 +24,14 @@ async function setup({
   error = false,
   referrals = [] as ReferralListItem[],
 } = {}) {
-  const listReferralsMock = loading
-    ? vi.fn().mockReturnValue(new Promise(() => {})) // never resolves
-    : error
-      ? vi.fn().mockRejectedValue(new Error('Network error'))
-      : vi.fn().mockResolvedValue(referrals);
+  let listReferralsMock: ReturnType<typeof vi.fn>;
+  if (loading) {
+    listReferralsMock = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+  } else if (error) {
+    listReferralsMock = vi.fn().mockRejectedValue(new Error('Network error'));
+  } else {
+    listReferralsMock = vi.fn().mockResolvedValue(referrals);
+  }
 
   const mockReferralsService = {
     listReferrals: listReferralsMock,
@@ -53,7 +56,7 @@ describe('Referrals list', () => {
   describe('error state', () => {
     it('shows error message on failure', async () => {
       await setup({ error: true });
-      expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load referrals');
+      expect(await screen.findByRole('alert')).toHaveTextContent('Network error');
     });
   });
 

--- a/members/src/app/referrals/referrals.ts
+++ b/members/src/app/referrals/referrals.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, inject, resource } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { SERVICE_LABELS } from '../admin/match-requests/match-request.constants';
+import {
+  getRelativeTime,
+  isValidDueDate,
+  parseDueDate,
+} from '../admin/match-requests/match-request.utilities';
+import { ReferralsService, type ReferralListItem } from '../services/referrals.service';
+
+@Component({
+  imports: [RouterLink],
+  templateUrl: './referrals.html',
+  styleUrl: './referrals.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Referrals {
+  private referralsService = inject(ReferralsService);
+
+  protected referralsResource = resource({
+    loader: () => this.referralsService.listReferrals(),
+  });
+
+  protected formatDueDate(item: ReferralListItem): string {
+    if (!isValidDueDate(item.estimatedDueDate)) return '—';
+    return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+      .format(parseDueDate(item.estimatedDueDate));
+  }
+
+  protected getRelativeTime(submitted: string): string {
+    return getRelativeTime(submitted);
+  }
+
+  protected getServiceLabel(service: string): string {
+    return SERVICE_LABELS[service] ?? service;
+  }
+}

--- a/members/src/app/services/referrals.service.ts
+++ b/members/src/app/services/referrals.service.ts
@@ -1,0 +1,60 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Auth } from '@angular/fire/auth';
+import { firstValueFrom } from 'rxjs';
+
+export interface ReferralDueDate {
+  month: string;
+  day: string;
+  year: string;
+}
+
+export interface ReferralListItem {
+  id: string;
+  submitted: string;
+  estimatedDueDate: ReferralDueDate;
+  services: string[];
+  zipcode: string;
+  birthLocation: string;
+}
+
+export interface ReferralDetail {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  zipcode: string;
+  estimatedDueDate: ReferralDueDate;
+  services: string[];
+  birthLocation: string;
+  otherInfo: string;
+  insurance: string[];
+  submitted: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReferralsService {
+  private auth = inject(Auth);
+  private http = inject(HttpClient);
+
+  async listReferrals(): Promise<ReferralListItem[]> {
+    const uid = this.auth.currentUser?.uid;
+    if (!uid) throw new Error('You must be signed in to view referrals.');
+
+    const response = await firstValueFrom(
+      this.http.get<{ referrals: ReferralListItem[] }>(`/api/members/${uid}/referrals`),
+    );
+    return response.referrals;
+  }
+
+  async getReferral(id: string): Promise<ReferralDetail> {
+    const uid = this.auth.currentUser?.uid;
+    if (!uid) throw new Error('You must be signed in to view referrals.');
+
+    return firstValueFrom(
+      this.http.get<ReferralDetail>(`/api/members/${uid}/referrals/${id}`),
+    );
+  }
+}

--- a/members/src/app/services/referrals.service.ts
+++ b/members/src/app/services/referrals.service.ts
@@ -11,7 +11,20 @@ export type ReferralListItem = Pick<
   'id' | 'submitted' | 'estimatedDueDate' | 'services' | 'zipcode' | 'birthLocation'
 >;
 
-export type ReferralDetail = Omit<MatchRequest, 'sent' | 'recaptchaScore'>;
+export type ReferralDetail = Pick<
+  MatchRequest,
+  | 'id'
+  | 'name'
+  | 'email'
+  | 'phone'
+  | 'zipcode'
+  | 'estimatedDueDate'
+  | 'services'
+  | 'birthLocation'
+  | 'otherInfo'
+  | 'insurance'
+  | 'submitted'
+>;
 
 @Injectable({
   providedIn: 'root',
@@ -24,14 +37,22 @@ export class ReferralsService {
     const uid = this.auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
+    const memberId = encodeURIComponent(uid);
     try {
       const response = await firstValueFrom(
-        this.http.get<{ referrals: ReferralListItem[] }>(`/api/members/${uid}/referrals`),
+        this.http.get<{ referrals: ReferralListItem[] }>(`/api/members/${memberId}/referrals`),
       );
       return response.referrals;
     } catch (error: unknown) {
+      console.error('Failed to load referrals', { uid, error });
       if (error instanceof HttpErrorResponse) {
         switch (error.status) {
+          case 0: {
+            throw new Error('Unable to connect. Check your network and try again.');
+          }
+          case 401: {
+            throw new Error('Your session has expired. Please sign in again.');
+          }
           case 403: {
             throw new Error(
               'Your membership is not currently active. Renew your membership to view referrals.',
@@ -42,7 +63,7 @@ export class ReferralsService {
           }
         }
       }
-      throw new Error('Failed to load referrals. Please try again.');
+      throw new Error('Failed to load referrals. Please try again.', { cause: error });
     }
   }
 
@@ -50,13 +71,22 @@ export class ReferralsService {
     const uid = this.auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
+    const memberId = encodeURIComponent(uid);
+    const referralId = encodeURIComponent(id);
     try {
       return await firstValueFrom(
-        this.http.get<ReferralDetail>(`/api/members/${uid}/referrals/${id}`),
+        this.http.get<ReferralDetail>(`/api/members/${memberId}/referrals/${referralId}`),
       );
     } catch (error: unknown) {
+      console.error('Failed to load referral', { uid, id, error });
       if (error instanceof HttpErrorResponse) {
         switch (error.status) {
+          case 0: {
+            throw new Error('Unable to connect. Check your network and try again.');
+          }
+          case 401: {
+            throw new Error('Your session has expired. Please sign in again.');
+          }
           case 403: {
             throw new Error(
               'Your membership is not currently active. Renew your membership to view referrals.',
@@ -65,9 +95,12 @@ export class ReferralsService {
           case 404: {
             throw new Error('Referral not found.');
           }
+          case 422: {
+            throw new Error('Invalid referral link. Please check the URL and try again.');
+          }
         }
       }
-      throw new Error('Failed to load referral. Please try again.');
+      throw new Error('Failed to load referral. Please try again.', { cause: error });
     }
   }
 }

--- a/members/src/app/services/referrals.service.ts
+++ b/members/src/app/services/referrals.service.ts
@@ -1,36 +1,17 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 import { firstValueFrom } from 'rxjs';
+import type { MatchRequest } from '../admin/admin.types';
 
-export interface ReferralDueDate {
-  month: string;
-  day: string;
-  year: string;
-}
+export type ReferralDueDate = MatchRequest['estimatedDueDate'];
 
-export interface ReferralListItem {
-  id: string;
-  submitted: string;
-  estimatedDueDate: ReferralDueDate;
-  services: string[];
-  zipcode: string;
-  birthLocation: string;
-}
+export type ReferralListItem = Pick<
+  MatchRequest,
+  'id' | 'submitted' | 'estimatedDueDate' | 'services' | 'zipcode' | 'birthLocation'
+>;
 
-export interface ReferralDetail {
-  id: string;
-  name: string;
-  email: string;
-  phone: string;
-  zipcode: string;
-  estimatedDueDate: ReferralDueDate;
-  services: string[];
-  birthLocation: string;
-  otherInfo: string;
-  insurance: string[];
-  submitted: string;
-}
+export type ReferralDetail = Omit<MatchRequest, 'sent' | 'recaptchaScore'>;
 
 @Injectable({
   providedIn: 'root',
@@ -43,18 +24,50 @@ export class ReferralsService {
     const uid = this.auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
-    const response = await firstValueFrom(
-      this.http.get<{ referrals: ReferralListItem[] }>(`/api/members/${uid}/referrals`),
-    );
-    return response.referrals;
+    try {
+      const response = await firstValueFrom(
+        this.http.get<{ referrals: ReferralListItem[] }>(`/api/members/${uid}/referrals`),
+      );
+      return response.referrals;
+    } catch (error: unknown) {
+      if (error instanceof HttpErrorResponse) {
+        switch (error.status) {
+          case 403: {
+            throw new Error(
+              'Your membership is not currently active. Renew your membership to view referrals.',
+            );
+          }
+          case 404: {
+            throw new Error('Member account not found. Please contact support.');
+          }
+        }
+      }
+      throw new Error('Failed to load referrals. Please try again.');
+    }
   }
 
   async getReferral(id: string): Promise<ReferralDetail> {
     const uid = this.auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
-    return firstValueFrom(
-      this.http.get<ReferralDetail>(`/api/members/${uid}/referrals/${id}`),
-    );
+    try {
+      return await firstValueFrom(
+        this.http.get<ReferralDetail>(`/api/members/${uid}/referrals/${id}`),
+      );
+    } catch (error: unknown) {
+      if (error instanceof HttpErrorResponse) {
+        switch (error.status) {
+          case 403: {
+            throw new Error(
+              'Your membership is not currently active. Renew your membership to view referrals.',
+            );
+          }
+          case 404: {
+            throw new Error('Referral not found.');
+          }
+        }
+      }
+      throw new Error('Failed to load referral. Please try again.');
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/members/:memberId/referrals` and `GET /api/members/:memberId/referrals/:requestId` — gated behind owner-or-admin auth and active Stripe membership (`isActiveStripeMember`)
- List endpoint returns safe fields only (no contact info); detail endpoint returns full request including name/email/phone
- Angular `/referrals` list and `/referrals/:id` detail pages with loading/empty/error/populated states
- Membership dashboard shows a **Referrals** card only for active Stripe members (`active` or `trialing`)
- Reuses existing admin match-request constants and utilities (`SERVICE_LABELS`, `SERVICE_LABELS_LONG`, `parseDueDate`, `getRelativeTime`) — no duplication

## Out of scope (intentional)

- Referral email opt-in toggle
- Notification emails
- Claim/response/status tracking workflows

## Test plan

- [ ] `cd functions && bun test` — 468 pass
- [ ] `cd functions && bun run build` — clean
- [ ] `cd members && bun run test` — 443 pass (1 skipped)
- [ ] `cd members && bun run build` — clean
- [ ] `bun run lint` — clean
- [ ] Sign in as active Stripe member → membership dashboard shows Referrals card
- [ ] Click Referrals → `/referrals` list loads (no contact info visible)
- [ ] Click View details → `/referrals/:id` shows full contact info
- [ ] Sign in as inactive/non-Stripe member → Referrals card not visible