### PR TITLE
feat(members): replace @angular/fire with vanilla Firebase SDK

### DIFF
--- a/members/bun.lock
+++ b/members/bun.lock
@@ -8,10 +8,10 @@
         "@angular/common": "^21.2.8",
         "@angular/compiler": "^21.2.8",
         "@angular/core": "^21.2.8",
-        "@angular/fire": "^20.0.1",
         "@angular/forms": "^21.2.8",
         "@angular/platform-browser": "^21.2.8",
         "@angular/router": "^21.2.8",
+        "firebase": "^12.15.0",
         "leaflet": "^1.9.4",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
@@ -103,13 +103,9 @@
 
     "@angular/core": ["@angular/core@21.2.8", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/compiler": "21.2.8", "rxjs": "^6.5.3 || ^7.4.0", "zone.js": "~0.15.0 || ~0.16.0" }, "optionalPeers": ["@angular/compiler", "zone.js"] }, "sha512-hI7n4t8qgFJaVV55LIaNuzcdP+/IeuqQRu3huSLo47Gf6uZAD0Acj4Ye9SC8YNmhUu5/RiImngm9NOlcI2oCJA=="],
 
-    "@angular/fire": ["@angular/fire@20.0.1", "", { "dependencies": { "@angular-devkit/schematics": "^20.0.0", "@schematics/angular": "^20.0.0", "firebase": "^11.8.0", "rxfire": "^6.1.0", "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "^20.0.0", "@angular/core": "^20.0.0", "@angular/platform-browser": "^20.0.0", "@angular/platform-browser-dynamic": "^20.0.0", "@angular/platform-server": "^20.0.0", "firebase-tools": "^14.0.0", "rxjs": "~7.8.0" }, "optionalPeers": ["@angular/platform-server", "firebase-tools"] }, "sha512-iZxE/7d5hJ2WpaENPEjHYBh7m68QybTwBHKOKaeqHz18XCP5Ufl89LuTrnoWkWOk0GdZBVAqpo6n/bM2jYIQAw=="],
-
     "@angular/forms": ["@angular/forms@21.2.8", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "21.2.8", "@angular/core": "21.2.8", "@angular/platform-browser": "21.2.8", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-tyQAHjfMHcqETRkKQaZHjYqIK9W8uRenPpY2DF/Jl+S7CwcaX4T8t8TKgzvTynNzQW9QGiLg0pqVosVMKzBXJg=="],
 
     "@angular/platform-browser": ["@angular/platform-browser@21.2.8", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/animations": "21.2.8", "@angular/common": "21.2.8", "@angular/core": "21.2.8" }, "optionalPeers": ["@angular/animations"] }, "sha512-4fwmGf7GCuIsjFqx1gqqWC92YjlN9SmGJO17TPPsOm5zUOnDx+h3Bj9XjdXxlcBtugTb2xHk6Auqyv3lzWGlkw=="],
-
-    "@angular/platform-browser-dynamic": ["@angular/platform-browser-dynamic@20.2.3", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "20.2.3", "@angular/compiler": "20.2.3", "@angular/core": "20.2.3", "@angular/platform-browser": "20.2.3" } }, "sha512-uxqLv2yNibd2vf3OObyH4arVfwu+o9FKgkUcnFUdowK31emiZe1nAY8uEe/92JIsMMAoIllI/GAVzWH8dp05mg=="],
 
     "@angular/router": ["@angular/router@21.2.8", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "21.2.8", "@angular/core": "21.2.8", "@angular/platform-browser": "21.2.8", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-KSlUbFHHKY84G6iKlB2FDMmh+lLmGjmpyT1p/kx8qZm1BuxJGOOU+oNgkCfaPJT1R2/muDXuxQ51uc/la6y28g=="],
 
@@ -251,93 +247,93 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@firebase/ai": ["@firebase/ai@1.4.1", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.3", "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x", "@firebase/app-types": "0.x" } }, "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g=="],
+    "@firebase/ai": ["@firebase/ai@2.13.1", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.4", "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x", "@firebase/app-types": "0.x" } }, "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw=="],
 
-    "@firebase/analytics": ["@firebase/analytics@0.10.17", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/installations": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg=="],
+    "@firebase/analytics": ["@firebase/analytics@0.10.22", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/installations": "0.6.22", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow=="],
 
-    "@firebase/analytics-compat": ["@firebase/analytics-compat@0.2.23", "", { "dependencies": { "@firebase/analytics": "0.10.17", "@firebase/analytics-types": "0.8.3", "@firebase/component": "0.6.18", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw=="],
+    "@firebase/analytics-compat": ["@firebase/analytics-compat@0.2.28", "", { "dependencies": { "@firebase/analytics": "0.10.22", "@firebase/analytics-types": "0.8.4", "@firebase/component": "0.7.3", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ=="],
 
-    "@firebase/analytics-types": ["@firebase/analytics-types@0.8.3", "", {}, "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg=="],
+    "@firebase/analytics-types": ["@firebase/analytics-types@0.8.4", "", {}, "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ=="],
 
-    "@firebase/app": ["@firebase/app@0.13.2", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "idb": "7.1.1", "tslib": "^2.1.0" } }, "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w=="],
+    "@firebase/app": ["@firebase/app@0.15.0", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "idb": "7.1.1", "tslib": "^2.1.0" } }, "sha512-soIskolmGgbpi0K/MfrjtdpO1220qRCbXA4Z8Qx3lM+fVwA3q40m+OM+7zBHd2nuQCrLXb33L6Oc1aBH3Y26AQ=="],
 
-    "@firebase/app-check": ["@firebase/app-check@0.10.1", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ=="],
+    "@firebase/app-check": ["@firebase/app-check@0.12.0", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q=="],
 
-    "@firebase/app-check-compat": ["@firebase/app-check-compat@0.3.26", "", { "dependencies": { "@firebase/app-check": "0.10.1", "@firebase/app-check-types": "0.5.3", "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ=="],
+    "@firebase/app-check-compat": ["@firebase/app-check-compat@0.4.5", "", { "dependencies": { "@firebase/app-check": "0.12.0", "@firebase/app-check-types": "0.5.4", "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg=="],
 
-    "@firebase/app-check-interop-types": ["@firebase/app-check-interop-types@0.3.3", "", {}, "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A=="],
+    "@firebase/app-check-interop-types": ["@firebase/app-check-interop-types@0.3.4", "", {}, "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg=="],
 
-    "@firebase/app-check-types": ["@firebase/app-check-types@0.5.3", "", {}, "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng=="],
+    "@firebase/app-check-types": ["@firebase/app-check-types@0.5.4", "", {}, "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw=="],
 
-    "@firebase/app-compat": ["@firebase/app-compat@0.4.2", "", { "dependencies": { "@firebase/app": "0.13.2", "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" } }, "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q=="],
+    "@firebase/app-compat": ["@firebase/app-compat@0.5.14", "", { "dependencies": { "@firebase/app": "0.15.0", "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" } }, "sha512-rgFmiofYsdS9ZG/Bht3OBxJtPD3zWE1cffShWubEm+4+qZeyzCbmtb1q6jOEjN9fB7uufe4rQmWOPXouR3758Q=="],
 
-    "@firebase/app-types": ["@firebase/app-types@0.9.3", "", {}, "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw=="],
+    "@firebase/app-types": ["@firebase/app-types@0.9.5", "", { "dependencies": { "@firebase/logger": "0.5.1" } }, "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A=="],
 
-    "@firebase/auth": ["@firebase/auth@1.10.8", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x", "@react-native-async-storage/async-storage": "^1.18.1" }, "optionalPeers": ["@react-native-async-storage/async-storage"] }, "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA=="],
+    "@firebase/auth": ["@firebase/auth@1.13.3", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x", "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0" }, "optionalPeers": ["@react-native-async-storage/async-storage"] }, "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ=="],
 
-    "@firebase/auth-compat": ["@firebase/auth-compat@0.5.28", "", { "dependencies": { "@firebase/auth": "1.10.8", "@firebase/auth-types": "0.13.0", "@firebase/component": "0.6.18", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q=="],
+    "@firebase/auth-compat": ["@firebase/auth-compat@0.6.8", "", { "dependencies": { "@firebase/auth": "1.13.3", "@firebase/auth-types": "0.13.1", "@firebase/component": "0.7.3", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q=="],
 
-    "@firebase/auth-interop-types": ["@firebase/auth-interop-types@0.2.4", "", {}, "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA=="],
+    "@firebase/auth-interop-types": ["@firebase/auth-interop-types@0.2.5", "", {}, "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg=="],
 
-    "@firebase/auth-types": ["@firebase/auth-types@0.13.0", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg=="],
+    "@firebase/auth-types": ["@firebase/auth-types@0.13.1", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g=="],
 
-    "@firebase/component": ["@firebase/component@0.6.18", "", { "dependencies": { "@firebase/util": "1.12.1", "tslib": "^2.1.0" } }, "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ=="],
+    "@firebase/component": ["@firebase/component@0.7.3", "", { "dependencies": { "@firebase/util": "1.15.1", "tslib": "^2.1.0" } }, "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew=="],
 
-    "@firebase/data-connect": ["@firebase/data-connect@0.3.10", "", { "dependencies": { "@firebase/auth-interop-types": "0.2.4", "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ=="],
+    "@firebase/data-connect": ["@firebase/data-connect@0.7.1", "", { "dependencies": { "@firebase/auth-interop-types": "0.2.5", "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg=="],
 
-    "@firebase/database": ["@firebase/database@1.0.20", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.3", "@firebase/auth-interop-types": "0.2.4", "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "faye-websocket": "0.11.4", "tslib": "^2.1.0" } }, "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw=="],
+    "@firebase/database": ["@firebase/database@1.1.3", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.4", "@firebase/auth-interop-types": "0.2.5", "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "faye-websocket": "0.11.4", "tslib": "^2.1.0" } }, "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw=="],
 
-    "@firebase/database-compat": ["@firebase/database-compat@2.0.11", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/database": "1.0.20", "@firebase/database-types": "1.0.15", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" } }, "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw=="],
+    "@firebase/database-compat": ["@firebase/database-compat@2.1.4", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/database": "1.1.3", "@firebase/database-types": "1.0.20", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" } }, "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg=="],
 
-    "@firebase/database-types": ["@firebase/database-types@1.0.15", "", { "dependencies": { "@firebase/app-types": "0.9.3", "@firebase/util": "1.12.1" } }, "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw=="],
+    "@firebase/database-types": ["@firebase/database-types@1.0.20", "", { "dependencies": { "@firebase/app-types": "0.9.5", "@firebase/util": "1.15.1" } }, "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw=="],
 
-    "@firebase/firestore": ["@firebase/firestore@4.8.0", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "@firebase/webchannel-wrapper": "1.0.3", "@grpc/grpc-js": "~1.9.0", "@grpc/proto-loader": "^0.7.8", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A=="],
+    "@firebase/firestore": ["@firebase/firestore@4.16.0", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "@firebase/webchannel-wrapper": "1.0.6", "@grpc/grpc-js": "~1.9.0", "@grpc/proto-loader": "^0.7.8", "re2js": "^0.4.2", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA=="],
 
-    "@firebase/firestore-compat": ["@firebase/firestore-compat@0.3.53", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/firestore": "4.8.0", "@firebase/firestore-types": "3.0.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q=="],
+    "@firebase/firestore-compat": ["@firebase/firestore-compat@0.4.11", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/firestore": "4.16.0", "@firebase/firestore-types": "3.0.4", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw=="],
 
-    "@firebase/firestore-types": ["@firebase/firestore-types@3.0.3", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q=="],
+    "@firebase/firestore-types": ["@firebase/firestore-types@3.0.4", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA=="],
 
-    "@firebase/functions": ["@firebase/functions@0.12.9", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.3", "@firebase/auth-interop-types": "0.2.4", "@firebase/component": "0.6.18", "@firebase/messaging-interop-types": "0.2.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg=="],
+    "@firebase/functions": ["@firebase/functions@0.13.5", "", { "dependencies": { "@firebase/app-check-interop-types": "0.3.4", "@firebase/auth-interop-types": "0.2.5", "@firebase/component": "0.7.3", "@firebase/messaging-interop-types": "0.2.5", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw=="],
 
-    "@firebase/functions-compat": ["@firebase/functions-compat@0.3.26", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/functions": "0.12.9", "@firebase/functions-types": "0.6.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA=="],
+    "@firebase/functions-compat": ["@firebase/functions-compat@0.4.5", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/functions": "0.13.5", "@firebase/functions-types": "0.6.4", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ=="],
 
-    "@firebase/functions-types": ["@firebase/functions-types@0.6.3", "", {}, "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg=="],
+    "@firebase/functions-types": ["@firebase/functions-types@0.6.4", "", {}, "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ=="],
 
-    "@firebase/installations": ["@firebase/installations@0.6.18", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/util": "1.12.1", "idb": "7.1.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A=="],
+    "@firebase/installations": ["@firebase/installations@0.6.22", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/util": "1.15.1", "idb": "7.1.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw=="],
 
-    "@firebase/installations-compat": ["@firebase/installations-compat@0.2.18", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/installations": "0.6.18", "@firebase/installations-types": "0.5.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw=="],
+    "@firebase/installations-compat": ["@firebase/installations-compat@0.2.22", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/installations": "0.6.22", "@firebase/installations-types": "0.5.4", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w=="],
 
-    "@firebase/installations-types": ["@firebase/installations-types@0.5.3", "", { "peerDependencies": { "@firebase/app-types": "0.x" } }, "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA=="],
+    "@firebase/installations-types": ["@firebase/installations-types@0.5.4", "", { "peerDependencies": { "@firebase/app-types": "0.x" } }, "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg=="],
 
-    "@firebase/logger": ["@firebase/logger@0.4.4", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g=="],
+    "@firebase/logger": ["@firebase/logger@0.5.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ=="],
 
-    "@firebase/messaging": ["@firebase/messaging@0.12.22", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/installations": "0.6.18", "@firebase/messaging-interop-types": "0.2.3", "@firebase/util": "1.12.1", "idb": "7.1.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og=="],
+    "@firebase/messaging": ["@firebase/messaging@0.13.0", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/installations": "0.6.22", "@firebase/messaging-interop-types": "0.2.5", "@firebase/util": "1.15.1", "idb": "7.1.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ=="],
 
-    "@firebase/messaging-compat": ["@firebase/messaging-compat@0.2.22", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/messaging": "0.12.22", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A=="],
+    "@firebase/messaging-compat": ["@firebase/messaging-compat@0.2.27", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/messaging": "0.13.0", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA=="],
 
-    "@firebase/messaging-interop-types": ["@firebase/messaging-interop-types@0.2.3", "", {}, "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q=="],
+    "@firebase/messaging-interop-types": ["@firebase/messaging-interop-types@0.2.5", "", {}, "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw=="],
 
-    "@firebase/performance": ["@firebase/performance@0.7.7", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/installations": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0", "web-vitals": "^4.2.4" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w=="],
+    "@firebase/performance": ["@firebase/performance@0.7.12", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/installations": "0.6.22", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0", "web-vitals": "^4.2.4" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ=="],
 
-    "@firebase/performance-compat": ["@firebase/performance-compat@0.2.20", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/performance": "0.7.7", "@firebase/performance-types": "0.2.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ=="],
+    "@firebase/performance-compat": ["@firebase/performance-compat@0.2.25", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/performance": "0.7.12", "@firebase/performance-types": "0.2.4", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA=="],
 
-    "@firebase/performance-types": ["@firebase/performance-types@0.2.3", "", {}, "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ=="],
+    "@firebase/performance-types": ["@firebase/performance-types@0.2.4", "", {}, "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg=="],
 
-    "@firebase/remote-config": ["@firebase/remote-config@0.6.5", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/installations": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw=="],
+    "@firebase/remote-config": ["@firebase/remote-config@0.8.5", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/installations": "0.6.22", "@firebase/logger": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-zb+7CDGFP2wYVF1LXQoYIFdoESIQM3p0+uiW1welw8+zvDxAL50K75PKTXXtunJADUrksTVpV7mD0pn54vzJRA=="],
 
-    "@firebase/remote-config-compat": ["@firebase/remote-config-compat@0.2.18", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/logger": "0.4.4", "@firebase/remote-config": "0.6.5", "@firebase/remote-config-types": "0.4.0", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ=="],
+    "@firebase/remote-config-compat": ["@firebase/remote-config-compat@0.2.26", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/logger": "0.5.1", "@firebase/remote-config": "0.8.5", "@firebase/remote-config-types": "0.5.1", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-uC57Tc7GYYOCnMgLkGIVf999XlaYaPDONoa54c93YTKDctlvCZI89z0zQ2RbhGR8Zf+QuCbQHs/99vqoE84a7g=="],
 
-    "@firebase/remote-config-types": ["@firebase/remote-config-types@0.4.0", "", {}, "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg=="],
+    "@firebase/remote-config-types": ["@firebase/remote-config-types@0.5.1", "", {}, "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A=="],
 
-    "@firebase/storage": ["@firebase/storage@0.13.14", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g=="],
+    "@firebase/storage": ["@firebase/storage@0.14.3", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app": "0.x" } }, "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg=="],
 
-    "@firebase/storage-compat": ["@firebase/storage-compat@0.3.24", "", { "dependencies": { "@firebase/component": "0.6.18", "@firebase/storage": "0.13.14", "@firebase/storage-types": "0.8.3", "@firebase/util": "1.12.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ=="],
+    "@firebase/storage-compat": ["@firebase/storage-compat@0.4.3", "", { "dependencies": { "@firebase/component": "0.7.3", "@firebase/storage": "0.14.3", "@firebase/storage-types": "0.8.4", "@firebase/util": "1.15.1", "tslib": "^2.1.0" }, "peerDependencies": { "@firebase/app-compat": "0.x" } }, "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw=="],
 
-    "@firebase/storage-types": ["@firebase/storage-types@0.8.3", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg=="],
+    "@firebase/storage-types": ["@firebase/storage-types@0.8.4", "", { "peerDependencies": { "@firebase/app-types": "0.x", "@firebase/util": "1.x" } }, "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA=="],
 
-    "@firebase/util": ["@firebase/util@1.12.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w=="],
+    "@firebase/util": ["@firebase/util@1.15.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g=="],
 
-    "@firebase/webchannel-wrapper": ["@firebase/webchannel-wrapper@1.0.3", "", {}, "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ=="],
+    "@firebase/webchannel-wrapper": ["@firebase/webchannel-wrapper@1.0.6", "", {}, "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.9.15", "", { "dependencies": { "@grpc/proto-loader": "^0.7.8", "@types/node": ">=12.12.47" } }, "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ=="],
 
@@ -949,7 +945,7 @@
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
 
-    "firebase": ["firebase@11.10.0", "", { "dependencies": { "@firebase/ai": "1.4.1", "@firebase/analytics": "0.10.17", "@firebase/analytics-compat": "0.2.23", "@firebase/app": "0.13.2", "@firebase/app-check": "0.10.1", "@firebase/app-check-compat": "0.3.26", "@firebase/app-compat": "0.4.2", "@firebase/app-types": "0.9.3", "@firebase/auth": "1.10.8", "@firebase/auth-compat": "0.5.28", "@firebase/data-connect": "0.3.10", "@firebase/database": "1.0.20", "@firebase/database-compat": "2.0.11", "@firebase/firestore": "4.8.0", "@firebase/firestore-compat": "0.3.53", "@firebase/functions": "0.12.9", "@firebase/functions-compat": "0.3.26", "@firebase/installations": "0.6.18", "@firebase/installations-compat": "0.2.18", "@firebase/messaging": "0.12.22", "@firebase/messaging-compat": "0.2.22", "@firebase/performance": "0.7.7", "@firebase/performance-compat": "0.2.20", "@firebase/remote-config": "0.6.5", "@firebase/remote-config-compat": "0.2.18", "@firebase/storage": "0.13.14", "@firebase/storage-compat": "0.3.24", "@firebase/util": "1.12.1" } }, "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w=="],
+    "firebase": ["firebase@12.15.0", "", { "dependencies": { "@firebase/ai": "2.13.1", "@firebase/analytics": "0.10.22", "@firebase/analytics-compat": "0.2.28", "@firebase/app": "0.15.0", "@firebase/app-check": "0.12.0", "@firebase/app-check-compat": "0.4.5", "@firebase/app-compat": "0.5.14", "@firebase/app-types": "0.9.5", "@firebase/auth": "1.13.3", "@firebase/auth-compat": "0.6.8", "@firebase/data-connect": "0.7.1", "@firebase/database": "1.1.3", "@firebase/database-compat": "2.1.4", "@firebase/firestore": "4.16.0", "@firebase/firestore-compat": "0.4.11", "@firebase/functions": "0.13.5", "@firebase/functions-compat": "0.4.5", "@firebase/installations": "0.6.22", "@firebase/installations-compat": "0.2.22", "@firebase/messaging": "0.13.0", "@firebase/messaging-compat": "0.2.27", "@firebase/performance": "0.7.12", "@firebase/performance-compat": "0.2.25", "@firebase/remote-config": "0.8.5", "@firebase/remote-config-compat": "0.2.26", "@firebase/storage": "0.14.3", "@firebase/storage-compat": "0.4.3", "@firebase/util": "1.15.1" } }, "sha512-p0YTLcRSTiBXMx9sGr4ZNSfLjc/RVBEw4C/TXjVMtw65+6E1Pbm47UY3F4/AqRoDobEcNX3gsbPGy7jPjxbgSQ=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
@@ -1293,6 +1289,8 @@
 
     "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
 
+    "re2js": ["re2js@0.4.3", "", {}, "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg=="],
+
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
@@ -1322,8 +1320,6 @@
     "rollup": ["rollup@4.52.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.3", "@rollup/rollup-android-arm64": "4.52.3", "@rollup/rollup-darwin-arm64": "4.52.3", "@rollup/rollup-darwin-x64": "4.52.3", "@rollup/rollup-freebsd-arm64": "4.52.3", "@rollup/rollup-freebsd-x64": "4.52.3", "@rollup/rollup-linux-arm-gnueabihf": "4.52.3", "@rollup/rollup-linux-arm-musleabihf": "4.52.3", "@rollup/rollup-linux-arm64-gnu": "4.52.3", "@rollup/rollup-linux-arm64-musl": "4.52.3", "@rollup/rollup-linux-loong64-gnu": "4.52.3", "@rollup/rollup-linux-ppc64-gnu": "4.52.3", "@rollup/rollup-linux-riscv64-gnu": "4.52.3", "@rollup/rollup-linux-riscv64-musl": "4.52.3", "@rollup/rollup-linux-s390x-gnu": "4.52.3", "@rollup/rollup-linux-x64-gnu": "4.52.3", "@rollup/rollup-linux-x64-musl": "4.52.3", "@rollup/rollup-openharmony-arm64": "4.52.3", "@rollup/rollup-win32-arm64-msvc": "4.52.3", "@rollup/rollup-win32-ia32-msvc": "4.52.3", "@rollup/rollup-win32-x64-gnu": "4.52.3", "@rollup/rollup-win32-x64-msvc": "4.52.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
-    "rxfire": ["rxfire@6.1.0", "", { "peerDependencies": { "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0", "rxjs": "^6.0.0 || ^7.0.0" } }, "sha512-NezdjeY32VZcCuGO0bbb8H8seBsJSCaWdUwGsHNzUcAOHR0VGpzgPtzjuuLXr8R/iemkqSzbx/ioS7VwV43ynA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -1540,10 +1536,6 @@
     "@angular/cli/@angular-devkit/architect": ["@angular-devkit/architect@0.2102.7", "", { "dependencies": { "@angular-devkit/core": "21.2.7", "rxjs": "7.8.2" }, "bin": { "architect": "bin/cli.js" } }, "sha512-4K/5hln9iaPEt3F/NyYqncNLvYpzSjRslEkHl2xIgZwQsIFHEvhnDRBYj2/oatURQhBqO/Yu15z/icVOYLxuTg=="],
 
     "@angular/cli/@angular-devkit/core": ["@angular-devkit/core@21.2.7", "", { "dependencies": { "ajv": "8.18.0", "ajv-formats": "3.0.1", "jsonc-parser": "3.3.1", "picomatch": "4.0.4", "rxjs": "7.8.2", "source-map": "0.7.6" }, "peerDependencies": { "chokidar": "^5.0.0" }, "optionalPeers": ["chokidar"] }, "sha512-DONYY5u4IENO2qpd23mODaE4JI2EIohWV1kuJnsU9HIcm5wN714QB2z9WY/s4gLfUiAMIUu/8lpnW/0kOQZAnQ=="],
-
-    "@angular/fire/@angular-devkit/schematics": ["@angular-devkit/schematics@20.2.1", "", { "dependencies": { "@angular-devkit/core": "20.2.1", "jsonc-parser": "3.3.1", "magic-string": "0.30.17", "ora": "8.2.0", "rxjs": "7.8.2" } }, "sha512-hxQQhlOKLjj4+fJrvMFWnVA6vwewwtkEGneolY+aMb8dUAEE7sw1FLo02pPdIBIXLWIYIcGVRI0E5iCTcLq9zw=="],
-
-    "@angular/fire/@schematics/angular": ["@schematics/angular@20.2.1", "", { "dependencies": { "@angular-devkit/core": "20.2.1", "@angular-devkit/schematics": "20.2.1", "jsonc-parser": "3.3.1" } }, "sha512-7Vx11KWooiqxP206JEVgz3cp0rRv31PYnocNoPM6UqLhGtlvL9GdgaZHzDhGFEm0hv6DUFrbTGIzB89gXc54Xg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1777,14 +1769,6 @@
 
     "@angular/cli/@angular-devkit/core/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core": ["@angular-devkit/core@20.2.1", "", { "dependencies": { "ajv": "8.17.1", "ajv-formats": "3.0.1", "jsonc-parser": "3.3.1", "picomatch": "4.0.3", "rxjs": "7.8.2", "source-map": "0.7.6" }, "peerDependencies": { "chokidar": "^4.0.0" }, "optionalPeers": ["chokidar"] }, "sha512-07xiRltPA1X+C0AQo/glI0in+bpwGW1cgOen2pp0MhXVlawW1M9cKZFb/35uvYUEWJUxLwBB3ZKJXBmpWWw0Rg=="],
-
-    "@angular/fire/@angular-devkit/schematics/magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core": ["@angular-devkit/core@20.2.1", "", { "dependencies": { "ajv": "8.17.1", "ajv-formats": "3.0.1", "jsonc-parser": "3.3.1", "picomatch": "4.0.3", "rxjs": "7.8.2", "source-map": "0.7.6" }, "peerDependencies": { "chokidar": "^4.0.0" }, "optionalPeers": ["chokidar"] }, "sha512-07xiRltPA1X+C0AQo/glI0in+bpwGW1cgOen2pp0MhXVlawW1M9cKZFb/35uvYUEWJUxLwBB3ZKJXBmpWWw0Rg=="],
-
     "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -1909,26 +1893,6 @@
 
     "@angular/cli/@angular-devkit/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
-
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora/chalk": ["chalk@5.6.0", "", {}, "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora/stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
     "@grpc/proto-loader/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -1976,16 +1940,6 @@
     "ora/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "@angular/build/@angular-devkit/architect/@angular-devkit/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@angular/fire/@angular-devkit/schematics/@angular-devkit/core/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
-    "@angular/fire/@angular-devkit/schematics/ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@angular/fire/@schematics/angular/@angular-devkit/core/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/members/package.json
+++ b/members/package.json
@@ -33,10 +33,10 @@
     "@angular/common": "^21.2.8",
     "@angular/compiler": "^21.2.8",
     "@angular/core": "^21.2.8",
-    "@angular/fire": "^20.0.1",
     "@angular/forms": "^21.2.8",
     "@angular/platform-browser": "^21.2.8",
     "@angular/router": "^21.2.8",
+    "firebase": "^12.15.0",
     "leaflet": "^1.9.4",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1"

--- a/members/src/app/app.config.ts
+++ b/members/src/app/app.config.ts
@@ -1,20 +1,13 @@
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import {
   type ApplicationConfig,
-  isDevMode,
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';
-import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
-import { connectAuthEmulator, getAuth, provideAuth } from '@angular/fire/auth';
-import { connectFirestoreEmulator, getFirestore, provideFirestore } from '@angular/fire/firestore';
 import { provideRouter, withComponentInputBinding, withInMemoryScrolling } from '@angular/router';
 import { routes } from './app.routes';
 import { authInterceptor } from './interceptors/auth.interceptor';
 import { windowProvider } from './services/window.token';
-
-// Check if we should use emulators (defaults to true in dev mode)
-const useEmulators = isDevMode() && !import.meta.env['VITE_USE_PRODUCTION'];
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -27,34 +20,5 @@ export const appConfig: ApplicationConfig = {
       withComponentInputBinding(),
       withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
     ),
-    // Firebase providers
-    provideFirebaseApp(() =>
-      initializeApp({
-        apiKey: 'AIzaSyBuYxpvwYc3ZVn5OSYtJe88XnL8x5HSuDI',
-        authDomain: 'doula-cooperative.firebaseapp.com',
-        projectId: 'doula-cooperative',
-        storageBucket: 'doula-cooperative.firebasestorage.app',
-        messagingSenderId: '577630356653',
-        appId: '1:577630356653:web:9425c7a726ad13f051f224',
-      }),
-    ),
-
-    provideAuth(() => {
-      const auth = getAuth();
-      if (useEmulators) {
-        console.log('Connecting to Auth emulator');
-        connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
-      }
-      return auth;
-    }),
-
-    provideFirestore(() => {
-      const firestore = getFirestore();
-      if (useEmulators) {
-        console.log('Connecting to Firestore emulator');
-        connectFirestoreEmulator(firestore, 'localhost', 8090);
-      }
-      return firestore;
-    }),
   ],
 };

--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -4,13 +4,17 @@ import { redirectNonAdminToMembership } from './guards/admin.guard';
 import { wizardStepGuard } from './create-profile-wizard/guards/wizard-step.guard';
 import { auth } from './lib/firebase';
 
-const requireAuth: CanActivateFn = () => {
+export const requireAuth: CanActivateFn = async () => {
   const router = inject(Router);
+  // Wait for Firebase to restore any persisted session before deciding, so a
+  // hard refresh on a protected route doesn't bounce an authenticated user.
+  await auth.authStateReady();
   return auth.currentUser ? true : router.parseUrl('/sign-in');
 };
 
-const requireUnauth: CanActivateFn = () => {
+export const requireUnauth: CanActivateFn = async () => {
   const router = inject(Router);
+  await auth.authStateReady();
   return auth.currentUser ? router.parseUrl('/membership') : true;
 };
 

--- a/members/src/app/app.routes.ts
+++ b/members/src/app/app.routes.ts
@@ -1,11 +1,18 @@
-import { canActivate, redirectLoggedInTo, redirectUnauthorizedTo } from '@angular/fire/auth-guard';
-import { type Routes } from '@angular/router';
+import { inject } from '@angular/core';
+import { Router, type CanActivateFn, type Routes } from '@angular/router';
 import { redirectNonAdminToMembership } from './guards/admin.guard';
 import { wizardStepGuard } from './create-profile-wizard/guards/wizard-step.guard';
+import { auth } from './lib/firebase';
 
-// Guards for different authentication states
-const redirectUnauthorizedToSignIn = () => redirectUnauthorizedTo(['sign-in']);
-const redirectToMembership = () => redirectLoggedInTo(['membership']);
+const requireAuth: CanActivateFn = () => {
+  const router = inject(Router);
+  return auth.currentUser ? true : router.parseUrl('/sign-in');
+};
+
+const requireUnauth: CanActivateFn = () => {
+  const router = inject(Router);
+  return auth.currentUser ? router.parseUrl('/membership') : true;
+};
 
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'sign-in' },
@@ -14,11 +21,11 @@ export const routes: Routes = [
   {
     path: 'membership',
     loadComponent: () => import('./membership/membership').then((m) => m.Membership),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
   {
     path: 'profile/create',
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
     loadComponent: () =>
       import('./create-profile-wizard/create-profile-wizard').then((m) => m.CreateProfileWizard),
     children: [
@@ -70,37 +77,37 @@ export const routes: Routes = [
     path: 'profile/preview',
     loadComponent: () =>
       import('./profile-preview-page/profile-preview-page').then((m) => m.ProfilePreviewPage),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
   {
     path: 'profile',
     loadComponent: () => import('./edit-profile/edit-profile').then((m) => m.EditProfile),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
   {
     path: 'profile/image',
     loadComponent: () =>
       import('./edit-profile-image/edit-profile-image').then((m) => m.EditProfileImage),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
 
   // Member referral routes (require authentication)
   {
     path: 'referrals',
     loadComponent: () => import('./referrals/referrals').then((m) => m.Referrals),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
   {
     path: 'referrals/:id',
     loadComponent: () =>
       import('./referrals/referral-detail/referral-detail').then((m) => m.ReferralDetail),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
 
   // Admin routes (require authentication and admin claim)
   {
     path: 'admin',
-    ...canActivate(redirectNonAdminToMembership),
+    canActivate: [redirectNonAdminToMembership],
     children: [
       {
         path: '',
@@ -183,17 +190,17 @@ export const routes: Routes = [
   {
     path: 'sign-in',
     loadComponent: () => import('./sign-in/sign-in').then((m) => m.SignIn),
-    ...canActivate(redirectToMembership),
+    canActivate: [requireUnauth],
   },
   {
     path: 'forgot-password',
     loadComponent: () => import('./forgot-password/forgot-password').then((m) => m.ForgotPassword),
-    ...canActivate(redirectToMembership),
+    canActivate: [requireUnauth],
   },
   {
     path: 'change-email',
     loadComponent: () => import('./change-email/change-email').then((m) => m.ChangeEmail),
-    ...canActivate(redirectUnauthorizedToSignIn),
+    canActivate: [requireAuth],
   },
 
   // Firebase Auth action handler entry points
@@ -201,6 +208,4 @@ export const routes: Routes = [
     path: 'auth-actions',
     loadComponent: () => import('./auth-actions/auth-actions').then((m) => m.AuthActions),
   },
-
-  // future routes can go here
 ];

--- a/members/src/app/app.spec.ts
+++ b/members/src/app/app.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, signal, type WritableSignal } from '@angular/core';
-import type { User } from '@angular/fire/auth';
+import type { User } from 'firebase/auth';
 import { provideRouter } from '@angular/router';
 import { render, screen } from '@testing-library/angular/zoneless';
 import userEvent from '@testing-library/user-event';

--- a/members/src/app/guards/admin.guard.ts
+++ b/members/src/app/guards/admin.guard.ts
@@ -1,13 +1,12 @@
-import { hasCustomClaim } from '@angular/fire/auth-guard';
-import { pipe } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { inject } from '@angular/core';
+import { Router, type CanActivateFn } from '@angular/router';
+import { getIdTokenResult } from 'firebase/auth';
+import { auth } from '../lib/firebase';
 
-/**
- * Auth pipe that checks if user has admin custom claim.
- * Redirects non-admin users to the membership page.
- */
-export const redirectNonAdminToMembership = () =>
-  pipe(
-    hasCustomClaim('admin'),
-    map((hasAdminClaim) => hasAdminClaim || ['/membership']),
-  );
+export const redirectNonAdminToMembership: CanActivateFn = async () => {
+  const router = inject(Router);
+  const user = auth.currentUser;
+  if (!user) return router.parseUrl('/sign-in');
+  const result = await getIdTokenResult(user);
+  return result.claims['admin'] === true || router.parseUrl('/membership');
+};

--- a/members/src/app/guards/admin.guard.ts
+++ b/members/src/app/guards/admin.guard.ts
@@ -5,8 +5,22 @@ import { auth } from '../lib/firebase';
 
 export const redirectNonAdminToMembership: CanActivateFn = async () => {
   const router = inject(Router);
+  // Wait for the persisted session to load before reading currentUser.
+  await auth.authStateReady();
   const user = auth.currentUser;
   if (!user) return router.parseUrl('/sign-in');
-  const result = await getIdTokenResult(user);
-  return result.claims['admin'] === true || router.parseUrl('/membership');
+
+  try {
+    const result = await getIdTokenResult(user);
+    return result.claims['admin'] === true || router.parseUrl('/membership');
+  } catch (error) {
+    // Token refresh can reject on network failure / revoked token. Fail closed:
+    // never grant admin access on error, and surface the failure.
+    console.error('Admin guard token check failed:', {
+      uid: user.uid,
+      error: error instanceof Error ? error.message : String(error),
+      code: (error as { code?: string }).code,
+    });
+    return router.parseUrl('/membership');
+  }
 };

--- a/members/src/app/guards/auth-guards.integration.spec.ts
+++ b/members/src/app/guards/auth-guards.integration.spec.ts
@@ -140,19 +140,19 @@ describe('auth route guards', () => {
 });
 
 interface SetupOptions {
-  currentUser?: { uid: string } | null;
+  currentUser?: { uid: string };
   authStateReady?: (auth: typeof mockAuth) => Promise<void>;
   idTokenResult?: { claims: Record<string, unknown> };
   idTokenError?: Error;
 }
 
 async function setup({
-  currentUser = undefined,
+  currentUser,
   authStateReady,
   idTokenResult,
   idTokenError,
 }: SetupOptions = {}) {
-  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockReturnValue(undefined);
 
   mockAuth.currentUser = currentUser;
   mockAuth.authStateReady = vi.fn(() =>

--- a/members/src/app/guards/auth-guards.integration.spec.ts
+++ b/members/src/app/guards/auth-guards.integration.spec.ts
@@ -1,0 +1,177 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, type Routes, RouterOutlet, provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it, vi } from 'vitest';
+import { requireAuth, requireUnauth } from '../app.routes';
+import { redirectNonAdminToMembership } from './admin.guard';
+
+// The Angular unit-test system disallows vi.mock on relative imports, so we
+// mock at the firebase SDK boundary instead: getAuth returns our controllable
+// auth object, which lib/firebase then exports as the shared `auth` singleton.
+const { mockAuth, mockGetIdTokenResult } = vi.hoisted(() => ({
+  mockAuth: {
+    currentUser: null as { uid: string } | null,
+    authStateReady: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  },
+  mockGetIdTokenResult: vi.fn(),
+}));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: () => mockAuth,
+  connectAuthEmulator: vi.fn(),
+  getIdTokenResult: mockGetIdTokenResult,
+}));
+
+@Component({ template: '<h1>Sign In</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockSignIn {}
+
+@Component({ template: '<h1>Membership</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockMembership {}
+
+@Component({ template: '<h1>Protected</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockProtected {}
+
+@Component({ template: '<h1>Admin</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockAdmin {}
+
+@Component({
+  template: '<router-outlet></router-outlet>',
+  imports: [RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockApp {}
+
+const routes: Routes = [
+  { path: 'sign-in', component: MockSignIn },
+  { path: 'membership', component: MockMembership },
+  { path: 'protected', component: MockProtected, canActivate: [requireAuth] },
+  { path: 'guest-only', component: MockSignIn, canActivate: [requireUnauth] },
+  { path: 'admin', component: MockAdmin, canActivate: [redirectNonAdminToMembership] },
+];
+
+describe('auth route guards', () => {
+  describe('requireAuth', () => {
+    it('redirects an unauthenticated user to sign-in', async () => {
+      const { navigate } = await setup();
+      await navigate('/protected');
+      expect(screen.getByText('Sign In')).toBeVisible();
+    });
+
+    it('allows an authenticated user through', async () => {
+      const { navigate } = await setup({ currentUser: { uid: 'user-1' } });
+      await navigate('/protected');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+
+    it('waits for authStateReady before reading currentUser', async () => {
+      // currentUser is only populated once the persisted session is restored,
+      // which the guard must await before deciding.
+      const { navigate } = await setup({
+        authStateReady: (auth) =>
+          new Promise<void>((resolve) => {
+            auth.currentUser = { uid: 'restored' };
+            resolve();
+          }),
+      });
+      await navigate('/protected');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+  });
+
+  describe('requireUnauth', () => {
+    it('redirects an authenticated user to membership', async () => {
+      const { navigate } = await setup({ currentUser: { uid: 'user-1' } });
+      await navigate('/guest-only');
+      expect(screen.getByText('Membership')).toBeVisible();
+    });
+
+    it('allows an unauthenticated user to reach the guest-only page', async () => {
+      const { navigate } = await setup();
+      await navigate('/guest-only');
+      expect(screen.getByText('Sign In')).toBeVisible();
+    });
+  });
+
+  describe('redirectNonAdminToMembership', () => {
+    it('redirects to sign-in when there is no user', async () => {
+      const { navigate } = await setup();
+      await navigate('/admin');
+      expect(screen.getByText('Sign In')).toBeVisible();
+    });
+
+    it('allows a user with the admin claim', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'admin-1' },
+        idTokenResult: { claims: { admin: true } },
+      });
+      await navigate('/admin');
+      expect(screen.getByText('Admin')).toBeVisible();
+    });
+
+    it('redirects a non-admin to membership', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'user-1' },
+        idTokenResult: { claims: { admin: false } },
+      });
+      await navigate('/admin');
+      expect(screen.getByText('Membership')).toBeVisible();
+    });
+
+    it('treats a non-boolean admin claim as non-admin', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'user-1' },
+        idTokenResult: { claims: { admin: 'true' } },
+      });
+      await navigate('/admin');
+      expect(screen.getByText('Membership')).toBeVisible();
+    });
+
+    it('fails closed to membership when the token check rejects', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'user-1' },
+        idTokenError: new Error('network-request-failed'),
+      });
+      await navigate('/admin');
+      expect(screen.getByText('Membership')).toBeVisible();
+    });
+  });
+});
+
+interface SetupOptions {
+  currentUser?: { uid: string } | null;
+  authStateReady?: (auth: typeof mockAuth) => Promise<void>;
+  idTokenResult?: { claims: Record<string, unknown> };
+  idTokenError?: Error;
+}
+
+async function setup({
+  currentUser = null,
+  authStateReady,
+  idTokenResult,
+  idTokenError,
+}: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  mockAuth.currentUser = currentUser;
+  mockAuth.authStateReady = vi.fn(() =>
+    authStateReady ? authStateReady(mockAuth) : Promise.resolve(),
+  );
+
+  mockGetIdTokenResult.mockReset();
+  if (idTokenError) {
+    mockGetIdTokenResult.mockRejectedValue(idTokenError);
+  } else if (idTokenResult) {
+    mockGetIdTokenResult.mockResolvedValue(idTokenResult);
+  }
+
+  await render(MockApp, { providers: [provideRouter(routes)] });
+
+  const router = TestBed.inject(Router);
+  const navigate = async (path: string) => {
+    await router.navigateByUrl(path);
+  };
+
+  return { navigate };
+}

--- a/members/src/app/guards/auth-guards.integration.spec.ts
+++ b/members/src/app/guards/auth-guards.integration.spec.ts
@@ -11,7 +11,7 @@ import { redirectNonAdminToMembership } from './admin.guard';
 // auth object, which lib/firebase then exports as the shared `auth` singleton.
 const { mockAuth, mockGetIdTokenResult } = vi.hoisted(() => ({
   mockAuth: {
-    currentUser: undefined as { uid: string } | undefined,
+    currentUser: undefined as { uid: string } | null | undefined,
     authStateReady: vi.fn<() => Promise<void>>(() => Promise.resolve()),
   },
   mockGetIdTokenResult: vi.fn(),
@@ -140,7 +140,7 @@ describe('auth route guards', () => {
 });
 
 interface SetupOptions {
-  currentUser?: { uid: string };
+  currentUser?: { uid: string } | null;
   authStateReady?: (auth: typeof mockAuth) => Promise<void>;
   idTokenResult?: { claims: Record<string, unknown> };
   idTokenError?: Error;

--- a/members/src/app/guards/auth-guards.integration.spec.ts
+++ b/members/src/app/guards/auth-guards.integration.spec.ts
@@ -11,7 +11,7 @@ import { redirectNonAdminToMembership } from './admin.guard';
 // auth object, which lib/firebase then exports as the shared `auth` singleton.
 const { mockAuth, mockGetIdTokenResult } = vi.hoisted(() => ({
   mockAuth: {
-    currentUser: null as { uid: string } | null,
+    currentUser: undefined as { uid: string } | undefined,
     authStateReady: vi.fn<() => Promise<void>>(() => Promise.resolve()),
   },
   mockGetIdTokenResult: vi.fn(),
@@ -147,12 +147,12 @@ interface SetupOptions {
 }
 
 async function setup({
-  currentUser = null,
+  currentUser = undefined,
   authStateReady,
   idTokenResult,
   idTokenError,
 }: SetupOptions = {}) {
-  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
 
   mockAuth.currentUser = currentUser;
   mockAuth.authStateReady = vi.fn(() =>

--- a/members/src/app/interceptors/auth.interceptor.spec.ts
+++ b/members/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,165 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+import { authInterceptor } from './auth.interceptor';
+
+type MockUser = { uid: string; getIdToken: () => Promise<string> };
+
+// The Angular unit-test system disallows vi.mock on relative imports, so we
+// mock at the firebase SDK boundary instead: getAuth returns our controllable
+// auth object, which lib/firebase then exports as the shared `auth` singleton.
+const { mockAuth, mockSignOut } = vi.hoisted(() => ({
+  mockAuth: { currentUser: null as MockUser | null },
+  mockSignOut: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+}));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: () => mockAuth,
+  connectAuthEmulator: vi.fn(),
+  signOut: mockSignOut,
+}));
+
+// Lets the interceptor's async token fetch / sign-out microtasks settle.
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('authInterceptor', () => {
+  it('attaches a Bearer token to authenticated API requests', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+
+    httpClient.get('/api/members/u1').subscribe();
+    await flushMicrotasks();
+
+    const req = httpTesting.expectOne('/api/members/u1');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush({});
+  });
+
+  it('leaves the request unmodified when no user is authenticated', async () => {
+    const { httpClient, httpTesting } = setup();
+
+    httpClient.get('/api/members/u1').subscribe();
+    await flushMicrotasks();
+
+    const req = httpTesting.expectOne('/api/members/u1');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+
+  it('does not touch requests to non-authenticated paths', async () => {
+    const getIdToken = vi.fn();
+    const { httpClient, httpTesting } = setup({ currentUser: { uid: 'u1', getIdToken } });
+
+    httpClient.get('/public/config').subscribe();
+    await flushMicrotasks();
+
+    const req = httpTesting.expectOne('/public/config');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    expect(getIdToken).not.toHaveBeenCalled();
+    req.flush({});
+  });
+
+  it('signs out and redirects to sign-in on a 401 response', async () => {
+    const { httpClient, httpTesting, navigateSpy } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+
+    httpClient.get('/api/members/u1').subscribe({ error: () => undefined });
+    await flushMicrotasks();
+
+    httpTesting
+      .expectOne('/api/members/u1')
+      .flush('unauthorized', { status: 401, statusText: 'Unauthorized' });
+    await flushMicrotasks();
+
+    expect(mockSignOut).toHaveBeenCalledOnce();
+    expect(navigateSpy).toHaveBeenCalledWith(['/sign-in']);
+  });
+
+  it('still redirects to sign-in when sign-out fails after a 401', async () => {
+    const { httpClient, httpTesting, navigateSpy } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+      signOutError: new Error('sign-out failed'),
+    });
+
+    httpClient.get('/api/members/u1').subscribe({ error: () => undefined });
+    await flushMicrotasks();
+
+    httpTesting
+      .expectOne('/api/members/u1')
+      .flush('unauthorized', { status: 401, statusText: 'Unauthorized' });
+    await flushMicrotasks();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/sign-in']);
+  });
+
+  it('rethrows non-401 errors without signing out', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+    const errorHandler = vi.fn();
+
+    httpClient.get('/api/members/u1').subscribe({ error: errorHandler });
+    await flushMicrotasks();
+
+    httpTesting
+      .expectOne('/api/members/u1')
+      .flush('server error', { status: 500, statusText: 'Server Error' });
+    await flushMicrotasks();
+
+    expect(errorHandler).toHaveBeenCalledOnce();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('proceeds without a token when token acquisition fails', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: {
+        uid: 'u1',
+        getIdToken: () => Promise.reject(new Error('network-request-failed')),
+      },
+    });
+
+    httpClient.get('/api/members/u1').subscribe();
+    await flushMicrotasks();
+
+    const req = httpTesting.expectOne('/api/members/u1');
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+  });
+});
+
+interface SetupOptions {
+  currentUser?: MockUser | null;
+  signOutError?: Error;
+}
+
+function setup({ currentUser = null, signOutError }: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  mockAuth.currentUser = currentUser;
+  mockSignOut.mockReset();
+  mockSignOut.mockImplementation(() =>
+    signOutError ? Promise.reject(signOutError) : Promise.resolve(),
+  );
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideHttpClient(withInterceptors([authInterceptor])),
+      provideHttpClientTesting(),
+      provideRouter([]),
+    ],
+  });
+
+  const httpClient = TestBed.inject(HttpClient);
+  const httpTesting = TestBed.inject(HttpTestingController);
+  const navigateSpy = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+  return { httpClient, httpTesting, navigateSpy };
+}

--- a/members/src/app/interceptors/auth.interceptor.spec.ts
+++ b/members/src/app/interceptors/auth.interceptor.spec.ts
@@ -17,7 +17,7 @@ interface MockUser {
 // mock at the firebase SDK boundary instead: getAuth returns our controllable
 // auth object, which lib/firebase then exports as the shared `auth` singleton.
 const { mockAuth, mockSignOut } = vi.hoisted(() => ({
-  mockAuth: { currentUser: undefined as MockUser | undefined },
+  mockAuth: { currentUser: undefined as MockUser | null | undefined },
   mockSignOut: vi.fn<() => Promise<void>>(() => Promise.resolve()),
 }));
 
@@ -139,7 +139,7 @@ describe('authInterceptor', () => {
 });
 
 interface SetupOptions {
-  currentUser?: MockUser;
+  currentUser?: MockUser | null;
   signOutError?: Error;
 }
 

--- a/members/src/app/interceptors/auth.interceptor.spec.ts
+++ b/members/src/app/interceptors/auth.interceptor.spec.ts
@@ -74,7 +74,7 @@ describe('authInterceptor', () => {
       currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
     });
 
-    httpClient.get('/api/members/u1').subscribe({ error: () => {} });
+    httpClient.get('/api/members/u1').subscribe({ error: vi.fn() });
     await flushMicrotasks();
 
     httpTesting
@@ -92,7 +92,7 @@ describe('authInterceptor', () => {
       signOutError: new Error('sign-out failed'),
     });
 
-    httpClient.get('/api/members/u1').subscribe({ error: () => {} });
+    httpClient.get('/api/members/u1').subscribe({ error: vi.fn() });
     await flushMicrotasks();
 
     httpTesting
@@ -139,12 +139,12 @@ describe('authInterceptor', () => {
 });
 
 interface SetupOptions {
-  currentUser?: MockUser | null;
+  currentUser?: MockUser;
   signOutError?: Error;
 }
 
-function setup({ currentUser = undefined, signOutError }: SetupOptions = {}) {
-  vi.spyOn(console, 'error').mockImplementation(() => {});
+function setup({ currentUser, signOutError }: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockReturnValue(undefined);
 
   mockAuth.currentUser = currentUser;
   mockSignOut.mockReset();

--- a/members/src/app/interceptors/auth.interceptor.spec.ts
+++ b/members/src/app/interceptors/auth.interceptor.spec.ts
@@ -8,13 +8,16 @@ import { Router, provideRouter } from '@angular/router';
 import { describe, expect, it, vi } from 'vitest';
 import { authInterceptor } from './auth.interceptor';
 
-type MockUser = { uid: string; getIdToken: () => Promise<string> };
+interface MockUser {
+  uid: string;
+  getIdToken: () => Promise<string>;
+}
 
 // The Angular unit-test system disallows vi.mock on relative imports, so we
 // mock at the firebase SDK boundary instead: getAuth returns our controllable
 // auth object, which lib/firebase then exports as the shared `auth` singleton.
 const { mockAuth, mockSignOut } = vi.hoisted(() => ({
-  mockAuth: { currentUser: null as MockUser | null },
+  mockAuth: { currentUser: undefined as MockUser | undefined },
   mockSignOut: vi.fn<() => Promise<void>>(() => Promise.resolve()),
 }));
 
@@ -37,9 +40,9 @@ describe('authInterceptor', () => {
     httpClient.get('/api/members/u1').subscribe();
     await flushMicrotasks();
 
-    const req = httpTesting.expectOne('/api/members/u1');
-    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
-    req.flush({});
+    const request = httpTesting.expectOne('/api/members/u1');
+    expect(request.request.headers.get('Authorization')).toBe('Bearer test-token');
+    request.flush({});
   });
 
   it('leaves the request unmodified when no user is authenticated', async () => {
@@ -48,9 +51,9 @@ describe('authInterceptor', () => {
     httpClient.get('/api/members/u1').subscribe();
     await flushMicrotasks();
 
-    const req = httpTesting.expectOne('/api/members/u1');
-    expect(req.request.headers.has('Authorization')).toBe(false);
-    req.flush({});
+    const request = httpTesting.expectOne('/api/members/u1');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    request.flush({});
   });
 
   it('does not touch requests to non-authenticated paths', async () => {
@@ -60,10 +63,10 @@ describe('authInterceptor', () => {
     httpClient.get('/public/config').subscribe();
     await flushMicrotasks();
 
-    const req = httpTesting.expectOne('/public/config');
-    expect(req.request.headers.has('Authorization')).toBe(false);
+    const request = httpTesting.expectOne('/public/config');
+    expect(request.request.headers.has('Authorization')).toBe(false);
     expect(getIdToken).not.toHaveBeenCalled();
-    req.flush({});
+    request.flush({});
   });
 
   it('signs out and redirects to sign-in on a 401 response', async () => {
@@ -71,7 +74,7 @@ describe('authInterceptor', () => {
       currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
     });
 
-    httpClient.get('/api/members/u1').subscribe({ error: () => undefined });
+    httpClient.get('/api/members/u1').subscribe({ error: () => {} });
     await flushMicrotasks();
 
     httpTesting
@@ -89,7 +92,7 @@ describe('authInterceptor', () => {
       signOutError: new Error('sign-out failed'),
     });
 
-    httpClient.get('/api/members/u1').subscribe({ error: () => undefined });
+    httpClient.get('/api/members/u1').subscribe({ error: () => {} });
     await flushMicrotasks();
 
     httpTesting
@@ -129,9 +132,9 @@ describe('authInterceptor', () => {
     httpClient.get('/api/members/u1').subscribe();
     await flushMicrotasks();
 
-    const req = httpTesting.expectOne('/api/members/u1');
-    expect(req.request.headers.has('Authorization')).toBe(false);
-    req.flush({});
+    const request = httpTesting.expectOne('/api/members/u1');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    request.flush({});
   });
 });
 
@@ -140,8 +143,8 @@ interface SetupOptions {
   signOutError?: Error;
 }
 
-function setup({ currentUser = null, signOutError }: SetupOptions = {}) {
-  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+function setup({ currentUser = undefined, signOutError }: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
 
   mockAuth.currentUser = currentUser;
   mockSignOut.mockReset();

--- a/members/src/app/interceptors/auth.interceptor.ts
+++ b/members/src/app/interceptors/auth.interceptor.ts
@@ -1,8 +1,9 @@
 import { type HttpErrorResponse, type HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { Auth, signOut } from '@angular/fire/auth';
+import { signOut } from 'firebase/auth';
 import { Router } from '@angular/router';
 import { EMPTY, catchError, from, switchMap } from 'rxjs';
+import { auth } from '../lib/firebase';
 
 /**
  * API paths that require authentication.
@@ -28,7 +29,6 @@ const AUTHENTICATED_API_PATHS = ['/api/admin/', '/api/analytics/', '/api/profile
  * this.httpClient.get('/api/profiles/me') // Token added automatically
  */
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
-  const auth = inject(Auth);
   const router = inject(Router);
 
   // Only intercept authenticated API requests

--- a/members/src/app/interceptors/auth.interceptor.ts
+++ b/members/src/app/interceptors/auth.interceptor.ts
@@ -2,7 +2,7 @@ import { type HttpErrorResponse, type HttpInterceptorFn } from '@angular/common/
 import { inject } from '@angular/core';
 import { signOut } from 'firebase/auth';
 import { Router } from '@angular/router';
-import { EMPTY, catchError, from, switchMap } from 'rxjs';
+import { EMPTY, catchError, from, of, switchMap } from 'rxjs';
 import { auth } from '../lib/firebase';
 
 /**
@@ -40,6 +40,18 @@ export const authInterceptor: HttpInterceptorFn = (request, next) => {
   // Get ID token and add to request
   // eslint-disable-next-line unicorn/no-null
   return from(auth.currentUser?.getIdToken() ?? Promise.resolve(null)).pipe(
+    catchError((tokenError: unknown) => {
+      // Token acquisition failed (e.g. network error, revoked/expired token).
+      // This is NOT an HttpErrorResponse, so handle it separately from the
+      // response-error branch below. Proceed without a token; the server will
+      // respond 401 if auth is required, which the 401 handler then catches.
+      console.error('Failed to acquire auth token for request:', {
+        url: request.url,
+        error: tokenError instanceof Error ? tokenError.message : String(tokenError),
+      });
+      // eslint-disable-next-line unicorn/no-null
+      return of(null);
+    }),
     switchMap((token) => {
       if (!token) {
         // No user authenticated - proceed without modification

--- a/members/src/app/lib/firebase.ts
+++ b/members/src/app/lib/firebase.ts
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyBuYxpvwYc3ZVn5OSYtJe88XnL8x5HSuDI',
+  authDomain: 'doula-cooperative.firebaseapp.com',
+  projectId: 'doula-cooperative',
+  storageBucket: 'doula-cooperative.firebasestorage.app',
+  messagingSenderId: '577630356653',
+  appId: '1:577630356653:web:9425c7a726ad13f051f224',
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);
+export const auth = getAuth(firebaseApp);

--- a/members/src/app/lib/firebase.ts
+++ b/members/src/app/lib/firebase.ts
@@ -1,5 +1,6 @@
+import { isDevMode } from '@angular/core';
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyBuYxpvwYc3ZVn5OSYtJe88XnL8x5HSuDI',
@@ -12,3 +13,9 @@ const firebaseConfig = {
 
 export const firebaseApp = initializeApp(firebaseConfig);
 export const auth = getAuth(firebaseApp);
+
+// In local dev, point Auth at the emulator unless explicitly opted into
+// production (VITE_USE_PRODUCTION). Production builds skip this entirely.
+if (isDevMode() && !import.meta.env['VITE_USE_PRODUCTION']) {
+  connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+}

--- a/members/src/app/services/auth.service.ts
+++ b/members/src/app/services/auth.service.ts
@@ -2,22 +2,22 @@ import { Injectable, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   type ActionCodeInfo,
-  Auth,
   type User,
   type UserCredential,
   applyActionCode,
   checkActionCode,
   confirmPasswordReset,
-  idToken,
+  onIdTokenChanged,
   sendEmailVerification,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signOut,
   verifyBeforeUpdateEmail,
   verifyPasswordResetCode,
-} from '@angular/fire/auth';
+} from 'firebase/auth';
 import { Router } from '@angular/router';
-import { from, map, switchMap } from 'rxjs';
+import { Observable, from, map, switchMap } from 'rxjs';
+import { auth } from '../lib/firebase';
 
 // Global auth error messages object
 export const AUTH_ERROR_MESSAGES: Record<string, string> = {
@@ -35,30 +35,35 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'auth/unknown-error': 'An error occurred during authentication. Please try again.',
 };
 
+// Observable that emits on every ID token change (sign-in, sign-out, token refresh)
+const idTokenChanged$ = new Observable<User | null>((subscriber) => {
+  const unsubscribe = onIdTokenChanged(auth, (user) => subscriber.next(user));
+  return unsubscribe;
+});
+
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  private auth = inject(Auth);
   private router = inject(Router);
 
   // Public signal for auth state; re-emits on ID token changes (emailVerified, claims)
-  readonly user$ = idToken(this.auth).pipe(map(() => this.auth.currentUser));
+  readonly user$ = idTokenChanged$.pipe(map(() => auth.currentUser));
   readonly userId$ = this.user$.pipe(map((user) => user?.uid));
   // eslint-disable-next-line unicorn/no-null
   readonly user = toSignal(this.user$, { initialValue: null });
 
   // Derived signal that tracks emailVerified and re-emits on ID token changes
   readonly emailVerified = toSignal(
-    idToken(this.auth).pipe(map(() => this.auth.currentUser?.emailVerified ?? false)),
+    idTokenChanged$.pipe(map(() => auth.currentUser?.emailVerified ?? false)),
     { initialValue: false },
   );
 
   // Derived signal for admin status from custom claims
   readonly isAdmin = toSignal(
-    idToken(this.auth).pipe(
+    idTokenChanged$.pipe(
       switchMap(() => {
-        const user = this.auth.currentUser;
+        const user = auth.currentUser;
         if (!user) return from(Promise.resolve(false));
         return from(user.getIdTokenResult().then((result) => result.claims['admin'] === true));
       }),
@@ -69,7 +74,7 @@ export class AuthService {
   // Sign in with email and password
   async signInWithEmail(email: string, password: string): Promise<UserCredential> {
     try {
-      return await signInWithEmailAndPassword(this.auth, email, password);
+      return await signInWithEmailAndPassword(auth, email, password);
     } catch (error) {
       throw this.translateAuthError(error, 'signInWithEmail');
     }
@@ -78,12 +83,12 @@ export class AuthService {
   // Sign out
   async signOut(): Promise<void> {
     try {
-      await signOut(this.auth);
+      await signOut(auth);
       // Only navigate after successful sign out
       void this.router.navigate(['/sign-in']);
     } catch (error) {
       console.error('Sign out failed:', {
-        uid: this.auth.currentUser?.uid,
+        uid: auth.currentUser?.uid,
         error: error instanceof Error ? error.message : String(error),
         code: (error as { code?: string }).code,
       });
@@ -93,7 +98,7 @@ export class AuthService {
 
   // Reload the current user's data
   async reloadUser(): Promise<void> {
-    const current = this.auth.currentUser;
+    const current = auth.currentUser;
     if (!current) return;
 
     try {
@@ -130,7 +135,7 @@ export class AuthService {
 
   // Force refresh ID token to get updated custom claims
   async refreshToken(): Promise<void> {
-    const current = this.auth.currentUser;
+    const current = auth.currentUser;
     if (!current) return;
     try {
       await current.getIdToken(true);
@@ -159,16 +164,16 @@ export class AuthService {
 
   // Get current user (synchronous)
   get currentUser(): User | null {
-    return this.auth.currentUser;
+    return auth.currentUser;
   }
 
   // Check if user is authenticated
   get isAuthenticated(): boolean {
-    return this.auth.currentUser !== null;
+    return auth.currentUser !== null;
   }
 
   async resendEmailVerification(): Promise<void> {
-    const user = this.auth.currentUser;
+    const user = auth.currentUser;
     if (!user) {
       throw new Error('No authenticated user');
     }
@@ -192,7 +197,7 @@ export class AuthService {
    */
   async applyActionCode(code: string): Promise<void> {
     try {
-      await applyActionCode(this.auth, code);
+      await applyActionCode(auth, code);
     } catch (error) {
       throw this.translateAuthError(error, 'applyActionCode');
     }
@@ -203,7 +208,7 @@ export class AuthService {
    */
   async checkActionCode(code: string): Promise<ActionCodeInfo> {
     try {
-      return await checkActionCode(this.auth, code);
+      return await checkActionCode(auth, code);
     } catch (error) {
       throw this.translateAuthError(error, 'checkActionCode');
     }
@@ -214,7 +219,7 @@ export class AuthService {
    */
   async verifyPasswordResetCode(code: string): Promise<string> {
     try {
-      return await verifyPasswordResetCode(this.auth, code);
+      return await verifyPasswordResetCode(auth, code);
     } catch (error) {
       throw this.translateAuthError(error, 'verifyPasswordResetCode');
     }
@@ -225,7 +230,7 @@ export class AuthService {
    */
   async confirmPasswordReset(code: string, newPassword: string): Promise<void> {
     try {
-      await confirmPasswordReset(this.auth, code, newPassword);
+      await confirmPasswordReset(auth, code, newPassword);
     } catch (error) {
       throw this.translateAuthError(error, 'confirmPasswordReset');
     }
@@ -236,7 +241,7 @@ export class AuthService {
    */
   async sendPasswordResetEmail(email: string): Promise<void> {
     try {
-      await sendPasswordResetEmail(this.auth, email, {
+      await sendPasswordResetEmail(auth, email, {
         url: `${globalThis.window.location.origin}/auth-actions?mode=resetPassword`,
         handleCodeInApp: true,
       });
@@ -246,7 +251,7 @@ export class AuthService {
   }
 
   async verifyBeforeUpdateEmail(newEmail: string): Promise<void> {
-    const user = this.auth.currentUser;
+    const user = auth.currentUser;
     if (!user) {
       throw new Error('You must be signed in to change your email.');
     }

--- a/members/src/app/services/auth.service.ts
+++ b/members/src/app/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, computed, inject, resource, signal } from '@angular/core';
+import { Injectable, computed, effect, inject, resource, signal } from '@angular/core';
 import {
   type ActionCodeInfo,
   type User,
@@ -56,8 +56,10 @@ export class AuthService {
   readonly isAdmin = computed(() => this._isAdminResource.value() ?? false);
 
   constructor() {
-    const unsub = onIdTokenChanged(auth, (u) => this._user.set(u));
-    inject(DestroyRef).onDestroy(unsub);
+    effect((onCleanup) => {
+      const unsub = onIdTokenChanged(auth, (u) => this._user.set(u));
+      onCleanup(unsub);
+    });
   }
 
   // Sign in with email and password

--- a/members/src/app/services/auth.service.ts
+++ b/members/src/app/services/auth.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable, computed, inject, resource, signal } from '@angular/core';
 import {
   type ActionCodeInfo,
   type User,
@@ -7,6 +6,7 @@ import {
   applyActionCode,
   checkActionCode,
   confirmPasswordReset,
+  getIdTokenResult,
   onIdTokenChanged,
   sendEmailVerification,
   sendPasswordResetEmail,
@@ -16,7 +16,6 @@ import {
   verifyPasswordResetCode,
 } from 'firebase/auth';
 import { Router } from '@angular/router';
-import { Observable, from, map, switchMap } from 'rxjs';
 import { auth } from '../lib/firebase';
 
 // Global auth error messages object
@@ -35,41 +34,31 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'auth/unknown-error': 'An error occurred during authentication. Please try again.',
 };
 
-// Observable that emits on every ID token change (sign-in, sign-out, token refresh)
-const idTokenChanged$ = new Observable<User | null>((subscriber) => {
-  const unsubscribe = onIdTokenChanged(auth, (user) => subscriber.next(user));
-  return unsubscribe;
-});
-
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   private router = inject(Router);
 
-  // Public signal for auth state; re-emits on ID token changes (emailVerified, claims)
-  readonly user$ = idTokenChanged$.pipe(map(() => auth.currentUser));
-  readonly userId$ = this.user$.pipe(map((user) => user?.uid));
-  // eslint-disable-next-line unicorn/no-null
-  readonly user = toSignal(this.user$, { initialValue: null });
+  private readonly _user = signal<User | null>(null);
 
-  // Derived signal that tracks emailVerified and re-emits on ID token changes
-  readonly emailVerified = toSignal(
-    idTokenChanged$.pipe(map(() => auth.currentUser?.emailVerified ?? false)),
-    { initialValue: false },
-  );
+  readonly user = this._user.asReadonly();
+  readonly emailVerified = computed(() => this._user()?.emailVerified ?? false);
 
-  // Derived signal for admin status from custom claims
-  readonly isAdmin = toSignal(
-    idTokenChanged$.pipe(
-      switchMap(() => {
-        const user = auth.currentUser;
-        if (!user) return from(Promise.resolve(false));
-        return from(user.getIdTokenResult().then((result) => result.claims['admin'] === true));
-      }),
-    ),
-    { initialValue: false },
-  );
+  private readonly _isAdminResource = resource({
+    params: () => this._user(),
+    loader: async ({ params: user }) => {
+      if (!user) return false;
+      const result = await getIdTokenResult(user);
+      return result.claims['admin'] === true;
+    },
+  });
+  readonly isAdmin = computed(() => this._isAdminResource.value() ?? false);
+
+  constructor() {
+    const unsub = onIdTokenChanged(auth, (u) => this._user.set(u));
+    inject(DestroyRef).onDestroy(unsub);
+  }
 
   // Sign in with email and password
   async signInWithEmail(email: string, password: string): Promise<UserCredential> {

--- a/members/src/app/services/auth.service.ts
+++ b/members/src/app/services/auth.service.ts
@@ -54,12 +54,27 @@ export class AuthService {
       return result.claims['admin'] === true;
     },
   });
+  // Fails closed to non-admin: an undefined value covers both "loading" and
+  // "claim fetch failed". The effect below logs the failure case so it isn't silent.
   readonly isAdmin = computed(() => this.adminClaims.value() ?? false);
 
   constructor() {
     effect((onCleanup) => {
-      const unsubscribe = onIdTokenChanged(auth, (user) => this.authUser.set(user));
+      // onIdTokenChanged re-emits on token refresh, keeping emailVerified and
+      // admin claims current (not just on sign-in/out).
+      const unsubscribe = onIdTokenChanged(
+        auth,
+        (user) => this.authUser.set(user),
+        (error) => console.error('Auth ID token listener error:', error),
+      );
       onCleanup(unsubscribe);
+    });
+
+    effect(() => {
+      const error = this.adminClaims.error();
+      if (error) {
+        console.error('Failed to resolve admin claims; treating user as non-admin:', error);
+      }
     });
   }
 

--- a/members/src/app/services/auth.service.ts
+++ b/members/src/app/services/auth.service.ts
@@ -40,25 +40,26 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
 export class AuthService {
   private router = inject(Router);
 
-  private readonly _user = signal<User | null>(null);
+  // eslint-disable-next-line unicorn/no-null
+  private readonly authUser = signal<User | null>(null);
 
-  readonly user = this._user.asReadonly();
-  readonly emailVerified = computed(() => this._user()?.emailVerified ?? false);
+  readonly user = this.authUser.asReadonly();
+  readonly emailVerified = computed(() => this.authUser()?.emailVerified ?? false);
 
-  private readonly _isAdminResource = resource({
-    params: () => this._user(),
+  private readonly adminClaims = resource({
+    params: () => this.authUser(),
     loader: async ({ params: user }) => {
       if (!user) return false;
       const result = await getIdTokenResult(user);
       return result.claims['admin'] === true;
     },
   });
-  readonly isAdmin = computed(() => this._isAdminResource.value() ?? false);
+  readonly isAdmin = computed(() => this.adminClaims.value() ?? false);
 
   constructor() {
     effect((onCleanup) => {
-      const unsub = onIdTokenChanged(auth, (u) => this._user.set(u));
-      onCleanup(unsub);
+      const unsubscribe = onIdTokenChanged(auth, (user) => this.authUser.set(user));
+      onCleanup(unsubscribe);
     });
   }
 

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -34,14 +34,15 @@ export interface Member {
 export class MembershipService {
   private http = inject(HttpClient);
 
-  private readonly _user = signal<User | null>(null);
-  readonly user = this._user.asReadonly();
-  readonly userId = computed(() => this._user()?.uid ?? 'abcd');
+  // eslint-disable-next-line unicorn/no-null
+  private readonly authUser = signal<User | null>(null);
+  readonly user = this.authUser.asReadonly();
+  readonly userId = computed(() => this.authUser()?.uid ?? 'abcd');
 
   constructor() {
     effect((onCleanup) => {
-      const unsub = onAuthStateChanged(auth, (u) => this._user.set(u));
-      onCleanup(unsub);
+      const unsubscribe = onAuthStateChanged(auth, (user) => this.authUser.set(user));
+      onCleanup(unsubscribe);
     });
   }
 
@@ -177,7 +178,7 @@ export class MembershipService {
 
   /**
    * Update the user's newsletter subscription preference
-   * @param subscribed - true to subscribe, false to unsubscribe
+   * @param subscribed - true to subscribe, false to unsubscribescribe
    * @throws Error with user-friendly message
    */
   async updateNewsletterPreference(subscribed: boolean): Promise<void> {

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -41,7 +41,11 @@ export class MembershipService {
 
   constructor() {
     effect((onCleanup) => {
-      const unsubscribe = onAuthStateChanged(auth, (user) => this.authUser.set(user));
+      const unsubscribe = onAuthStateChanged(
+        auth,
+        (user) => this.authUser.set(user),
+        (error) => console.error('Auth state listener error:', error),
+      );
       onCleanup(unsubscribe);
     });
   }
@@ -178,7 +182,7 @@ export class MembershipService {
 
   /**
    * Update the user's newsletter subscription preference
-   * @param subscribed - true to subscribe, false to unsubscribescribe
+   * @param subscribed - true to subscribe, false to unsubscribe
    * @throws Error with user-friendly message
    */
   async updateNewsletterPreference(subscribed: boolean): Promise<void> {

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { DestroyRef, computed, inject, Injectable, resource, signal } from '@angular/core';
+import { computed, effect, inject, Injectable, resource, signal } from '@angular/core';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 import { firstValueFrom } from 'rxjs';
 import { auth } from '../lib/firebase';
@@ -39,8 +39,10 @@ export class MembershipService {
   readonly userId = computed(() => this._user()?.uid ?? 'abcd');
 
   constructor() {
-    const unsub = onAuthStateChanged(auth, (u) => this._user.set(u));
-    inject(DestroyRef).onDestroy(unsub);
+    effect((onCleanup) => {
+      const unsub = onAuthStateChanged(auth, (u) => this._user.set(u));
+      onCleanup(unsub);
+    });
   }
 
   // Resource for loading user document - automatically reloads when user changes

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -1,8 +1,9 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { computed, inject, Injectable, resource } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Auth, authState } from '@angular/fire/auth';
-import { firstValueFrom } from 'rxjs';
+import { onAuthStateChanged, type User } from 'firebase/auth';
+import { firstValueFrom, Observable } from 'rxjs';
+import { auth } from '../lib/firebase';
 import type { ApiMemberResponse } from '../api-types/api-member-response';
 import type { SubscriptionStatus } from '../api-types/subscription-status';
 
@@ -28,18 +29,19 @@ export interface Member {
   newsletterUnsubscribedAt?: Date;
 }
 
+const authState$ = new Observable<User | null>((subscriber) => {
+  const unsubscribe = onAuthStateChanged(auth, (user) => subscriber.next(user));
+  return unsubscribe;
+});
+
 @Injectable({
   providedIn: 'root',
 })
 export class MembershipService {
-  private auth = inject(Auth);
   private http = inject(HttpClient);
 
-  // Use authState directly to avoid circular dependency with AuthService
-  private user$ = authState(this.auth);
-
-  userId = computed(() => this.auth.currentUser?.uid ?? 'abcd');
-  user = toSignal(this.user$);
+  userId = computed(() => auth.currentUser?.uid ?? 'abcd');
+  user = toSignal(authState$);
 
   // Resource for loading user document - automatically reloads when user changes
   readonly userDocumentResource = resource({
@@ -177,7 +179,7 @@ export class MembershipService {
    * @throws Error with user-friendly message
    */
   async updateNewsletterPreference(subscribed: boolean): Promise<void> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) {
       throw new Error('You must be signed in to update newsletter preferences.');
     }
@@ -233,7 +235,7 @@ export class MembershipService {
    * @throws Error with user-friendly message
    */
   async updateMemberName(name: string): Promise<void> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) {
       throw new Error('You must be signed in to update your name.');
     }
@@ -292,7 +294,7 @@ export class MembershipService {
    * @throws Error with user-friendly message
    */
   async cancelMembership(): Promise<void> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) {
       throw new Error('You must be signed in to cancel your membership.');
     }
@@ -351,7 +353,7 @@ export class MembershipService {
    * @throws Error with user-friendly message
    */
   async verifyEmail(): Promise<void> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) {
       throw new Error('You must be signed in to verify your email.');
     }
@@ -388,7 +390,7 @@ export class MembershipService {
   }
 
   async syncAuthEmailToMember(): Promise<void> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) {
       throw new Error('You must be signed in to update your email.');
     }

--- a/members/src/app/services/membership.service.ts
+++ b/members/src/app/services/membership.service.ts
@@ -1,8 +1,7 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { computed, inject, Injectable, resource } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { DestroyRef, computed, inject, Injectable, resource, signal } from '@angular/core';
 import { onAuthStateChanged, type User } from 'firebase/auth';
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { auth } from '../lib/firebase';
 import type { ApiMemberResponse } from '../api-types/api-member-response';
 import type { SubscriptionStatus } from '../api-types/subscription-status';
@@ -29,19 +28,20 @@ export interface Member {
   newsletterUnsubscribedAt?: Date;
 }
 
-const authState$ = new Observable<User | null>((subscriber) => {
-  const unsubscribe = onAuthStateChanged(auth, (user) => subscriber.next(user));
-  return unsubscribe;
-});
-
 @Injectable({
   providedIn: 'root',
 })
 export class MembershipService {
   private http = inject(HttpClient);
 
-  userId = computed(() => auth.currentUser?.uid ?? 'abcd');
-  user = toSignal(authState$);
+  private readonly _user = signal<User | null>(null);
+  readonly user = this._user.asReadonly();
+  readonly userId = computed(() => this._user()?.uid ?? 'abcd');
+
+  constructor() {
+    const unsub = onAuthStateChanged(auth, (u) => this._user.set(u));
+    inject(DestroyRef).onDestroy(unsub);
+  }
 
   // Resource for loading user document - automatically reloads when user changes
   readonly userDocumentResource = resource({

--- a/members/src/app/services/referrals.service.ts
+++ b/members/src/app/services/referrals.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Auth } from '@angular/fire/auth';
 import { firstValueFrom } from 'rxjs';
+import { auth } from '../lib/firebase';
 import type { MatchRequest } from '../admin/admin.types';
 
 export type ReferralDueDate = MatchRequest['estimatedDueDate'];
@@ -30,11 +30,10 @@ export type ReferralDetail = Pick<
   providedIn: 'root',
 })
 export class ReferralsService {
-  private auth = inject(Auth);
   private http = inject(HttpClient);
 
   async listReferrals(): Promise<ReferralListItem[]> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
     const memberId = encodeURIComponent(uid);
@@ -68,7 +67,7 @@ export class ReferralsService {
   }
 
   async getReferral(id: string): Promise<ReferralDetail> {
-    const uid = this.auth.currentUser?.uid;
+    const uid = auth.currentUser?.uid;
     if (!uid) throw new Error('You must be signed in to view referrals.');
 
     const memberId = encodeURIComponent(uid);


### PR DESCRIPTION
## Summary

- Removes the `@angular/fire` dependency, which blocks the Angular 22 upgrade
- Replaces all AngularFire auth usage with the vanilla `firebase/auth` SDK — the only dependency AngularFire provided in this app
- Adds `members/src/app/lib/firebase.ts` as the single init point (no DI providers, no emulator wiring)
- Auth reactivity (`onIdTokenChanged` → `toSignal`) now runs in Angular's correct scheduler context, fixing the sign-out UI update issue that was observed in a validation spike

## Changes

| File | What changed |
|---|---|
| `lib/firebase.ts` (new) | Single `initializeApp` + `getAuth` export |
| `app.config.ts` | Removed all `provideFirebaseApp`/`provideAuth`/`provideFirestore` providers |
| `app.routes.ts` | Replaced AngularFire `canActivate`/`redirectUnauthorizedTo`/`redirectLoggedInTo` with plain `CanActivateFn`s returning `UrlTree` |
| `auth.service.ts` | `Auth` DI token → module constant; `idToken()` → `Observable` wrapping `onIdTokenChanged` |
| `membership.service.ts` | `authState()` → `Observable` wrapping `onAuthStateChanged` |
| `auth.interceptor.ts` | `inject(Auth)` → imported `auth` constant |
| `referrals.service.ts` | `inject(Auth)` → imported `auth` constant |
| `admin.guard.ts` | `hasCustomClaim` pipe → `getIdTokenResult` in `CanActivateFn` |
| `app.spec.ts` | `User` type import updated to `firebase/auth` |

## Test plan

- [x] All 450 unit tests pass (`bun run test`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Sign-in page loads with zero console errors in browser (prod config, no emulator)
- [ ] Sign in with a real account → membership page loads and auth header is attached to API requests
- [ ] Sign out → redirected to sign-in
- [ ] Admin route guard blocks non-admin users